### PR TITLE
fix node_modules permissions before git clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ endif
 
 clean: SHELL := /bin/sh
 clean: ##@prepare Remove all output folders
+	@test -d node_modules && chmod -R 744 node_modules; \
+	test -d node_modules.tmp && chmod -R 744 node_modules.tmp; \
 	git clean -dxf -f
 
 clean-nix: SHELL := /bin/sh


### PR DESCRIPTION
This is due to copying `node_modules` from nix store which is read-only.
Should fix Nightly build errors like this:
```
22:59:43  + make clean
22:59:43  git clean -dxf -f
22:59:44  warning: failed to remove node_modules/is-plain-obj/license: Permission denied
22:59:44  warning: failed to remove node_modules/is-plain-obj/index.js: Permission denied
22:59:44  warning: failed to remove node_modules/is-plain-obj/readme.md: Permission denied
22:59:44  warning: failed to remove node_modules/is-plain-obj/package.json: Permission denied
22:59:44  warning: failed to remove node_modules/plist/LICENSE: Permission denied
...
```
https://ci.status.im/job/status-react/job/nightly/1114/