### PR TITLE
[fix] destructuring in events for fx/defn macro

### DIFF
--- a/src/status_im/utils/fx.clj
+++ b/src/status_im/utils/fx.clj
@@ -2,12 +2,12 @@
   (:refer-clojure :exclude [defn]))
 
 (defn- register-events
-  [events interceptors name args]
+  [events interceptors name argsyms]
   (mapv (fn [event]
           `(status-im.utils.handlers/register-handler-fx
             ~event
             ~interceptors
-            (fn [cofx# [_# ~@args]] (~name cofx# ~@args))))
+            (fn [cofx# [_# ~@argsyms]] (~name cofx# ~@argsyms))))
         events))
 
 (defmacro defn
@@ -55,5 +55,5 @@
               (let [~cofx cofx#]
                 ~@fdecl)
               (throw (js/Error. (str "fx/defn expects a map of cofx as first argument got " cofx# " in function " ~name))))))
-         ~@(register-events events interceptors (with-meta name m) args))
+         ~@(register-events events interceptors (with-meta name m) argsyms))
       (throw (Exception. (str "fx/defn expects a vector of keyword as value for :events key in attr-map in function " name))))))

--- a/test/cljs/status_im/test/utils/fx.cljs
+++ b/test/cljs/status_im/test/utils/fx.cljs
@@ -29,6 +29,13 @@
   [{:keys [db]} b]
   (identity nil))
 
+(fx/defn hello6
+  "lol lazy function does nothing"
+  {:events [:test2]}
+  [{:keys [db]} {:keys [a b]}]
+  {:db {:a (identity a)
+        :b b}})
+
 (deftest merge-fxs-test
   (testing "merge function for fxs"
     (let [cofx {:db {:c 2}}]


### PR DESCRIPTION
Destructuring wasn't working in events declared in the defn macro
added a test

status: ready