### PR TITLE
[7105] Feature - Adding error for a field defined with range

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1023,6 +1023,7 @@
     "chaos-unicorn-day": "Chaos Unicorn Day",
     "chaos-unicorn-day-details": "\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83D\uDE80!",
     "invalid-format": "Invalid format\nMust be {{format}}",
+    "invalid-range": "Invalid format, must be between {{min}} and {{max}}",
     "mailserver-format": "enode://{enode-id}:{password}@{ip-address}:{port}",
     "bootnode-format": "enode://{enode-id}@{ip-address}:{port}",
     "fetch-messages": "↓ Fetch messages",


### PR DESCRIPTION
Fixes #7105 

![status-input-range-validation](https://user-images.githubusercontent.com/88840/57955495-65664580-78f6-11e9-9712-bbf63c40f589.gif)

### Summary
Support input range validation with `min` and `max` properties

### Review notes


* Add the extension code, install it and check the validation

### Testing notes


* Add the extension code, install it and check the validation

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

* Android
* iOS
* macOS
* Linux
* Windows

#### Areas that maybe impacted


* Extensions

##### Functional


* 1-1 chats
* public chats
* group chats
* wallet / transactions
* dapps / app browsing
* account recovery
* new account
* user profile updates
* networks
* mailservers
* fleet
* bootnodes

##### Non-functional


* battery performance
* CPU performance / speed of the app
* network consumption

### Steps to test
Add the following extension to test

```
{meta {:name "Test extension example 10"
:description "just to test the input error example version 10"
:documentation ""}

views/hello
[input {:style {:margin 10} :placeholder "Test" :min 1 :max 8}]

hooks/wallet.settings.hello
{:label "Settings for test error input extension"
:view [hello]}}
```

* Open Status
* ...
* Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->

