### PR TITLE
Changed placeholder to show "Enter password"

### DIFF
--- a/src/status_im/ui/screens/accounts/login/views.cljs
+++ b/src/status_im/ui/screens/accounts/login/views.cljs
@@ -67,7 +67,7 @@
                     :important-for-accessibility :no-hide-descendants}
         [text-input/text-input-with-label
          {:label             (i18n/label :t/password)
-          :placeholder       (i18n/label :t/password)
+          :placeholder       (i18n/label :t/enter-password)
           :ref               #(reset! password-text-input %)
           :auto-focus        (= view-id :login)
           :on-submit-editing (when sign-in-enabled?


### PR DESCRIPTION
### Summary

Originally both the password label and the placeholder were displaying "Password" on login. I corrected the placeholder to show "Enter password" instead.

#### Platforms

- Android
- iOS
- macOS
- Linux
- Windows
