### PR TITLE
Fix/on result in app transactions

### DIFF
--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -553,7 +553,7 @@
 
 (fx/defn eth-transaction-call
   [{:keys [db] :as cofx}
-   {:keys [contract method params on-success on-error details] :as transaction}]
+   {:keys [contract method params on-result on-error details] :as transaction}]
   (let [current-address (ethereum/current-address db)
         transaction (merge {:to        contract
                             :from      current-address
@@ -562,7 +562,7 @@
                             :symbol    :ETH
                             :method    "eth_sendTransaction"
                             :amount    (money/bignumber 0)
-                            :on-success on-success
+                            :on-result on-result
                             :on-error  on-error}
                            details)
         go-to-view-id (if (get-in db [:account/account :wallet-set-up-passed?])


### PR DESCRIPTION
- based on @jeluard finding of argument mismatch in wallet/eth-transaction-call function
- this function is only called in the tribute-to-talk and stickers features to start the transaction flow.
- this is a typo fix, before the function was expecting `on-success` and later in the flow `on-result` was used so nothing was happening on transaction result.

# Tests

This doesn't require tests are this is just a typo fix

Currently in non modified builds only stickers can be tested. Here are the steps I tested on Android:
create account on ropsten, get eth and snt, go to #test public chat and buy stickers pack, wait for transaction to be on chain, click on install button, was able to post stickers in the channel
status: ready <!-- Can be ready or wip -->