### PR TITLE
[perf] Minimize com.taoensso/timbre dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,7 @@
                                       :deps/manifest :deps}
          com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}
          com.taoensso/timbre         {:mvn/version "4.10.0"}
+         com.taoensso/encore         {:mvn/version "2.94.0"}
          hickory                     {:mvn/version "0.7.1"}
          com.cognitect/transit-cljs  {:mvn/version "0.8.248"}
          status-im/pluto             {:mvn/version "iteration-4-9"}

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [status-im/re-frame "0.10.5"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/timbre "4.10.0"]
+                 [com.taoensso/encore "2.94.0"]
                  [hickory "0.7.1"]
                  [com.cognitect/transit-cljs "0.8.248"]
                  [status-im/pluto "iteration-4-9"]


### PR DESCRIPTION
https://github.com/ptaoussanis/timbre/issues/278

saves more than 100KB when compiled with :advanced. It seems that this code is quite heavy so it costs ~450ms of startup time on my slow device (galaxy a500d).

status: ready