### PR TITLE
[perf] use objectForPrimaryKey instead of getByField

### DIFF
--- a/src/status_im/data_store/browser.cljs
+++ b/src/status_im/data_store/browser.cljs
@@ -20,5 +20,7 @@
   "Returns tx function for removing browser"
   [browser-id]
   (fn [realm]
-    (let [browser (core/single (core/get-by-field realm :browser :browser-id browser-id))]
+    (let [browser (.objectForPrimaryKey realm
+                                        "browser"
+                                        browser-id)]
       (core/delete realm browser))))

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -88,7 +88,7 @@
     (core/delete realm (core/get-by-field realm :chat :chat chat-id))))
 
 (defn- get-chat-by-id [chat-id realm]
-  (core/single (core/get-by-field realm :chat :chat-id chat-id)))
+  (.objectForPrimaryKey realm "chat" chat-id))
 
 (defn clear-history-tx
   "Returns tx function for clearing the history of chat"

--- a/src/status_im/data_store/contact_recovery.cljs
+++ b/src/status_im/data_store/contact_recovery.cljs
@@ -2,9 +2,10 @@
   (:require [status-im.data-store.realm.core :as core]))
 
 (defn get-contact-recovery-by-id [public-key]
-  (-> @core/account-realm
-      (core/get-by-field  :contact-recovery :id public-key)
-      (core/single-clj :contact-recovery)))
+  (core/realm-obj->clj (.objectForPrimaryKey @core/account-realm
+                                             "contact-recovery"
+                                             public-key)
+                       :contact-recovery))
 
 (defn save-contact-recovery-tx
   "Returns tx function for saving a contact-recovery"

--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -44,7 +44,7 @@
       ((save-contact-tx contact) realm))))
 
 (defn- get-contact-by-id [public-key realm]
-  (core/single (core/get-by-field realm :contact :public-key public-key)))
+  (.objectForPrimaryKey realm "contact" public-key))
 
 (defn- get-messages-by-messages-ids
   [message-ids]

--- a/src/status_im/data_store/dapp_permissions.cljs
+++ b/src/status_im/data_store/dapp_permissions.cljs
@@ -19,4 +19,4 @@
   "Returns tx function for removing dapp permissions"
   [dapp]
   (fn [realm]
-    (core/delete realm (core/single (core/get-by-field realm :dapp-permissions :dapp dapp)))))
+    (core/delete realm (.objectForPrimaryKey realm "dapp" dapp))))

--- a/src/status_im/data_store/mailservers.cljs
+++ b/src/status_im/data_store/mailservers.cljs
@@ -61,8 +61,9 @@
   "Returns tx function for deleting mailserver topic"
   [topic]
   (fn [realm]
-    (let [mailserver-topic (core/single
-                            (core/get-by-field realm :mailserver-topic :topic topic))]
+    (let [mailserver-topic (.objectForPrimaryKey realm
+                                                 "mailserver-topic"
+                                                 topic)]
       (core/delete realm mailserver-topic))))
 
 (defn save-chat-requests-range

--- a/src/status_im/data_store/transport.cljs
+++ b/src/status_im/data_store/transport.cljs
@@ -41,6 +41,5 @@
   "Returns tx function for deleting transport"
   [chat-id]
   (fn [realm]
-    (let [transport (core/single
-                     (core/get-by-field realm :transport :chat-id chat-id))]
+    (let [transport (.objectForPrimaryKey realm "transport" chat-id)]
       (core/delete realm transport))))


### PR DESCRIPTION
Replace all usages of realm.core/single by objectForPrimaryKey for queries by primary key on a single object

# Tests

no effects

status: ready