### PR TITLE
WIP Scan invalid qr-code and dismiss error with no redirect

### DIFF
--- a/env/dev/env/config.cljs
+++ b/env/dev/env/config.cljs
@@ -1,6 +1,6 @@
 (ns env.config)
 
 (def figwheel-urls {:android "ws://localhost:3449/figwheel-ws",
- :ios "ws://192.168.0.9:3449/figwheel-ws",
+  :ios "ws://192.168.0.9:3449/figwheel-ws",
  :desktop "ws://localhost:3449/figwheel-ws"}
 )

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -675,6 +675,11 @@
 ;; qr-scanner module
 
 (handlers/register-handler-fx
+ :qr-scanner.ui/qr-code-error-dismissed
+ (fn [cofx [_ _]]
+   (qr-scanner/scan-qr-code-after-error-dismiss cofx)))
+
+(handlers/register-handler-fx
  :qr-scanner.ui/scan-qr-code-pressed
  (fn [cofx [_ identifier handler & [opts]]]
    (qr-scanner/scan-qr-code cofx identifier (merge {:handler handler} opts))))

--- a/src/status_im/qr_scanner/core.cljs
+++ b/src/status_im/qr_scanner/core.cljs
@@ -1,7 +1,9 @@
 (ns status-im.qr-scanner.core
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
+            [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.utils :as utils]
+            [taoensso.timbre :as log]
             [status-im.utils.fx :as fx]))
 
 (fx/defn scan-qr-code
@@ -19,10 +21,17 @@
                                               50))
                                            #(re-frame/dispatch [deny-handler qr-codes]))}})
 
+
+(fx/defn scan-qr-code-after-error-dismiss
+  [{:keys [db]}]
+  (let [view-id (:view-id db)]
+    {:db (assoc-in db [:navigation/screen-params view-id :barcode-read?] false)}))
+
 (fx/defn set-qr-code
   [{:keys [db]} context data]
   (merge {:db (-> db
                   (update :qr-codes dissoc context)
+                  (update-in [:navigation/screen-params :qr-scanner] assoc :barcode-read? true)
                   (dissoc :current-qr-context))}
          (when-let [qr-codes (get-in db [:qr-codes context])]
            {:dispatch [(:handler qr-codes) context data (dissoc qr-codes :handler)]})))

--- a/src/status_im/ui/screens/add_new/models.cljs
+++ b/src/status_im/ui/screens/add_new/models.cljs
@@ -6,17 +6,11 @@
             [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.fx :as fx]))
 
-(fx/defn process-qr-code
+(fx/defn handle-qr-code
   [cofx data]
   (if (spec/valid? :global/public-key data)
     (universal-links/handle-view-profile cofx data)
     (or (universal-links/handle-url cofx data)
-        {:utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)
-                            :content    (i18n/label :t/use-valid-qr-code {:data data})
-                            :on-dismiss #(re-frame/dispatch [:navigate-to-clean :home])}})))
-
-(fx/defn handle-qr-code
-  [cofx data]
-  (fx/merge cofx
-            (navigation/navigate-to-clean :home {})
-            (process-qr-code data)))
+        {:utils/show-popup {:title   (i18n/label :t/unable-to-read-this-code)
+                            :content (i18n/label :t/use-valid-qr-code {:data data})
+                            :on-dismiss #(re-frame/dispatch [:qr-scanner.ui/qr-code-error-dismissed])}})))

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -183,7 +183,11 @@
  :screens/on-will-focus
  (fn [{:keys [db] :as cofx} [_ view-id]]
    (fx/merge cofx
-             {:db (assoc db :view-id view-id)}
+             (if (= view-id :qr-scanner)
+               {:db (-> db
+                        (assoc :view-id view-id)
+                        (assoc-in [:navigation/screen-params view-id :barcode-read?] false))}
+               {:db (assoc db :view-id view-id)})
              #(case view-id
                 :keycard-settings (hardwallet/settings-screen-did-load %)
                 :reset-card (hardwallet/reset-card-screen-did-load %)

--- a/src/status_im/ui/screens/qr_scanner/views.cljs
+++ b/src/status_im/ui/screens/qr_scanner/views.cljs
@@ -8,6 +8,7 @@
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.qr-scanner.styles :as styles]
+            [taoensso.timbre :as log]
             [status-im.ui.components.toolbar.actions :as actions]))
 
 (defview qr-scanner-toolbar [title identifier]
@@ -27,28 +28,29 @@
 ;; that two separate instances of `qr-scanner` screen can work simultaneously
 (defview qr-scanner [{identifier :current-qr-context} screen-focused?]
   (letsubs [camera-initialized? (reagent/atom false)
-            barcode-read? (reagent/atom false)]
-    [react/view styles/barcode-scanner-container
-     [qr-scanner-toolbar (or (:toolbar-title identifier) (i18n/label :t/scan-qr)) identifier]
-     ;; camera component should be hidden if screen is not shown
-     ;; otherwise another screen with camera from a different stack
-     ;; will not work properly
-     (when @screen-focused?
-       [camera/camera {:onBarCodeRead #(if (:multiple? identifier)
-                                         (on-barcode-read identifier %)
-                                         (when-not @barcode-read?
-                                           (do (reset! barcode-read? true)
-                                               (on-barcode-read identifier %))))
-                       :ref           #(reset! camera-initialized? true)
-                       :captureAudio  false
-                       :style         styles/barcode-scanner}])
-     [react/view styles/rectangle-container
-      [react/view styles/rectangle
-       [react/image {:source {:uri :corner_left_top}
-                     :style  styles/corner-left-top}]
-       [react/image {:source {:uri :corner_right_top}
-                     :style  styles/corner-right-top}]
-       [react/image {:source {:uri :corner_right_bottom}
-                     :style  styles/corner-right-bottom}]
-       [react/image {:source {:uri :corner_left_bottom}
-                     :style  styles/corner-left-bottom}]]]]))
+            {barcode-read-sub? :barcode-read?} [:get-screen-params]]
+    (let [barcode-read? (reagent/atom barcode-read-sub?)]        
+		    [react/view styles/barcode-scanner-container
+		     [qr-scanner-toolbar (or (:toolbar-title identifier) (i18n/label :t/scan-qr)) identifier]
+		     ;; camera component should be hidden if screen is not shown
+		     ;; otherwise another screen with camera from a different stack
+		     ;; will not work properly
+		     (when @screen-focused?
+		       [camera/camera {:onBarCodeRead #(if (:multiple? identifier)
+		                                         (on-barcode-read identifier %)
+		                                         (when-not @barcode-read?
+		                                           (do (reset! barcode-read? true)
+		                                               (on-barcode-read identifier %))))
+		                         :ref           #(reset! camera-initialized? true)
+		                         :captureAudio  false
+		                         :style         styles/barcode-scanner}])
+		       [react/view styles/rectangle-container
+		        [react/view styles/rectangle
+		         [react/image {:source {:uri :corner_left_top}
+		                       :style  styles/corner-left-top}]
+		         [react/image {:source {:uri :corner_right_top}
+		                       :style  styles/corner-right-top}]
+		         [react/image {:source {:uri :corner_right_bottom}
+		                       :style  styles/corner-right-bottom}]
+		         [react/image {:source {:uri :corner_left_bottom}
+		                       :style  styles/corner-left-bottom}]]]])))


### PR DESCRIPTION
This PR fixes https://github.com/status-im/status-react/issues/5287

Originally, I submitted https://github.com/status-im/status-react/pull/7745, but it caused this regression https://github.com/status-im/status-react/issues/8044

This PR is the same as https://github.com/status-im/status-react/pull/7745 but uses an atom check in `src/status_im/ui/screens/qr_scanner/views.cljs`

This is a WIP because there is still more work to do:

1. Another issue came up where after an invalid code is scanned, after dismissing the error message another QR code _can_ be scanned (confirmed that the `:barcode-read?` screen paramater is indeed toggled), but an error message does not show up.
1. The `:qr-scanner.ui/qr-code-error-dismissed` event is not yet fired when opening the QR scanner from starting a new chat. This changed from when I submitted my original PR. It used to be in `src/status_im/contact/core.cljs` but not anymore. If anyone can direct me where it is now, that would be greatly appreciated.

