### PR TITLE
[perf][fix] typography

### DIFF
--- a/src/status_im/ui/components/typography.cljs
+++ b/src/status_im/ui/components/typography.cljs
@@ -61,22 +61,44 @@
   [{:keys [typography] :as style}]
   {:pre [(or (nil? typography) (contains? typography-styles typography))]}
   (let [{:keys [font-weight font-style font-size line-height]
-         :or {line-height (get-line-height font-size)}
          :as style}
         (merge default-style
                (get typography-styles
                     typography)
+               (dissoc style :typography :nested?))]
+    (if platform/desktop?
+      (assoc style :font-family default-font-family)
+      (-> style
+          (assoc :font-family
+                 (str default-font-family "-"
+                      (case font-weight
+                        "400" (when-not (= font-style :italic)
+                                "Regular")
+                        "500" "Medium"
+                        "600" "SemiBold"
+                        "700" "Bold")
+                      (when (= font-style :italic)
+                        "Italic")))
+          (dissoc :font-weight :font-style)))))
+
+(defn get-nested-style
+  [{:keys [typography] :as style}]
+  {:pre [(or (nil? typography) (contains? typography-styles typography))]}
+  (let [{:keys [font-weight font-style font-size] :as style}
+        (merge (get typography-styles
+                    typography)
                (dissoc style :typography))]
-    (assoc style
-           :font-family (if platform/desktop?
-                          default-font-family
-                          (str default-font-family "-"
-                               (case font-weight
-                                 "400"   (when-not (= font-style :italic)
-                                           "Regular")
-                                 "500"   "Medium"
-                                 "600"   "SemiBold"
-                                 "700"   "Bold")
-                               (when (= font-style :italic)
-                                 "Italic")))
-           :line-height line-height)))
+    (if platform/desktop?
+      style
+      (cond-> (dissoc style :font-weight :font-style)
+        (or font-weight font-style)
+        (assoc :font-family
+               (str default-font-family "-"
+                    (case font-weight
+                      "500" "Medium"
+                      "600" "SemiBold"
+                      "700" "Bold"
+                      (when-not (= font-style :italic)
+                        "Regular"))
+                    (when (= font-style :italic)
+                      "Italic")))))))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -46,8 +46,6 @@
      [react/text {:style               styles/last-message-text
                   :number-of-lines     1
                   :accessibility-label :chat-message-text}
-      #_(if-let [render-recipe (:render-recipe content)]
-          (chat.utils/render-chunks render-recipe message))
       (:text content)]
 
      :else
@@ -112,8 +110,7 @@
          [message-timestamp timestamp]]]
        [react/view styles/item-lower-container
         (let [{:keys [tribute-status tribute-label]} (:tribute-to-talk contact)]
-          (if (or group-chat
-                  (#{:none :paid} tribute-status))
+          (if (not (#{:require :pending} tribute-status))
             [message-content-text {:content      last-message-content
                                    :content-type last-message-content-type}]
             [react/text {:style styles/last-message-text} tribute-label]))


### PR DESCRIPTION
## Testing
Tested on Android emulator. validated by design
Go in #test public chat and retrieve a day of history
Should be much faster now and with correct typo on android

## Design
Before:
https://user-images.githubusercontent.com/1181225/58860162-ce4a0d80-86ab-11e9-950c-41195bc559b2.png
After:
https://user-images.githubusercontent.com/1181225/58860168-d013d100-86ab-11e9-9a5d-cde7e8c1791b.png

## Dev
code for testing view:

```clojure
[react/view
[react/text "regular"]
[react/text {:style {:font-weight "500"}} "medium"]
[react/text {:style {:font-weight "600"}} "semi-bold"]
[react/text {:style {:font-weight "700"}} "bold"]
[react/text {:style {:font-style :italic}} "regular italic"]
[react/text {:style {:font-weight "500"
:font-style :italic}} "medium italic"]
[react/text {:style {:font-weight "600"
:font-style :italic}} "semibold italic"]
[react/text {:style {:font-weight "700"
:font-style :italic}} "bold italic"]
[react/nested-text
{:style {:typography :title-bold}}
"title-bold"
[{:style {:font-size 10}}
"this is small still bold"
[{:style {:font-weight "400"}}
"this is small not bold"]
[{:style {:typography :timestamp}} "this is a timestamp"]]]
[react/nested-text
{:style {:typography :title-bold}}
"title-bold"
[{:style {:font-weight "400"}}
"not bold"]
[{:style {:typography :timestamp}} "this is a timestamp"]]
[react/nested-text
{:style {:font-weight "400"}}
"title-bold"
[{:style {:font-weight "700"}}
"not bold"]
[{:style {:typography :timestamp}} "this is a timestamp"]]]
```

status: ready <!-- Can be ready or wip -->

