### PR TITLE
#6517 fix chat preview amount ios

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -87,7 +87,7 @@
   [label-key {:keys [content]}]
   (let [{:keys [amount coin]} (:params content)]
     [react/text {:number-of-lines 1}
-     (i18n/label label-key {:amount (i18n/label-number amount)
+     (i18n/label label-key {:amount amount
                             :asset  (wallet.utils/display-symbol coin)})]))
 
 (def personal-send-request-params


### PR DESCRIPTION
fixes #6517 

### Summary

Fixes bug on ios when number like 10000 shows up as 10 in chat preview. 
`i18n/label-number` is already applied to `:amount` number inside `i18n/label` so there is no need to call it twice.

status: ready <!-- Can be ready or wip -->
