### PR TITLE
Change e2e kickoff column to "E2E Tests"

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -10,7 +10,7 @@ project-board:
 automated-tests:
   repo-full-name: 'status-im/status-react'
   job-full-name: 'end-to-end-tests/status-app-end-to-end-tests'
-  kickoff-column-name: 'REVIEW'
+  kickoff-column-name: 'E2E Tests'
 
 github-team:
   slug: 'clojure'


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Changes Probot config so that e2e tests are kicked off when moving card to `E2E tests` column.

status: ready <!-- Can be ready or wip -->