### PR TITLE
Update the defn macro

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -309,20 +309,6 @@
 ;; accounts login module
 
 (handlers/register-handler-fx
- :accounts.login.ui/password-input-submitted
- (fn [cofx _]
-   (accounts.login/user-login cofx false)))
-
-(handlers/register-handler-fx
- :accounts.login.callback/login-success
- [(re-frame/inject-cofx :web3/get-web3)
-  (re-frame/inject-cofx :data-store/get-all-mailservers)
-  (re-frame/inject-cofx :data-store/transport)
-  (re-frame/inject-cofx :data-store/mailserver-topics)]
- (fn [cofx [_ login-result]]
-   (accounts.login/user-login-callback cofx login-result)))
-
-(handlers/register-handler-fx
  :accounts.login.callback/verify-success
  (fn [cofx [_ verify-result realm-error]]
    (accounts.login/verify-callback cofx verify-result realm-error)))

--- a/src/status_im/tribute_to_talk/core.cljs
+++ b/src/status_im/tribute_to_talk/core.cljs
@@ -247,7 +247,7 @@
                      [:navigation/screen-params :tribute-to-talk :state]
                      :transaction-failed)})))
 
-(defn remove
+(fx/defn remove
   [{:keys [db] :as cofx}]
   (fx/merge cofx
             {:db (assoc-in db [:navigation/screen-params :tribute-to-talk]

--- a/src/status_im/utils/fx.clj
+++ b/src/status_im/utils/fx.clj
@@ -1,6 +1,15 @@
 (ns status-im.utils.fx
   (:refer-clojure :exclude [defn]))
 
+(defn- register-events
+  [events interceptors name args]
+  (mapv (fn [event]
+          `(status-im.utils.handlers/register-handler-fx
+            ~event
+            ~interceptors
+            (fn [cofx# [_# ~@args]] (~name cofx# ~@args))))
+        events))
+
 (defmacro defn
   "Defines an fx producing function
   Takes the same arguments as the defn macro
@@ -12,7 +21,8 @@
   Notes:
   - destructuring of cofx is possible
   - supports docstring
-  - supports attr-map
+  - supports attr-map with optional :events key which needs to be a vector of
+  event keywords under which the function will be registered
   - TODO: add suport for `prepost-map?` (don't forget to add it to arglist)
   - TODO: add validation of macro parameters"
   {:arglists '([name doc-string? attr-map? [params*] body])}
@@ -26,17 +36,24 @@
         m (if (map? (first fdecl))
             (conj m (first fdecl))
             m)
+        events (get m :events [])
+        interceptors (get m :interceptors [])
         fdecl (if (map? (first fdecl))
                 (next fdecl)
                 fdecl)
         [cofx & args] (first fdecl)
         fdecl (next fdecl)
         argsyms (take (count args) (repeatedly #(gensym "arg")))]
-    `(clojure.core/defn ~(with-meta name m)
-       ([~@argsyms] (fn [cofx#] (~name cofx# ~@argsyms)))
-       ([cofx# ~@args]
-        (if (and (map? cofx#)
-                 (not (nil? (:db cofx#))))
-          (let [~cofx cofx#]
-            ~@fdecl)
-          (throw (js/Error. (str "fx/defn expects a map of cofx as first argument got " cofx# " in function " ~name))))))))
+    (if (and (sequential? events)
+             (every? keyword? events))
+      `(do
+         (clojure.core/defn ~(with-meta name m)
+           ([~@argsyms] (fn [cofx#] (~(with-meta name m) cofx# ~@argsyms)))
+           ([cofx# ~@args]
+            (if (and (map? cofx#)
+                     (not (nil? (:db cofx#))))
+              (let [~cofx cofx#]
+                ~@fdecl)
+              (throw (js/Error. (str "fx/defn expects a map of cofx as first argument got " cofx# " in function " ~name))))))
+         ~@(register-events events interceptors (with-meta name m) args))
+      (throw (Exception. (str "fx/defn expects a vector of keyword as value for :events key in attr-map in function " name))))))

--- a/test/cljs/status_im/test/utils/fx.cljs
+++ b/test/cljs/status_im/test/utils/fx.cljs
@@ -17,6 +17,18 @@
   [{:keys [db]} b]
   (identity nil))
 
+(fx/defn hello4
+  {:doc "this function is useless as well"
+   :events [:test/valid1 :test/valid2]}
+  [{:keys [db]} b]
+  {:db (assoc db :a b) :b (:a db)})
+
+(fx/defn hello5
+  "lol lazy function does nothing"
+  {:events [:test]}
+  [{:keys [db]} b]
+  (identity nil))
+
 (deftest merge-fxs-test
   (testing "merge function for fxs"
     (let [cofx {:db {:c 2}}]


### PR DESCRIPTION
This macro should make the events.cljs ns obsolete over time.

the defn macro knows register the function as an events under the
keywords provided in the :events key of the attributes map. It also
adds the interceptors provided in the :interceptors map

exemple:

```clojure
(fx/defn hello4
  {:doc "this function is useless as well"
   :events [:test/valid1 :test/valid2]}
  [{:keys [db]} b]
  {:db (assoc db :a b) :b (:a db)})
```

## Testing

Tested in Android emulator.

This PR is more of a dev experience improvement, but since the macro is basically behind everything happening in status-react, it is still worth testing. 
In this PR it is used in the login events, so to test it:
- create an account, 
- logout play around a bit. 

I don't think the app would even be able to login if there was a bug in this PR

status: ready