### PR TITLE
[7715] Feature: Contextual bottom sheet on long press

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -2038,10 +2038,11 @@
 ;; bottom-sheet events
 (handlers/register-handler-fx
  :bottom-sheet/show-sheet
- (fn [cofx [_ view]]
+ (fn [cofx [_ view options]]
    (bottom-sheet/show-bottom-sheet
     cofx
-    {:view view})))
+    {:view view
+     :options options})))
 
 (handlers/register-handler-fx
  :bottom-sheet/hide-sheet

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -52,6 +52,7 @@
 ;;bottom sheet
 (reg-root-key-sub :bottom-sheet/show? :bottom-sheet/show?)
 (reg-root-key-sub :bottom-sheet/view :bottom-sheet/view)
+(reg-root-key-sub :bottom-sheet/options :bottom-sheet/options)
 
 ;;general
 (reg-root-key-sub :network-name :chain)

--- a/src/status_im/ui/components/bottom_sheet/db.cljs
+++ b/src/status_im/ui/components/bottom_sheet/db.cljs
@@ -3,3 +3,4 @@
 
 (spec/def :bottom-sheet/show? (spec/nilable boolean?))
 (spec/def :bottom-sheet/view (spec/nilable keyword?))
+(spec/def :bottom-sheet/options (spec/nilable map?))

--- a/src/status_im/ui/components/bottom_sheet/events.cljs
+++ b/src/status_im/ui/components/bottom_sheet/events.cljs
@@ -3,10 +3,11 @@
             [status-im.utils.handlers :as handlers]))
 
 (fx/defn show-bottom-sheet
-  [{:keys [db]} {:keys [view]}]
+  [{:keys [db]} {:keys [view options]}]
   {:db (assoc db
               :bottom-sheet/show? true
-              :bottom-sheet/view view)})
+              :bottom-sheet/view view
+              :bottom-sheet/options options)})
 
 (fx/defn hide-bottom-sheet
   [{:keys [db]}]

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -274,6 +274,7 @@
                                 :stickers/packs-pendning
                                 :bottom-sheet/show?
                                 :bottom-sheet/view
+                                :bottom-sheet/options
                                 :extensions/profile
                                 :wallet/custom-token-screen]
                           :opt-un [::modal

--- a/src/status_im/ui/screens/group/chat_settings/events.cljs
+++ b/src/status_im/ui/screens/group/chat_settings/events.cljs
@@ -11,8 +11,9 @@
  :show-group-chat-profile
  (fn [{:keys [db] :as cofx} [_ chat-id]]
    (fx/merge cofx
-             {:db (assoc db
-                         :new-chat-name (get-in db [:chats chat-id :name]))}
+             {:db (-> db
+                      (assoc :new-chat-name (get-in db [:chats chat-id :name]))
+                      (assoc :current-chat-id chat-id))}
              (navigation/navigate-to-cofx :group-chat-profile nil))))
 
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/home/sheet/views.cljs
+++ b/src/status_im/ui/screens/home/sheet/views.cljs
@@ -1,11 +1,14 @@
 (ns status-im.ui.screens.home.sheet.views
+  (:require-macros [status-im.utils.views :refer [defview letsubs] :as views])
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.ui.components.action-button.action-button :as action-button]
             [status-im.ui.components.action-button.styles :as action-button.styles]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list-selection :as list-selection]
-            [status-im.ui.components.react :as react]))
+            [status-im.ui.components.react :as react]
+            [status-im.utils.universal-links.core :as universal-links]
+            [status-im.utils.platform :as platform]))
 
 (defn hide-sheet-and-dispatch [event]
   (re-frame/dispatch [:bottom-sheet/hide-sheet])
@@ -49,6 +52,80 @@
                               (re-frame/dispatch [:bottom-sheet/hide-sheet])
                               (list-selection/open-share {:message (i18n/label :t/get-status-at)}))}]]])
 
+(defview public-chat-actions-view []
+  (letsubs [{:keys [chat-id]} [:bottom-sheet/options]]
+    [react/view {:flex 1 :flex-direction :row}
+     [react/view action-button.styles/actions-list
+      (when-not platform/desktop?
+        (let [link    (universal-links/generate-link :public-chat :external chat-id)
+              message (i18n/label :t/share-public-chat-text {:link link})]
+          [action-button/action-button
+           {:label               (i18n/label :t/share-chat)
+            :accessibility-label :share-chat-button
+            :icon                :main-icons/share
+            :icon-opts           {:color colors/blue}
+            :on-press            #(do
+                                    (re-frame/dispatch [:bottom-sheet/hide-sheet])
+                                    (list-selection/open-share {:message message}))}]))
+      [action-button/action-button
+       {:label               (i18n/label :t/delete-chat)
+        :label-style         {:color colors/red}
+        :accessibility-label :delete-chat-button
+        :icon                :main-icons/delete
+        :icon-opts           {:color colors/red}
+        :cyrcle-color        colors/red-light
+        :on-press            #(hide-sheet-and-dispatch [:chat.ui/remove-chat-pressed chat-id])}]]]))
+
+(defview private-chat-actions-view []
+  (letsubs [{:keys [chat-id]} [:bottom-sheet/options]]
+    [react/view {:flex 1 :flex-direction :row}
+     [react/view action-button.styles/actions-list
+      [action-button/action-button
+       {:label               (i18n/label :t/view-profile)
+        :accessibility-label :view-profile-button
+        :icon                :main-icons/profile
+        :icon-opts           {:color colors/blue}
+        :on-press            #(hide-sheet-and-dispatch [:chat.ui/show-profile chat-id])}]
+      [action-button/action-button
+       {:label               (i18n/label :t/delete-chat)
+        :label-style         {:color colors/red}
+        :accessibility-label :delete-chat-button
+        :icon                :main-icons/delete
+        :icon-opts           {:color colors/red}
+        :cyrcle-color        colors/red-light
+        :on-press            #(hide-sheet-and-dispatch [:chat.ui/remove-chat-pressed chat-id])}]]]))
+
+(defview group-chat-actions-view []
+  (letsubs [{:keys [chat-id]} [:bottom-sheet/options]]
+    [react/view {:flex 1 :flex-direction :row}
+     [react/view action-button.styles/actions-list
+      [action-button/action-button
+       {:label               (i18n/label :t/group-info)
+        :accessibility-label :group-info-button
+        :icon                :main-icons/group-chat
+        :icon-opts           {:color colors/blue}
+        :on-press            #(hide-sheet-and-dispatch [:show-group-chat-profile chat-id])}]
+      [action-button/action-button
+       {:label               (i18n/label :t/delete-and-leave-group)
+        :label-style         {:color colors/red}
+        :accessibility-label :delete-and-leave-group-button
+        :icon                :main-icons/delete
+        :icon-opts           {:color colors/red}
+        :cyrcle-color        colors/red-light
+        :on-press            #(hide-sheet-and-dispatch [:group-chats.ui/remove-chat-pressed chat-id])}]]]))
+
 (def add-new
   {:content        add-new-view
    :content-height 320})
+
+(def public-chat-actions
+  {:content        public-chat-actions-view
+   :content-height 128})
+
+(def private-chat-actions
+  {:content        private-chat-actions-view
+   :content-height 128})
+
+(def group-chat-actions
+  {:content        group-chat-actions-view
+   :content-height 128})

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -104,7 +104,7 @@
   (views/letsubs [logging-in? [:accounts/login]]
     [react/view styles/action-button-container
      [react/touchable-highlight {:accessibility-label :new-chat-button
-                                 :on-press            (when-not logging-in? #(re-frame/dispatch [:bottom-sheet/show-sheet :add-new]))}
+                                 :on-press            (when-not logging-in? #(re-frame/dispatch [:bottom-sheet/show-sheet :add-new {}]))}
       [react/view styles/action-button
        (if logging-in?
          [react/activity-indicator {:color     :white

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -31,7 +31,16 @@
                  (merge mobile-network-settings/offline-sheet)
 
                  (= view :add-new)
-                 (merge home.sheet/add-new))]
+                 (merge home.sheet/add-new)
+
+                 (= view :public-chat-actions)
+                 (merge home.sheet/public-chat-actions)
+
+                 (= view :private-chat-actions)
+                 (merge home.sheet/private-chat-actions)
+
+                 (= view :group-chat-actions)
+                 (merge home.sheet/group-chat-actions))]
 
       [bottom-sheet/bottom-sheet opts])))
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -31,6 +31,7 @@
     "done": "Done",
     "remove-from-contacts": "Remove from contacts",
     "delete-chat": "Delete chat",
+    "delete-and-leave-group": "Delete and leave group",
     "new-group-chat": "New group chat",
     "edit-chats": "Edit chats",
     "sign-in": "Sign in",


### PR DESCRIPTION
Fixes #7715 

### Review notes: 
Added and made use of new root subscription `:bottom-sheet/options` to pass `chat-id` needed by chat actions buttons. Not sure if there is a better approach(perhaps change and use `:current-chat-id` `:on-long-press`), but thought it might be useful for other/future bottom-sheet use cases as well.

Tested so far only on iOS simulator

status: ready for review