### PR TITLE
DIVIDE APK SIZE BY 2 IN 2 LINES YOU WON'T BELIEVE THAT ONE TRICK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ HELP_FUN = \
 		   }
 HOST_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 
+# Defines which variables will be kept for Nix pure shell, use semicolon as divider
+export NIX_KEEP ?= BUILD_ENV
 export NIX_CONF_DIR = $(PWD)/nix
 
 export REACT_SERVER_PORT ?= 5001 # any value different from default 5000 will work; this has to be specified for both the Node.JS server process and the Qt process
@@ -101,21 +103,22 @@ prod-build:
 	lein prod-build
 
 prod-build-android: export TARGET_OS ?= android
+prod-build-android: export BUILD_ENV ?= prod
 prod-build-android:
-	BUILD_ENV=prod lein prod-build-android && \
+	lein prod-build-android && \
 	node prepare-modules.js
 
 prod-build-ios: export TARGET_OS ?= ios
-prod-build-ios: export BUILD_ENV = prod
+prod-build-ios: export BUILD_ENV ?= prod
 prod-build-ios:
-	BUILD_ENV=prod lein prod-build-ios && \
+	lein prod-build-ios && \
 	node prepare-modules.js
 
 prod-build-desktop: export TARGET_OS ?= $(HOST_OS)
-prod-build-desktop: export BUILD_ENV = prod
+prod-build-desktop: export BUILD_ENV ?= prod
 prod-build-desktop:
 	git clean -qdxf -f ./index.desktop.js desktop/ && \
-	BUILD_ENV=prod lein prod-build-desktop && \
+	lein prod-build-desktop && \
 	node prepare-modules.js
 
 #--------------

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -149,8 +149,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-
-
     defaultConfig {
         applicationId "im.status.ethereum"
         minSdkVersion 23
@@ -159,7 +157,7 @@ android {
         versionCode getVersionCode()
         versionName getVersionName()
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86-64"
+            abiFilters getEnvOrConfig('NDK_ABI_FILTERS').split(';')
         }
     }
     /**
@@ -179,7 +177,6 @@ android {
         exclude 'META-INF/rxjava.properties'
         exclude '/lib/mips64/**'
         exclude '/lib/arm64-v8a/**'
-        exclude '/lib/x86_64/**'
         /** Fix for: Execution failed for task ':app:transformNativeLibsWithStripDebugSymbolForDebug'.
         *   with recent version of ndk (17.0.4754217)
         */
@@ -204,7 +201,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86"
+            include "armeabi-v7a", "arm64-v8a", "x86"
         }
     }
     buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,4 +24,7 @@ STATUS_RELEASE_STORE_PASSWORD=password
 STATUS_RELEASE_KEY_ALIAS=status
 STATUS_RELEASE_KEY_PASSWORD=password
 
+# platforms for which to build the Android bundle
+NDK_ABI_FILTERS=armeabi-v7a;arm64-v8a;x86
+
 org.gradle.jvmargs=-Xmx8704M


### PR DESCRIPTION
Not sure why we build for x86 and x86_64 considering almost no one uses x86 and we exclude the libraries for x86_64 anyway.

This also reduces the APK size from 51 MB to 31 MB.

Related to #8292 and #8326.