### PR TITLE
[fix #8375] "save password" unavailable for non bioauth devices

### DIFF
--- a/src/status_im/biometric_auth/core.cljs
+++ b/src/status_im/biometric_auth/core.cljs
@@ -71,9 +71,9 @@
 (defn get-supported [callback]
   (cond platform/ios? (do-get-supported callback)
         platform/android? (if android-device-blacklisted?
-                            (callback false)
+                            (callback nil)
                             (do-get-supported callback))
-        :else (callback false)))
+        :else (callback nil)))
 
 (defn authenticate
   ([cb]

--- a/src/status_im/utils/keychain/core.cljs
+++ b/src/status_im/utils/keychain/core.cljs
@@ -4,7 +4,6 @@
             [status-im.react-native.js-dependencies :as rn]
             [status-im.utils.platform :as platform]
             [status-im.utils.security :as security]
-            [status-im.biometric-auth.core :as biometric-auth]
             [status-im.native-module.core :as status]))
 
 (def key-bytes 64)
@@ -85,10 +84,6 @@
          (enum-val "ACCESS_CONTROL" "BIOMETRY_ANY_OR_DEVICE_PASSCODE")}))
       (.then callback)))
 
-;; Android and iOS
-(defn- biometric-auth-available? [callback]
-  (biometric-auth/get-supported #(callback (some? %))))
-
 ;; Stores the password for the address to the Keychain
 (defn save-user-password [address password callback]
   (-> (.setInternetCredentials (rn/keychain) address address password keychain-secure-hardware (clj->js keychain-restricted-availability))
@@ -118,13 +113,11 @@
 (defn can-save-user-password? [callback]
   (cond
     platform/ios? (check-conditions callback
-                                    device-encrypted?
-                                    biometric-auth-available?)
+                                    device-encrypted?)
 
     platform/android?  (check-conditions
                         callback
                         secure-hardware-available?
-                        biometric-auth-available?
                         device-not-rooted?)
 
     :else (callback false)))


### PR DESCRIPTION
fixes #8375 

I forgot to remove biometric availability check on `an-save-user-password?` function.

fixed also `:supported-biometric-auth` in `:db` to be always `nil` when bioauth not supported (as per specs)

status: ready to test