### PR TITLE
[feature] add transaction watch

### DIFF
--- a/src/status_im/ethereum/subscriptions.cljs
+++ b/src/status_im/ethereum/subscriptions.cljs
@@ -47,6 +47,7 @@
                   :block block
                   :transactions (keep-user-transactions wallet-address
                                                         transactions)}}
+                (transactions/check-watched-transactions)
                 (when (or (not current-block)
                           (not= number (inc current-block)))
                   ;; in case we skipped some blocks or got an uncle, re-fetch history


### PR DESCRIPTION
add transaction watches feature for internal transactions
when trigger-fn returns true, on-trigger fn is executed

# Test

this is not used in the codebase, will be testable within ttt PR

status: ready