### PR TITLE
[perf] prod version of slurp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ conan.cmake
 # modules
 status-modules/translations
 status-modules/cljs
+status-modules/resources

--- a/prepare-modules.js
+++ b/prepare-modules.js
@@ -1,20 +1,25 @@
 var fs = require("fs");
+var path = require('path');
+var dirs = ["status-modules/cljs", "status-modules/resources"];
 
-var modules = [
-    "i18n"
-];
-
-modules.forEach(
-    function (moduleName) {
-        fs.readFile(`status-modules/cljs/${moduleName}-raw.js`, "utf8", function (err, data) {
-            if (err) throw err;
-            fs.writeFile(`status-modules/cljs/${moduleName}.js`,
-                ("module.exports=`" + data.replace(/[\\$'"]/g, "\\$&") + "`;"),
-                function (err) {
-                    if (err) {
-                        return console.log(err);
-                    }
-                });
-        });
+dirs.forEach(dir => {
+    fs.readdir(dir, (err, files) => {
+        if (files) {
+            files.forEach(file => {
+                if (file.endsWith("-raw.js")) {
+                    const filePath = path.resolve(dir, file);
+                    fs.readFile(filePath, "utf8", function (err, data) {
+                        if (err) throw err;
+                        fs.writeFile(filePath.replace("-raw.js", ".js"),
+                            ("module.exports=`" + data.replace(/[\\$'"]/g, "\\$&") + "`;"),
+                            function (err) {
+                                if (err) {
+                                    return console.log(err);
+                                }
+                            });
+                    });
+                }
+            });
+        }
     });
-
+});

--- a/src/status_im/extensions/capacities/map.cljs
+++ b/src/status_im/extensions/capacities/map.cljs
@@ -55,17 +55,18 @@
 (defview map-webview [{:keys [interactive fly style marker on-change]}]
   (letsubs [webview (atom nil)]
     [map-component
-     {:style                                 style
-      :origin-whitelist                      ["*"]
-      :source                                {:html mapview-html :base-url (cond
-                                                                             platform/ios? "./mapview/"
-                                                                             platform/android? "file:///android_asset/"
-                                                                             :else nil)}
-      :java-script-enabled                   true
-      :bounces                               false
-      :over-scroll-mode                      "never"
-      :local-storage-enabled                 true
-      :render-error                          web-view-error
+     {:style                             style
+      :origin-whitelist                  ["*"]
+      :source                            {:html     (mapview-html)
+                                          :base-url (cond
+                                                      platform/ios? "./mapview/"
+                                                      platform/android? "file:///android_asset/"
+                                                      :else nil)}
+      :java-script-enabled               true
+      :bounces                           false
+      :over-scroll-mode                  "never"
+      :local-storage-enabled             true
+      :render-error                      web-view-error
 
       ;; load only local resources, for non-local resources open external browser
       :on-should-start-load-with-request     #(let [url (.-url %)]

--- a/src/status_im/fleet/core.cljs
+++ b/src/status_im/fleet/core.cljs
@@ -31,8 +31,8 @@
 (def default-les-fleets (slurp "resources/config/fleets-les.json"))
 
 (defn fleets [{:keys [custom-fleets]}]
-  (as-> [default-fleets
-         default-les-fleets] $
+  (as-> [(default-fleets)
+         (default-les-fleets)] $
     (mapv #(:fleets (types/json->clj %)) $)
     (conj $ custom-fleets)
     (reduce merge $)))

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -55,7 +55,13 @@
      [list/item-icon {:icon      :main-icons/next
                       :icon-opts {:color :gray}}]]]])
 
-(def default-public-chats (types/json->clj (slurp "resources/default_public_chats.json")))
+(def default-public-chats-json
+  (slurp "resources/default_public_chats.json"))
+
+(def default-public-chats
+  (memoize
+   (fn []
+     (types/json->clj (default-public-chats-json)))))
 
 (views/defview new-public-chat []
   (views/letsubs [topic [:public-group-topic]
@@ -71,7 +77,7 @@
      [react/view styles/chat-name-container
       [react/text {:style styles/section-title}
        (i18n/label :t/selected)]]
-     [list/flat-list {:data                         default-public-chats
+     [list/flat-list {:data                         (default-public-chats)
                       :key-fn                       identity
                       :render-fn                    render-topic
                       :keyboard-should-persist-taps :always

--- a/src/status_im/utils/js_resources.cljs
+++ b/src/status_im/utils/js_resources.cljs
@@ -1,5 +1,5 @@
 (ns status-im.utils.js-resources
-  (:require-macros [status-im.utils.slurp :refer [slurp slurp-bot]])
+  (:require-macros [status-im.utils.slurp :refer [slurp]])
   (:require [status-im.utils.types :refer [json->clj]]
             [clojure.string :as s]))
 
@@ -9,17 +9,24 @@
   (and (string? url) (s/starts-with? url local-protocol)))
 
 (def webview-js (slurp "resources/js/webview.js"))
-(def web3 (str "; if (typeof Web3 == 'undefined') {"
-               (slurp "node_modules/web3/dist/web3.min.js")
-               "}"))
+(def web3-file (slurp "node_modules/web3/dist/web3.min.js"))
+(def web3
+  (memoize
+   (fn []
+     (str "; if (typeof Web3 == 'undefined') {"
+          (web3-file)
+          "}"))))
+
+(def web3-init-file (slurp "resources/js/web3_init.js"))
 (defn web3-init [current-account-address network-id]
   (str "var currentAccountAddress = \"" current-account-address "\";"
        "var networkId = \"" network-id "\";"
-       (slurp "resources/js/web3_init.js")))
+       (web3-init-file)))
 
+(def web3-opt-in-init-file (slurp "resources/js/web3_opt_in.js"))
 (defn web3-opt-in-init [network-id]
   (str "var networkId = \"" network-id "\";"
-       (slurp "resources/js/web3_opt_in.js")))
+       (web3-opt-in-init-file)))
 
 (defn local-storage-data [data]
   (str "var localStorageData = " (or data "{}") ";"))

--- a/src/status_im/utils/slurp.clj
+++ b/src/status_im/utils/slurp.clj
@@ -1,15 +1,31 @@
 (ns status-im.utils.slurp
   (:refer-clojure :exclude [slurp])
-  (:require [clojure.string :as string]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import (java.io File)))
+
+(def prod? (= "prod" (System/getenv "BUILD_ENV")))
+
+(defn copy-file [source-path dest-path]
+  (io/copy (io/file source-path) (io/file dest-path)))
+
+(def resources-dir "status-modules/resources/")
+
+(defn check-resources-dir []
+  (let [resources (File. resources-dir)]
+    (when-not (.exists resources)
+      (.mkdir resources))))
 
 (defmacro slurp [file]
-  (clojure.core/slurp file))
-
-(defmacro slurp-bot [bot-name & files]
-  (->> (concat files ["translations.js" "bot.js"])
-       (map (fn [file-name]
-              (try
-                (clojure.core/slurp
-                 (string/join "/" ["resources/js/bots" (name bot-name) file-name]))
-                (catch Exception _ ""))))
-       (apply str)))
+  (if prod?
+    (let [name      (str/replace file #"[\/\.]" "_")
+          file-name (str resources-dir name)]
+      (check-resources-dir)
+      (copy-file file (str file-name "-raw.js"))
+      (let [res (gensym "res")]
+        `(let [~res (atom nil)]
+           (fn []
+             (or @~res
+                 (reset! ~res (js/require ~(str file-name ".js"))))))))
+    `(fn []
+       ~(clojure.core/slurp file))))


### PR DESCRIPTION
solves #8381
solves #8383

review only the last commit

All resources loaded by slurp are moved to status-modules/resources dir
in release builds and are loaded only by demand instead of being bundled into
index.*.js.

status: ready