### PR TITLE
[#7819] fix - avoid unnecessary effects when joining/syncing already active public chat

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -41,6 +41,12 @@
   ([cofx chat-id]
    (public-chat? (get-chat cofx chat-id))))
 
+(defn active-chat?
+  ([chat]
+   (:is-active chat))
+  ([cofx chat-id]
+   (active-chat? (get-chat cofx chat-id))))
+
 (defn group-chat?
   ([chat]
    (and (multi-user-chat? chat)
@@ -289,13 +295,16 @@
 (fx/defn start-public-chat
   "Starts a new public chat"
   [cofx topic {:keys [dont-navigate?] :as opts}]
-  (fx/merge cofx
-            (add-public-chat topic)
-            #(when-not dont-navigate?
-               (navigate-to-chat % topic opts))
-            (public-chat/join-public-chat topic)
-            (when platform/desktop?
-              (desktop.events/change-tab :home))))
+  (if (active-chat? cofx topic)
+    (when-not dont-navigate?
+      (navigate-to-chat cofx topic opts))
+    (fx/merge cofx
+              (add-public-chat topic)
+              #(when-not dont-navigate?
+                 (navigate-to-chat % topic opts))
+              (public-chat/join-public-chat topic)
+              #(when platform/desktop?
+                 (desktop.events/change-tab % :home)))))
 
 (fx/defn disable-chat-cooldown
   "Turns off chat cooldown (protection against message spamming)"

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -155,7 +155,6 @@
   (let [contacts (:contacts/contacts db)
         contact-batches (partition-all contact-batch-n (vals contacts))]
     (concat (mapv contact-batch->sync-installation-message contact-batches)
-
             [(sync-installation-account-message cofx)]
             (chats->sync-installation-messages cofx))))
 

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -5,6 +5,7 @@
             [re-frame.core :as re-frame]
             [status-im.accounts.db :as accounts.db]
             [status-im.chat.models :as chat]
+            [status-im.pairing.core :as pairing]
             [status-im.extensions.registry :as extensions.registry]
             [status-im.ui.components.list-selection :as list-selection]
             [status-im.ui.components.react :as react]
@@ -65,7 +66,10 @@
 
 (fx/defn handle-public-chat [cofx public-chat]
   (log/info "universal-links: handling public chat" public-chat)
-  (chat/start-public-chat cofx public-chat {}))
+  (fx/merge
+   cofx
+   (chat/start-public-chat public-chat {})
+   (pairing/sync-public-chat public-chat)))
 
 (fx/defn handle-view-profile [{:keys [db] :as cofx} public-key]
   (log/info "universal-links: handling view profile" public-key)


### PR DESCRIPTION
Fixes #7819 - which was created first when all repercussions were not fully known; Later #7952, #7974, #7992 were created as they were discovered.

status: ready