### PR TITLE
[fix] externs for Preview Privacy Mode

### DIFF
--- a/externs.js
+++ b/externs.js
@@ -425,6 +425,7 @@ var TopLevel = {
     "setAutoCancel" : function () {},
     "setBackgroundColor" : function () {},
     "setBarStyle" : function () {},
+    "setBlankPreviewFlag" : function () {},
     "setCategory" : function () {},
     "setChannelId" : function () {},
     "setCurrentDapp" : function () {},


### PR DESCRIPTION
@churik fixes the `Preview privacy mode` switch

## Testing

no need to wait for e2e tests to end before testing, this is an advanced compilation issue, the js call made when tapping the switch was turned into garbage because it wasn't referenced in externs.js
this is the only thing affected by this change

status: ready <!-- Can be ready or wip -->