### PR TITLE
Fix bug with outgoing-status

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -74,10 +74,15 @@
                              {}))}))
 
 (defn add-outgoing-status
-  [{:keys [from] :as message} current-public-key]
+  [{:keys [from outgoing-status] :as message} current-public-key]
   (if (and (= from current-public-key)
            (not (system-message? message)))
-    (assoc message :outgoing true)
+    (assoc message
+           :outgoing true
+           ;; We don't override outgoing-status if there, which means
+           ;; that our device has sent the message, while if empty is coming
+           ;; from a different device
+           :outgoing-status (or outgoing-status :sent))
     message))
 
 (defn build-desktop-notification

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -236,3 +236,26 @@
              (get-in fx2 [:db :chats "chat-id" :messages])))
       (is (= {}
              (get-in fx2 [:db :chats "chat-id" :message-groups]))))))
+
+(deftest add-outgoing-status
+  (testing "coming from us"
+    (testing "system-message"
+      (let [message (message/add-outgoing-status {:message-type :system-message
+                                                  :from "us"} "us")]
+        (is (not (:outgoing message)))
+        (is (not (:outgoing-status message)))))
+    (testing "has already a an outgoing status"
+      (testing "it does not override it"
+        (let [message (message/add-outgoing-status {:outgoing-status :sending
+                                                    :from "us"} "us")]
+          (is (:outgoing message))
+          (is (= :sending (:outgoing-status message))))))
+    (testing "does not have an outgoing status"
+      (testing "it sets it to sent"
+        (let [message (message/add-outgoing-status {:from "us"} "us")]
+          (is (:outgoing message))
+          (is (= :sent (:outgoing-status message)))))))
+  (testing "not coming from us"
+    (let [message (message/add-outgoing-status {:from "not-us"} "us")]
+      (is (not (:outgoing message)))
+      (is (not (:outgoing-status message))))))


### PR DESCRIPTION
outgoing-status was not added on received messages, which meant that if
we receceived a message from a different device in a public chat
:outgoing-status would not be saved in the database, resulting in the
message being displayed as not coming from us on logging out/logging in
again.

status: ready