### PR TITLE
keep SSL_CERT_FILE and NIX_SSL_CERT_FILE env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ HELP_FUN = \
 HOST_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 # Defines which variables will be kept for Nix pure shell, use semicolon as divider
-export NIX_KEEP ?= BUILD_ENV
+export NIX_KEEP ?= BUILD_ENV,SSL_CERT_FILE,NIX_SSL_CERT_FILE
 export NIX_CONF_DIR = $(PWD)/nix
 
 export REACT_SERVER_PORT ?= 5001 # any value different from default 5000 will work; this has to be specified for both the Node.JS server process and the Qt process

--- a/ci/nix.groovy
+++ b/ci/nix.groovy
@@ -8,7 +8,7 @@ def shell(Map opts = [:], String cmd) {
   def defaults = [
     pure: true,
     args: ['target-os': env.TARGET_OS],
-    keep: ['LOCALE_ARCHIVE_2_27'],
+    keep: ['LOCALE_ARCHIVE_2_27', 'SSL_CERT_FILE', 'NIX_SSL_CERT_FILE'],
   ]
   /* merge defaults with received opts */
   opts = defaults + opts


### PR DESCRIPTION
My proposed fix for the Fastlane SSL errors:
```
SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
```

Summary:

* SSL errors were happening only in Fastlane and couldn't be reproduced with just Ruby
* Turns out Nix sets `SSL_CERT_FILE` and `NIX_SSL_CERT_FILE` to `/no-cert-file.crt`
* This breaks certificate verification and causes `unable to get local issuer certificate` errors
* The behavior happened only on `linux-01` and `linux-03`, rest of hosts being unaffected
* Turns out those two hosts were running newer versoin of [`setup.sh`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/stdenv/generic/setup.sh#L649-L657) script
* New version handles `IN_NIX_SHELL` differently(expects `pure` or `impure` to be a value, not empty)
* In order to avoid this logic we have to keep `SSL_CERT_FILE` and `NIX_SSL_CERT_FILE`

More details: https://github.com/status-im/infra-ci/issues/6