### PR TITLE
Optimized ScrollView instead of FlatList for desktop chat

### DIFF
--- a/src/status_im/ui/screens/chat/input/send_button.cljs
+++ b/src/status_im/ui/screens/chat/input/send_button.cljs
@@ -13,7 +13,7 @@
              login-processing?
              disconnected?))))
 
-(defview send-button-view [{:keys [input-text]}]
+(defview send-button-view [{:keys [input-text]} on-send-press]
   (letsubs [{:keys [command-completion]} [:chats/selected-chat-command]
             disconnected? [:disconnected?]
             {:keys [processing]} [:accounts/login]]
@@ -21,7 +21,7 @@
                (or (not command-completion)
                    (#{:complete :less-than-needed} command-completion)))
       [react/touchable-highlight
-       {:on-press #(re-frame/dispatch [:chat.ui/send-current-message])}
+       {:on-press on-send-press}
        [vector-icons/icon :main-icons/arrow-up
         {:container-style     style/send-message-container
          :accessibility-label :send-message-button

--- a/src/status_im/ui/screens/chat/message/gap.cljs
+++ b/src/status_im/ui/screens/chat/message/gap.cljs
@@ -4,12 +4,13 @@
             [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.utils.datetime :as datetime]
-            [status-im.ui.screens.chat.styles.input.gap :as style]))
+            [status-im.ui.screens.chat.styles.input.gap :as style]
+            [status-im.utils.platform :as platform]))
 
 (defn on-press
   [ids first-gap? idx list-ref]
   (fn []
-    (when (and list-ref @list-ref)
+    (when (and list-ref @list-ref (not platform/desktop?))
       (.scrollToIndex @list-ref
                       #js {:index        (max 0 (dec idx))
                            :viewOffset   20

--- a/src/status_im/ui/screens/chat/styles/main.cljs
+++ b/src/status_im/ui/screens/chat/styles/main.cljs
@@ -271,3 +271,5 @@
 (def decline-chat
   {:color colors/blue
    :margin-bottom 40})
+
+(def messages-list-vertical-padding 46)


### PR DESCRIPTION
fixes #8163

### Summary

FlatList implementation in react-native-desktop works slow and makes chat in mobile ui for desktop unusable

As a workaround, until FlatList implementation is buggy we can use ScrollView component that has optimization on Qt side of react-native-desktop. 

### Review notes
`ScrollView` that used instead of `FlatList` taken from current desktop UI and works the same way

### Testing notes
Currently in new mobile UI you can't open user profile by clicking on his avatar. This is a known issue. I have a solution for it in `react-native-desktop` but this solution causes bug in old desktop UI which is default now (only part of avatar image responds to click.)
My suggestion is to leave this bug for now and fix it before we fully switch to new UI

#### Platforms
- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
Only chat area should be impacted

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
- enable mobile UI by setting `MOBILE_UI_FOR_DESKTOP=1` in `.env` file
- make sure that chat has better performance and behaves the same way as a current desktop UI.


status: ready