### PR TITLE
[android] ignore the gms version from `react-native-http-bridge`.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -255,7 +255,9 @@ dependencies {
     implementation project(':react-native-background-timer')
     implementation project(':react-native-svg')
     implementation 'com.android.support:multidex:1.0.2'
-    implementation project(':react-native-http-bridge')
+    compile (project(':react-native-http-bridge')) {
+        exclude group: "com.google.android.gms"
+    }
     implementation project(':react-native-splash-screen')
     implementation project(':react-native-image-resizer')
     implementation project(':react-native-dialogs')


### PR DESCRIPTION
`react-native-http-bridge` has an unbound dependency on GMS,
that sometimes brings unnecessary transitive dependencies to our builds.

This commit forces to ignore this depencency.


status: ready <!-- Can be ready or wip -->