### PR TITLE
fix margin between plus button and bottom tab bar #8166

### DIFF
--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -188,7 +188,10 @@
 (def action-button-container
   {:position    :absolute
    :align-items :center
-   :bottom      (+ tabs.styles/tabs-diff 6)
+   :bottom      (+ tabs.styles/tabs-diff (cond
+                                           platform/ios? 16
+                                           platform/android? 0
+                                           platform/desktop? 6))
    :width       40
    :height      40})
 


### PR DESCRIPTION
fixes #8166

### Summary

Set margin between plus button and bottom tab bar to 16.

status: ready 