### PR TITLE
[refactor] use `ethereum` `current-address` and `chain-keyword`

### DIFF
--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -85,13 +85,12 @@
       (re-frame/dispatch [:browser.callback/resolve-ens-multihash-error]))))
 
 (fx/defn resolve-url
-  [{{:keys [network] :as db} :db} {:keys [error? resolved-url]}]
+  [{:keys [db]} {:keys [error? resolved-url]}]
   (when (not error?)
     (let [current-url (get-current-url (get-current-browser db))
           host (http/url-host current-url)]
       (if (and (not resolved-url) (ens/is-valid-eth-name? host))
-        (let [network (get-in db [:account/account :networks network])
-              chain   (ethereum/network->chain-keyword network)]
+        (let [chain   (ethereum/chain-keyword db)]
           {:db                            (update db :browser/options assoc :resolving? true)
            :browser/resolve-ens-content {:registry (get ens/ens-registries
                                                         chain)
@@ -100,11 +99,10 @@
         {:db (update db :browser/options assoc :url (or resolved-url current-url) :resolving? false)}))))
 
 (fx/defn resolve-ens-contenthash
-  [{{:keys [network] :as db} :db}]
+  [{:keys [db]}]
   (let [current-url (get-current-url (get-current-browser db))
         host (http/url-host current-url)]
-    (let [network (get-in db [:account/account :networks network])
-          chain   (ethereum/network->chain-keyword network)]
+    (let [chain   (ethereum/chain-keyword db)]
       {:db                            (update db :browser/options assoc :resolving? true)
        :browser/resolve-ens-contenthash {:registry (get ens/ens-registries
                                                         chain)

--- a/src/status_im/ethereum/contracts.cljs
+++ b/src/status_im/ethereum/contracts.cljs
@@ -12,6 +12,5 @@
 
 (defn get-address
   [db contract]
-  (let [chain-keyword (-> (get-in db [:account/account :networks (:network db)])
-                          ethereum/network->chain-keyword)]
+  (let [chain-keyword (ethereum/chain-keyword db)]
     (get-in contracts [contract chain-keyword])))

--- a/src/status_im/ethereum/subscriptions.cljs
+++ b/src/status_im/ethereum/subscriptions.cljs
@@ -37,12 +37,11 @@
 (fx/defn new-block
   [{:keys [db] :as cofx} {:keys [number transactions] :as block}]
   (when number
-    (let [{:keys [:account/account :wallet/all-tokens network
-                  :ethereum/current-block]} db
-          chain (ethereum/network->chain-keyword (get-in account [:networks network]))
+    (let [{:keys [:wallet/all-tokens :ethereum/current-block]} db
+          chain (ethereum/chain-keyword db)
           chain-tokens (into {} (map (juxt :address identity)
                                      (tokens/tokens-for all-tokens chain)))
-          wallet-address (ethereum/normalized-address (:address account))
+          wallet-address (ethereum/current-address db)
           token-contracts-addresses (into #{} (keys chain-tokens))]
       (fx/merge cofx
                 {:db (assoc-in db [:ethereum/current-block] number)
@@ -94,11 +93,11 @@
 
 (fx/defn initialize
   [{:keys [db] :as cofx}]
-  (let [{:keys [:account/account :wallet/all-tokens network]} db
-        chain (ethereum/network->chain-keyword (get-in account [:networks network]))
+  (let [{:keys [:wallet/all-tokens]} db
+        chain (ethereum/chain-keyword db)
         chain-tokens (into {} (map (juxt :address identity)
                                    (tokens/tokens-for all-tokens chain)))
-        normalized-address (ethereum/normalized-address (:address account))
+        normalized-address (ethereum/current-address db)
         padded-address (transactions/add-padding normalized-address)]
     {:ethereum.subscriptions/new-block nil
      :ethereum.subscriptions/token-transactions

--- a/src/status_im/ethereum/transactions/etherscan.cljs
+++ b/src/status_im/ethereum/transactions/etherscan.cljs
@@ -161,13 +161,12 @@
 
 (fx/defn fetch-history
   [{:keys [db] :as cofx}]
-  (let [{:keys [:account/account :wallet/all-tokens network]} db
-        chain (ethereum/network->chain-keyword
-               (get-in account [:networks network]))
+  (let [{:keys [:account/account :wallet/all-tokens]} db
+        chain (ethereum/chain-keyword db)
         chain-tokens (into {} (map (juxt :address identity)
                                    (tokens/tokens-for all-tokens chain)))
         chaos-mode? (get-in account [:settings :chaos-mode?])
-        normalized-address (ethereum/normalized-address (:address account))]
+        normalized-address (ethereum/current-address db)]
     #:ethereum.transactions.etherscan
      {:fetch-history
       {:chain chain

--- a/src/status_im/extensions/capacities/ethereum.cljs
+++ b/src/status_im/extensions/capacities/ethereum.cljs
@@ -36,9 +36,7 @@
                         (first address)
                         address)]
     (if (ens/is-valid-eth-name? first-address)
-      (let [{:keys [network]} db
-            network-info (get-in db [:account/account :networks network])
-            chain (ethereum/network->chain-keyword network-info)
+      (let [chain (ethereum/chain-keyword db)
             registry (get ens/ens-registries chain)]
         (ens/get-addr registry first-address
                       #(f db (assoc arguments address-keyword %))))
@@ -376,9 +374,7 @@
  :extensions/ethereum-resolve-ens
  (fn [{db :db} [_ _ {:keys [name on-success on-failure]}]]
    (if (ens/is-valid-eth-name? name)
-     (let [{:keys [network]} db
-           network-info (get-in db [:account/account :networks network])
-           chain (ethereum/network->chain-keyword network-info)
+     (let [chain (ethereum/chain-keyword db)
            registry (get ens/ens-registries chain)]
        (ens/get-addr registry name
                      #(on-success {:value %})))
@@ -395,7 +391,7 @@
      (fx/merge cofx
                {:db (assoc-in db [:wallet :send-transaction]
                               {:id                id
-                               :from             (ethereum/normalized-address (get-in db [:account/account :address]))
+                               :from             (ethereum/current-address db)
                                :data             (or data (str "0x" (abi-spec/from-utf8 message)))
                                :on-result        [:extensions/wallet-ui-on-success on-success]
                                :on-error         [:extensions/wallet-ui-on-failure on-failure]

--- a/src/status_im/network/core.cljs
+++ b/src/status_im/network/core.cljs
@@ -73,10 +73,6 @@
      :name       network-name
      :config     config}))
 
-(defn get-chain [{:keys [db]}]
-  (let [network  (get (:networks (:account/account db)) (:network db))]
-    (ethereum/network->chain-keyword network)))
-
 (defn get-network [{:keys [db]} network-id]
   (get-in db [:account/account :networks network-id]))
 

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -949,11 +949,11 @@
  :<- [:balance]
  :<- [:prices]
  :<- [:wallet/currency]
- :<- [:network]
+ :<- [:ethereum/chain-keyword]
  :<- [:wallet/all-tokens]
- (fn [[balance prices currency network all-tokens] [_ currency-code]]
+ (fn [[balance prices currency chain all-tokens] [_ currency-code]]
    (if (and balance prices)
-     (let [assets          (tokens/tokens-for all-tokens (ethereum/network->chain-keyword network))
+     (let [assets          (tokens/tokens-for all-tokens chain)
            token->decimals (into {} (map #(vector (:symbol %) (:decimals %)) assets))
            balance-total-value
            (get-balance-total-value balance
@@ -984,22 +984,20 @@
 
 (re-frame/reg-sub
  :wallet/visible-tokens-symbols
- :<- [:network]
+ :<- [:ethereum/chain-keyword]
  :<- [:account/account]
- (fn [[network current-account]]
-   (let [chain (ethereum/network->chain-keyword network)]
-     (get-in current-account [:settings :wallet :visible-tokens chain]))))
+ (fn [[chain current-account]]
+   (get-in current-account [:settings :wallet :visible-tokens chain])))
 
 (re-frame/reg-sub
  :wallet/visible-assets
- :<- [:network]
+ :<- [:ethereum/chain-keyword]
  :<- [:wallet/visible-tokens-symbols]
  :<- [:wallet/all-tokens]
- (fn [[network visible-tokens-symbols all-tokens]]
-   (let [chain (ethereum/network->chain-keyword network)]
-     (conj (filter #(contains? visible-tokens-symbols (:symbol %))
-                   (tokens/sorted-tokens-for all-tokens chain))
-           (tokens/native-currency chain)))))
+ (fn [[chain visible-tokens-symbols all-tokens]]
+   (conj (filter #(contains? visible-tokens-symbols (:symbol %))
+                 (tokens/sorted-tokens-for all-tokens chain))
+         (tokens/native-currency chain))))
 
 (re-frame/reg-sub
  :wallet/visible-assets-with-amount
@@ -1510,19 +1508,19 @@
  (fn [_ [_ _ {:keys [value]}]]
    value))
 
-(defn get-token-for [network all-tokens token]
+(defn get-token-for [chain all-tokens token]
   (if (= token "ETH")
     {:decimals 18
      :address  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}
-    (tokens/token-for (ethereum/network->chain-keyword network) all-tokens token)))
+    (tokens/token-for chain all-tokens token)))
 
 (re-frame/reg-sub
  :extensions.wallet/balance
  :<- [:wallet/all-tokens]
- :<- [:network]
+ :<- [:ethereum/chain-keyword]
  :<- [:balance]
- (fn [[all-tokens network balance] [_ _ {token :token}]]
-   (let [{:keys [decimals]} (get-token-for network all-tokens token)
+ (fn [[all-tokens chain balance] [_ _ {token :token}]]
+   (let [{:keys [decimals]} (get-token-for chain all-tokens token)
          value (or (get balance (keyword token)) (money/bignumber 0))]
      {:value        (money/token->unit value decimals)
       :value-in-wei value})))
@@ -1544,10 +1542,10 @@
  :extensions.wallet/tokens
  :<- [:wallet/all-tokens]
  :<- [:wallet/visible-tokens-symbols]
- :<- [:network]
- (fn [[all-tokens visible-tokens-symbols network] [_ _ {filter-vector :filter visible :visible}]]
+ :<- [:ethereum/chain-keyword]
+ (fn [[all-tokens visible-tokens-symbols chain] [_ _ {filter-vector :filter visible :visible}]]
    (let [tokens (map normalize-token (filter #(and (not (:nft? %)) (if visible (contains? visible-tokens-symbols (:symbol %)) true))
-                                             (tokens/sorted-tokens-for all-tokens (ethereum/network->chain-keyword network))))]
+                                             (tokens/sorted-tokens-for all-tokens chain)))]
      (if filter-vector
        (filter #((set filter-vector) (:symbol %)) tokens)
        tokens))))

--- a/src/status_im/tribute_to_talk/core.cljs
+++ b/src/status_im/tribute_to_talk/core.cljs
@@ -18,8 +18,7 @@
 (fx/defn update-settings
   [{:keys [db] :as cofx} {:keys [snt-amount message update] :as new-settings}]
   (let [account-settings (get-in db [:account/account :settings])
-        chain-keyword    (-> (get-in db [:account/account :networks (:network db)])
-                             ethereum/network->chain-keyword)
+        chain-keyword    (ethereum/chain-keyword db)
         tribute-to-talk-settings (cond-> (merge (tribute-to-talk.db/get-settings db)
                                                 new-settings)
                                    new-settings

--- a/src/status_im/tribute_to_talk/db.cljs
+++ b/src/status_im/tribute_to_talk/db.cljs
@@ -16,8 +16,7 @@
 
 (defn get-settings
   [db]
-  (let [chain-keyword    (-> (get-in db [:account/account :networks (:network db)])
-                             ethereum/network->chain-keyword)]
+  (let [chain-keyword (ethereum/chain-keyword db)]
     (get-in db [:account/account :settings :tribute-to-talk chain-keyword])))
 
 (defn enabled?

--- a/src/status_im/ui/screens/stickers/views.cljs
+++ b/src/status_im/ui/screens/stickers/views.cljs
@@ -22,10 +22,9 @@
    [icons/icon :main-icons/check {:color colors/white :height 20 :width 20}]])
 
 (defview price-badge [price id owned pending]
-  (letsubs [network [:network]
+  (letsubs [chain   [:ethereum/chain-keyword]
             balance [:balance]]
-    (let [chain           (ethereum/network->chain-keyword network)
-          snt             (money/to-number (if (= :mainnet chain) (:SNT balance) (:STT balance)))
+    (let [snt             (money/to-number (if (= :mainnet chain) (:SNT balance) (:STT balance)))
           not-enough-snt? (> price snt)
           no-snt?         (or (nil? snt) (zero? snt))]
       [react/touchable-highlight {:on-press #(cond pending nil

--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -75,12 +75,9 @@
 (handlers/register-handler-fx
  :wallet.send/set-recipient
  (fn [{:keys [db]} [_ recipient]]
-   (let [{:keys [web3 network]} db
-         network-info (get-in db [:account/account :networks network])
-         chain (ethereum/network->chain-keyword network-info)]
+   (let [chain (ethereum/chain-keyword db)]
      (if (ens/is-valid-eth-name? recipient)
-       {:resolve-address {:web3     web3
-                          :registry (get ens/ens-registries chain)
+       {:resolve-address {:registry (get ens/ens-registries chain)
                           :ens-name recipient
                           :cb       #(re-frame/dispatch [:wallet.send/set-recipient %])}}
        (if (ethereum/address? recipient)

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -156,9 +156,9 @@
 
 (views/defview asset-selector [{:keys [disabled? type symbol error]}]
   (views/letsubs [balance    [:balance]
-                  network    [:network]
+                  chain      [:ethereum/chain-keyword]
                   all-tokens [:wallet/all-tokens]]
-    (let [{:keys [name icon decimals color] :as token} (tokens/asset-for all-tokens (ethereum/network->chain-keyword network) symbol)]
+    (let [{:keys [name icon decimals color] :as token} (tokens/asset-for all-tokens chain symbol)]
       (when name
         [react/view
          [cartouche {:disabled? disabled? :on-press #(re-frame/dispatch [:navigate-to (type->view type)])}

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -30,14 +30,14 @@
 
 (views/defview send-transaction-request []
   ;; TODO(jeluard) both send and request flows should be merged
-  (views/letsubs [network                                           [:account/network]
-                  {:keys [to to-name public-key]}                   [:wallet.send/transaction]
-                  {:keys [amount amount-error amount-text symbol
-                          to to-name public-key]}                   [:wallet.request/transaction]
-                  network-status                                    [:network-status]
-                  all-tokens                                        [:wallet/all-tokens]
-                  scroll                                            (atom nil)]
-    (let [{:keys [decimals] :as token} (tokens/asset-for all-tokens (ethereum/network->chain-keyword network) symbol)]
+  (views/letsubs [chain                           [:ethereum/chain-keyword]
+                  {:keys [to to-name public-key]} [:wallet.send/transaction]
+                  {:keys [amount amount-error amount-text symbol to
+                          to-name public-key]}    [:wallet.request/transaction]
+                  network-status                  [:network-status]
+                  all-tokens                      [:wallet/all-tokens]
+                  scroll                          (atom nil)]
+    (let [{:keys [decimals] :as token} (tokens/asset-for all-tokens chain symbol)]
       [wallet.components/simple-screen {:avoid-keyboard? true}
        [wallet.components/toolbar (i18n/label :t/new-request)]
        [react/view components.styles/flex

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -150,10 +150,9 @@
                         :padding-vertical 14}}
     (i18n/label :t/signing-phrase-warning)]])
 
-(defn- render-send-transaction-view [{:keys [modal? transaction scroll advanced? keycard? signing-phrase network all-tokens amount-input network-status]}]
+(defn- render-send-transaction-view [{:keys [chain modal? transaction scroll advanced? keycard? signing-phrase all-tokens amount-input network-status]}]
   (let [{:keys [amount amount-text amount-error asset-error show-password-input? to to-name sufficient-funds?
                 sufficient-gas? in-progress? from-chat? symbol]} transaction
-        chain (ethereum/network->chain-keyword network)
         native-currency (tokens/native-currency chain)
         {:keys [decimals] :as token} (tokens/asset-for all-tokens chain symbol)
         online? (= :online network-status)]
@@ -218,7 +217,7 @@
 (defview send-transaction []
   (letsubs [transaction [:wallet.send/transaction]
             advanced? [:wallet.send/advanced?]
-            network [:account/network]
+            chain [:ethereum/chain-keyword]
             scroll (atom nil)
             network-status [:network-status]
             all-tokens [:wallet/all-tokens]
@@ -230,7 +229,7 @@
                             :advanced?      advanced?
                             :keycard?       keycard?
                             :signing-phrase signing-phrase
-                            :network        network
+                            :chain          chain
                             :all-tokens     all-tokens
                             :network-status network-status}]))
 
@@ -238,7 +237,7 @@
 (defview send-transaction-modal []
   (letsubs [transaction [:wallet.send/transaction]
             advanced? [:wallet.send/advanced?]
-            network [:account/network]
+            chain [:ethereum/chain-keyword]
             scroll (atom nil)
             network-status [:network-status]
             all-tokens [:wallet/all-tokens]
@@ -251,7 +250,7 @@
                               :advanced?      advanced?
                               :keycard?       keycard?
                               :signing-phrase signing-phrase
-                              :network        network
+                              :chain          chain
                               :all-tokens     all-tokens
                               :network-status network-status}]
       [react/view wallet.styles/wallet-modal-container

--- a/src/status_im/ui/screens/wallet/settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/settings/views.cljs
@@ -58,11 +58,10 @@
      [list/item-secondary symbol]]]])
 
 (defview manage-assets []
-  (letsubs [network        [:network]
+  (letsubs [chain          [:ethereum/chain-keyword]
             visible-tokens [:wallet/visible-tokens-symbols]
             all-tokens     [:wallet/all-tokens]]
-    (let [chain-key (ethereum/network->chain-keyword network)
-          {custom-tokens true default-tokens nil} (group-by :custom? (tokens/sorted-tokens-for all-tokens chain-key))]
+    (let [{custom-tokens true default-tokens nil} (group-by :custom? (tokens/sorted-tokens-for all-tokens chain))]
       [react/view (merge components.styles/flex {:background-color :white})
        [status-bar/status-bar]
        [toolbar]

--- a/src/status_im/ui/screens/wallet/transaction_fee/views.cljs
+++ b/src/status_im/ui/screens/wallet/transaction_fee/views.cljs
@@ -26,7 +26,7 @@
 
 (defview transaction-fee []
   (letsubs [send-transaction            [:wallet.send/transaction]
-            network                     [:account/network]
+            chain                       [:ethereum/chain-keyword]
             {gas-edit       :gas
              max-fee        :max-fee
              gas-price-edit :gas-price} [:wallet/edit]
@@ -34,7 +34,6 @@
     (let [{:keys [amount symbol]} send-transaction
           gas                (:value gas-edit)
           gas-price          (:value gas-price-edit)
-          chain              (ethereum/network->chain-keyword network)
           native-currency    (tokens/native-currency chain)
           {:keys [decimals] :as token} (tokens/asset-for all-tokens chain symbol)]
       [components/simple-screen {:status-bar-type :modal-wallet}

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -57,9 +57,6 @@
 (defn network->chain-keyword [network]
   (chain-id->chain-keyword (network->chain-id network)))
 
-(defn get-chain-keyword [db]
-  (network->chain-keyword (get-in db [:account/account :networks (:network db)])))
-
 (defn network->chain-name [network]
   (-> network
       network->chain-keyword

--- a/src/status_im/wallet/custom_tokens/core.cljs
+++ b/src/status_im/wallet/custom_tokens/core.cljs
@@ -85,7 +85,7 @@
 
 (defn field-exists?
   [{:wallet/keys [all-tokens] :as db} field-key field-value]
-  (let [chain-key (ethereum/get-chain-keyword db)]
+  (let [chain-key (ethereum/chain-keyword db)]
     (some #(= field-value (get % field-key))
           (vals (get all-tokens chain-key)))))
 
@@ -101,7 +101,7 @@
 
 (defn token-in-list?
   [{:wallet/keys [all-tokens] :as db} contract]
-  (let [chain-key (ethereum/get-chain-keyword db)
+  (let [chain-key (ethereum/chain-keyword db)
         addresses (set (map string/lower-case (keys (get all-tokens chain-key))))]
     (not (nil? (get addresses (string/lower-case contract))))))
 
@@ -168,7 +168,7 @@
 (fx/defn add-custom-token
   [{:keys [db] :as cofx}]
   (let [{:keys [contract name symbol decimals]} (get db :wallet/custom-token-screen)
-        chain-key (ethereum/get-chain-keyword db)
+        chain-key (ethereum/chain-keyword db)
         symbol    (keyword symbol)
         new-token {:address  contract
                    :name     name
@@ -183,7 +183,7 @@
 
 (fx/defn remove-custom-token
   [{:keys [db] :as cofx} {:keys [address] :as token}]
-  (let [chain-key (ethereum/get-chain-keyword db)]
+  (let [chain-key (ethereum/chain-keyword db)]
     (fx/merge (update-in cofx [:db :wallet/all-tokens chain-key] dissoc address)
               (wallet/remove-custom-token token))))
 


### PR DESCRIPTION
in many places in the codebase, we are doing various destructuring
and function calls to get the normalized current address and the chain
keyword for the current network

this PR replace all usages by utility functions introduced recently

status: ready