### PR TITLE
Remove unused chat fields

### DIFF
--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -106,8 +106,7 @@
   (fn [realm]
     (let [chat (get-chat-by-id chat-id realm)]
       (doto chat
-        (aset "is-active" false)
-        (aset "removed-at" now)))))
+        (aset "is-active" false)))))
 
 (defn add-chat-contacts-tx
   "Returns tx function for adding chat contacts"

--- a/src/status_im/data_store/realm/schemas/account/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/chat.cljs
@@ -251,3 +251,9 @@
   (update v13 :properties assoc
           :group-chat-local-version {:type :int
                                      :optional true}))
+(def v15
+  (update v14 :properties dissoc
+          :message-overhead
+          :removed-from-at
+          :added-to-at
+          :removed-at))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -495,6 +495,23 @@
           contact-recovery/v1
           mailserver-requests-gap/v1])
 
+(def v43 [chat/v15
+          chat-requests-range/v1
+          transport/v8
+          contact/v7
+          message/v10
+          mailserver/v11
+          mailserver-topic/v2
+          user-status/v2
+          membership-update/v1
+          installation/v3
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9
+          contact-device-info/v1
+          contact-recovery/v1
+          mailserver-requests-gap/v1])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -621,4 +638,7 @@
                :migration     (constantly nil)}
               {:schema        v42
                :schemaVersion 42
-               :migration     migrations/v42}])
+               :migration     migrations/v42}
+              {:schema        v43
+               :schemaVersion 43
+               :migration     (constantly nil)}])

--- a/test/cljs/status_im/test/sign_in/data.cljs
+++ b/test/cljs/status_im/test/sign_in/data.cljs
@@ -28,18 +28,14 @@
     :admins                    #{}
     :members-joined            #{}
     :name                      "status"
-    :removed-from-at           nil
     :membership-updates        ()
     :unviewed-messages-count   0
     :last-message-content-type "text/plain"
     :is-active                 true
     :last-message-content      {:chat-id "status" :text "darn typos...! "}
     :debug?                    false
-    :added-to-at               nil
     :group-chat                true
     :public?                   true
-    :removed-at                nil
-    :message-overhead          0
     :chat-id                   "status"
     :timestamp                 1547361080397
     :deleted-at-clock-value    nil}
@@ -51,7 +47,6 @@
     :admins                    #{}
     :members-joined            #{}
     :name                      "rv"
-    :removed-from-at           nil
     :membership-updates        ()
     :unviewed-messages-count   0
     :last-message-content-type "text/plain"
@@ -59,11 +54,8 @@
     :last-message-content      {:chat-id "0x04173f7cdea0076a7998abb674cc79fe61337c42db77043c01d5b0f3e3ac1e5a45bca0c93bb9f3c3d38b7cc9a7337cd64f9f9b2114fe4bbdfe1ae2633ba14d8c9c"
                                 :text    "Hey"}
     :debug?                    false
-    :added-to-at               nil
     :group-chat                false
     :public?                   false
-    :removed-at                nil
-    :message-overhead          0
     :chat-id                   "0x043ae31038ff45a31b096a91d3f8290e079366fbbae76a00fbbd349cd0e5b8d7598965d206772ec4504f68908649a08383cdc51a52cdae5e9ccc744ace4d37020f"
     :timestamp                 1547271770816
     :deleted-at-clock-value    nil}
@@ -75,7 +67,6 @@
     :admins                    #{}
     :members-joined            #{}
     :name                      "Darkviolet Lightgreen Halcyon"
-    :removed-from-at           nil
     :membership-updates        ()
     :unviewed-messages-count   0
     :last-message-content-type "text/plain"
@@ -83,11 +74,8 @@
     :last-message-content      {:chat-id "0x04173f7cdea0076a7998abb674cc79fe61337c42db77043c01d5b0f3e3ac1e5a45bca0c93bb9f3c3d38b7cc9a7337cd64f9f9b2114fe4bbdfe1ae2633ba14d8c9c"
                                 :text    "Djndjd"}
     :debug?                    false
-    :added-to-at               nil
     :group-chat                false
     :public?                   false
-    :removed-at                nil
-    :message-overhead          0
     :chat-id                   "0x04d6e56a475cd35f512d6ce0bf76c2c2af435c85ff48c2b9bdefd129f620e051a436f50961eae5717b2a750e59c3f5b60647d927da46d0b8b11621640b5678fc24"
     :timestamp                 1547186895328
     :deleted-at-clock-value    nil}])


### PR DESCRIPTION
Some fields in the `chats` dictionary in both app-db and realm are unused. This commit removed these fields, to simplify implementation of go protocol.

## Note to QA

Migrations from the current release version should work, the list of chats should be migrated successfully.

---

status: ready <!-- Can be ready or wip -->