### PR TITLE
temporary fix for realm issues

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,7 +155,7 @@ android {
         versionCode getVersionCode()
         versionName getVersionName()
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86-64"
+            abiFilters "armeabi-v7a", "x86"
         }
     }
     /**


### PR DESCRIPTION
Dropping 64bit platforms as a temporary workaround for Realm.js issues in #8366.

We will have to undo-this using #8326 once Realm.js issue is fixed.

See for context:
* https://github.com/realm/realm-js/issues/2282
* https://github.com/facebook/react-native/issues/25060