### PR TITLE
Use react-native-screens

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -280,6 +280,7 @@ dependencies {
     implementation project(':react-native-firebase')
     implementation project(':react-native-shake')
     implementation project(':react-native-gesture-handler')
+    implementation project(':react-native-screens')
     implementation project(':RNMail')
     compile ('com.google.android.gms:play-services-base:16.0.1') {
         force = true

--- a/android/app/src/main/java/im/status/ethereum/MainActivity.java
+++ b/android/app/src/main/java/im/status/ethereum/MainActivity.java
@@ -25,6 +25,7 @@ import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
 import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 
+import com.facebook.react.ReactFragmentActivity;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.modules.core.PermissionListener;
 import org.devio.rn.splashscreen.SplashScreen;
@@ -32,7 +33,7 @@ import org.devio.rn.splashscreen.SplashScreen;
 import java.util.Properties;
 import im.status.ethereum.module.StatusThreadPoolExecutor;
 
-public class MainActivity extends ReactActivity
+public class MainActivity extends ReactFragmentActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback{
 
 

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.java
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.java
@@ -39,6 +39,7 @@ import me.alwx.HttpServer.HttpServerReactPackage;
 import com.chirag.RNMail.*;
 import com.clipsub.RNShake.RNShakeEventPackage;
 import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.swmansion.rnscreens.RNScreensPackage;
 
 public class MainApplication extends MultiDexApplication implements ReactApplication {
 
@@ -78,7 +79,8 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
                     new KeychainPackage(),
                     new RNShakeEventPackage(),
                     new FingerprintAuthPackage(),
-                    new RNGestureHandlerPackage());
+                    new RNGestureHandlerPackage(),
+                    new RNScreensPackage());
         }
 
         @Override

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -50,3 +50,5 @@ include ':react-native-shake'
 project(':react-native-shake').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-shake/android')
 include ':react-native-gesture-handler'
 project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
+include ':react-native-screens'
+project(':react-native-screens').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-screens/android')

--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -33,6 +33,7 @@
               "eth-phishing-detect"
               "react-native-config"
               "react-native-svg"
+              "react-native-screens"
               "react-native-keychain"
               "rn-snoopy"
               "rn-snoopy/stream/bars"

--- a/externs.js
+++ b/externs.js
@@ -561,5 +561,6 @@ var TopLevel = {
     "_android": function () {},
     "isSupported" : function () {},
     "authenticate" : function () {},
-    "createAppContainer" : function () {}
+    "createAppContainer" : function () {},
+    "useScreens" : function () {}
 }

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		D99C50E5E18942A39C8DDF61 /* Inter-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = B321D25F4493470980039457 /* Inter-BoldItalic.otf */; };
 		DC3316E4BB514C6F80B60D84 /* Inter-ExtraLightItalic-BETA.otf in Resources */ = {isa = PBXBuildFile; fileRef = EBCA9155761E4EBCB2EAFE9A /* Inter-ExtraLightItalic-BETA.otf */; };
 		E0AD9E8F495A4907B65104BF /* libRCTImageResizer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BEE3436791D42248F853999 /* libRCTImageResizer.a */; };
+		E3CDB8AF22BBE460009BFE27 /* libRNScreens.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E3CDB8A822BBD9D3009BFE27 /* libRNScreens.a */; };
 		E5A39B2530D54142B8C03B94 /* Inter-ExtraBoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1BF670316EE6470584BB715B /* Inter-ExtraBoldItalic.otf */; };
 		F0C362ACB0B24A2DB9AD29AC /* Inter-ExtraLight-BETA.otf in Resources */ = {isa = PBXBuildFile; fileRef = 17787D310A644038B9357960 /* Inter-ExtraLight-BETA.otf */; };
 		FD4F213C3873473CB703B1D2 /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 674B3D9595A047AB8D518F4E /* libRNFS.a */; };
@@ -512,6 +513,13 @@
 			remoteGlobalIDString = 5D72D2E81C16249000E22EC1;
 			remoteInfo = RCTImageResizer;
 		};
+		E3CDB8A722BBD9D3009BFE27 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E3CDB86E22BBD9D2009BFE27 /* RNScreens.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNScreens;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -635,6 +643,7 @@
 		CE4E31B21D8695250033ED64 /* Statusgo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Statusgo.framework; path = "../modules/react-native-status/ios/RCTStatus/Statusgo.framework"; sourceTree = "<group>"; };
 		D489EE8D5F52DA10AC715727 /* Pods-StatusImTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StatusImTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-StatusImTests/Pods-StatusImTests.release.xcconfig"; sourceTree = "<group>"; };
 		DF1CD4C3D1254774ACCAE4E8 /* libBVLinearGradient.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libBVLinearGradient.a; sourceTree = "<group>"; };
+		E3CDB86E22BBD9D2009BFE27 /* RNScreens.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNScreens.xcodeproj; path = "../node_modules/react-native-screens/ios/RNScreens.xcodeproj"; sourceTree = "<group>"; };
 		EBCA9155761E4EBCB2EAFE9A /* Inter-ExtraLightItalic-BETA.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-ExtraLightItalic-BETA.otf"; path = "../resources/fonts/Inter-ExtraLightItalic-BETA.otf"; sourceTree = "<group>"; };
 		F090E261B9854867A728CE4F /* RealmReact.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RealmReact.xcodeproj; path = "../node_modules/realm/react-native/ios/RealmReact.xcodeproj"; sourceTree = "<group>"; };
 		F9238D6B1E5F055900C047B9 /* SF-UI-Text-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-UI-Text-Semibold.otf"; sourceTree = "<group>"; };
@@ -659,6 +668,7 @@
 				ABC194E5221009A800EB06E6 /* libRNLanguages.a in Frameworks */,
 				475D202F20B7450D00879A77 /* libRNFirebase.a in Frameworks */,
 				4C9FBC56227C85640024181F /* libRNMail.a in Frameworks */,
+				E3CDB8AF22BBE460009BFE27 /* libRNScreens.a in Frameworks */,
 				C93242561FE1C68C00FE7099 /* libRCTAnimation.a in Frameworks */,
 				4C16DE0C1F89508700AA10DB /* JavaScriptCore.framework in Frameworks */,
 				B2DEA0D01E49E33300FA28D6 /* libRCTHttpServer.a in Frameworks */,
@@ -966,6 +976,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				E3CDB86E22BBD9D2009BFE27 /* RNScreens.xcodeproj */,
 				4C24EFF322B12D0D009A5636 /* RNGestureHandler.xcodeproj */,
 				4C5F698522815E4E00D26222 /* RNShakeEvent.xcodeproj */,
 				4C9FBC19227C85250024181F /* RNMail.xcodeproj */,
@@ -1175,6 +1186,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		E3CDB86F22BBD9D2009BFE27 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E3CDB8A822BBD9D3009BFE27 /* libRNScreens.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1369,6 +1388,10 @@
 				{
 					ProductGroup = 4C9FBC1A227C85250024181F /* Products */;
 					ProjectRef = 4C9FBC19227C85250024181F /* RNMail.xcodeproj */;
+				},
+				{
+					ProductGroup = E3CDB86F22BBD9D2009BFE27 /* Products */;
+					ProjectRef = E3CDB86E22BBD9D2009BFE27 /* RNScreens.xcodeproj */;
 				},
 				{
 					ProductGroup = 475D1EEE20B73EE000879A77 /* Products */;
@@ -1825,6 +1848,13 @@
 			fileType = archive.ar;
 			path = libRCTImageResizer.a;
 			remoteRef = CE4E319D1D8693090033ED64 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E3CDB8A822BBD9D3009BFE27 /* libRNScreens.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNScreens.a;
+			remoteRef = E3CDB8A722BBD9D3009BFE27 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -54,6 +54,7 @@
     "react-native-qrcode": "git+https://github.com/status-im/react-native-qrcode.git#v0.2.8",
     "react-native-randombytes": "3.5.0",
     "react-native-safe-area-view": "0.9.0",
+    "react-native-screens": "^1.0.0-alpha.22",
     "react-native-securerandom": "git+https://github.com/status-im/react-native-securerandom.git#0.1.1-2",
     "react-native-shake": "^3.3.1",
     "react-native-splash-screen": "3.1.1",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5653,7 +5653,7 @@ react-native-safe-area-view@^0.14.1:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-"react-native-screens@^1.0.0 || ^1.0.0-alpha":
+"react-native-screens@^1.0.0 || ^1.0.0-alpha", react-native-screens@^1.0.0-alpha.22:
   version "1.0.0-alpha.22"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.22.tgz#7a120377b52aa9bbb94d0b8541a014026be9289b"
   integrity sha512-kSyAt0AeVU6N7ZonfV6dP6iZF8B7Bce+tk3eujXhzBGsLg0VSLnU7uE9VqJF0xdQrHR91ZjGgVMieo/8df9KTA==

--- a/react-native/src/mobile/status_im/react_native/js_dependencies.cljs
+++ b/react-native/src/mobile/status_im/react_native/js_dependencies.cljs
@@ -35,6 +35,7 @@
 (defn background-timer []   (.-default (background-timer-class)))
 (def react-navigation       (js/require "react-navigation"))
 (def react-native-shake     (js-require/js-require "react-native-shake"))
+(def react-native-screens   (js-require/js-require "react-native-screens"))
 (def mail-class             (js-require/js-require  "react-native-mail"))
 (defn react-native-mail []  (.-default (mail-class)))
 (def desktop-linking        #js {:addEventListener (fn [])})

--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -43,6 +43,7 @@
                         (when-not (zero? @keyboard-height)
                           (dispatch [:set :keyboard-height 0]))))
         (.hide react/splash-screen)
+        (.useScreens (rn-dependencies/react-native-screens))
         (.addEventListener (react/app-state) "change" app-state-change-handler)
         (.addEventListener rn-dependencies/react-native-languages "change" on-languages-change)
         (.addEventListener (rn-dependencies/react-native-shake)

--- a/src/status_im/ios/core.cljs
+++ b/src/status_im/ios/core.cljs
@@ -39,6 +39,7 @@
                       #(when-not (= 0 @keyboard-height)
                          (dispatch [:set :keyboard-height 0])))
         (.hide react/splash-screen)
+        (.useScreens (rn-dependencies/react-native-screens))
         (.addEventListener (react/app-state) "change" app-state-change-handler)
         (.addEventListener rn-dependencies/react-native-languages "change" on-languages-change)
         (.addEventListener (rn-dependencies/react-native-shake)


### PR DESCRIPTION
According to https://reactnavigation.org/docs/en/react-native-screens.html, it makes sense to try using react-native-screens after migration to react-navigation v3 (thank you @rasom!). It is optional in react-navigation v3 but will be on by default in v4.

I don't know how to test cpu/mem usage changes yet, but at least the View hierarchy becomes just a tad shallower (can be seen through React Developer Tools)