### PR TITLE
fix network switching in dev mode

### DIFF
--- a/src/status_im/network/ui/views.cljs
+++ b/src/status_im/network/ui/views.cljs
@@ -9,7 +9,8 @@
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]
             [status-im.ui.components.styles :as components.styles]
-            [status-im.network.ui.styles :as styles]))
+            [status-im.network.ui.styles :as styles]
+            status-im.network.events))
 
 (defn- network-icon [connected? size]
   [react/view (styles/network-icon connected? size)


### PR DESCRIPTION
`status-im.network.events` wasn't required in dev mode, that's why events were not registered

status: ready