### PR TITLE
[performance] replace reduce by reduce-kv

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -44,12 +44,14 @@
 
 (defn active-chats
   [contacts chats {:keys [public-key]}]
-  (reduce (fn [acc [chat-id {:keys [is-active] :as chat}]]
-            (if is-active
-              (assoc acc chat-id (enrich-active-chat contacts chat public-key))
-              acc))
-          {}
-          chats))
+  (reduce-kv (fn [acc chat-id {:keys [is-active] :as chat}]
+               (if is-active
+                 (assoc acc
+                        chat-id
+                        (enrich-active-chat contacts chat public-key))
+                 acc))
+             {}
+             chats))
 
 (defn topic-by-current-chat
   [{:keys [current-chat-id chats] :as db}]

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -177,10 +177,10 @@
 
 (defn enrich-contacts
   [contacts]
-  (reduce (fn [acc [public-key contact]]
-            (assoc acc public-key (enrich-contact contact)))
-          {}
-          contacts))
+  (reduce-kv (fn [acc public-key contact]
+               (assoc acc public-key (enrich-contact contact)))
+             {}
+             contacts))
 
 (defn get-blocked-contacts
   [contacts]


### PR DESCRIPTION
For associative collections, using reduce-kv should
give a small performance gain over reduce as there is
no allocation of tuples for key/value pairs

status: ready