### PR TITLE
[#8145] exclude some chars when generating pairing password

### DIFF
--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -55,7 +55,7 @@
     "react-native-safe-area-view": "0.9.0",
     "react-native-securerandom": "git+https://github.com/status-im/react-native-securerandom.git#0.1.1-2",
     "react-native-splash-screen": "3.1.1",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.3",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.4",
     "react-native-svg": "^9.2.4",
     "react-native-svg-transformer": "^0.12.1",
     "react-native-tcp": "git+https://github.com/status-im/react-native-tcp.git#v3.3.0-1-status",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5586,9 +5586,9 @@ react-native-splash-screen@3.1.1:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.1.1.tgz#1a4e46c9fdce53ff52af2a2cb4181788c4e30b30"
   integrity sha512-PU2YocOSGbLjL9Vgcq/cwMNuHHKNjjuPpa1IPMuWo+6EB/fSZ5VOmxSa7+eucQe3631s3NhGuk3eHKahU03a4Q==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.3":
-  version "2.5.3"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#4ba5e8a771e764c449c19180e5eaa8553c789b8d"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.4":
+  version "2.5.4"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#5a4e9206bbe7e1a30aad0bc254b5e370a63643cc"
 
 react-native-svg-transformer@^0.12.1:
   version "0.12.1"


### PR DESCRIPTION
fixes #8145 

### Summary
Exclude similar-looking chars and special symbols when generating pairing password.

Related PR https://github.com/status-im/react-native-status-keycard/pull/15

status: ready

