### PR TITLE
[feature] allow internal transaction to specify asset

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -43,8 +43,8 @@
 (re-frame/reg-fx
  ::send-transaction
  (fn [[params all-tokens symbol chain on-completed masked-password]]
-   (case symbol
-     :ETH (send-ethers params on-completed masked-password)
+   (if (= symbol :ETH)
+     (send-ethers params on-completed masked-password)
      (send-tokens all-tokens symbol chain params on-completed masked-password))))
 
 (re-frame/reg-fx
@@ -121,7 +121,7 @@
  :wallet.callback/transaction-completed
  [(re-frame/inject-cofx :random-id-generator)]
  (fn [{:keys [db now] :as cofx} [_ {:keys [result error]}]]
-   (let [{:keys [id method public-key to symbol amount-text on-result on-error
+   (let [{:keys [id method public-key to symbol asset amount-text on-result on-error
                  send-transaction-message?]}
          (get-in db [:wallet :send-transaction])
          db' (assoc-in db [:wallet :send-transaction :in-progress?] false)
@@ -145,7 +145,7 @@
                      %
                      public-key
                      {:address to
-                      :asset   (name symbol)
+                      :asset   (name (or asset symbol))
                       :amount  amount-text
                       :tx-hash result}))
                  #(when-not on-result

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -152,7 +152,7 @@
 
 (defn- render-send-transaction-view [{:keys [chain modal? transaction scroll advanced? keycard? signing-phrase all-tokens amount-input network-status]}]
   (let [{:keys [amount amount-text amount-error asset-error show-password-input? to to-name sufficient-funds?
-                sufficient-gas? in-progress? from-chat? symbol]} transaction
+                sufficient-gas? in-progress? from-chat? asset symbol]} transaction
         native-currency (tokens/native-currency chain)
         {:keys [decimals] :as token} (tokens/asset-for all-tokens chain symbol)
         online? (= :online network-status)]
@@ -177,7 +177,7 @@
          {:disabled? (or from-chat? modal? show-password-input?)
           :error     asset-error
           :type      :send
-          :symbol    symbol}]
+          :symbol    (or asset symbol)}]
         [wallet.components/amount-selector
          {:disabled?     (or from-chat? modal? show-password-input?)
           :error         (or amount-error


### PR DESCRIPTION
- allows transaction flow started by an internal feature to show
the right asset in the overview and in transaction messages
(required for tribute to talk)

status: ready