### PR TITLE
upgrade react-native: 0.59.9 > 0.59.10

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -54,8 +54,8 @@ PODS:
   - nanopb/decode (0.3.8)
   - nanopb/encode (0.3.8)
   - Protobuf (3.6.1)
-  - React (0.59.9):
-    - React/Core (= 0.59.9)
+  - React (0.59.10):
+    - React/Core (= 0.59.10)
   - react-native-background-timer (2.1.0-alpha.6):
     - React
   - react-native-camera (1.1.5):
@@ -68,8 +68,8 @@ PODS:
     - React
   - react-native-webview (5.2.1):
     - React
-  - React/Core (0.59.9):
-    - yoga (= 0.59.9.React)
+  - React/Core (0.59.10):
+    - yoga (= 0.59.10.React)
   - RNKeychain (3.0.0-rc.3):
     - React
   - SQLCipher (3.4.2):
@@ -80,7 +80,7 @@ PODS:
   - SSZipArchive (2.1.4)
   - TouchID (4.4.1):
     - React
-  - yoga (0.59.9.React)
+  - yoga (0.59.10.React)
 
 DEPENDENCIES:
   - Firebase/Core

--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -33,7 +33,7 @@
     "querystring-es3": "0.2.1",
     "react": "16.8.3",
     "react-dom": "16.4.2",
-    "react-native": "git+https://github.com/status-im/react-native.git#v0.59.9-status",
+    "react-native": "git+https://github.com/status-im/react-native.git#v0.59.10",
     "react-native-background-timer": "2.1.0-alpha.6",
     "react-native-camera": "git+https://github.com/status-im/react-native-camera.git#v1.1.5-1-status",
     "react-native-config": "git+https://github.com/status-im/react-native-config.git#0.11.2-1",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5779,9 +5779,9 @@ react-native-webview@^5.2.1:
     escape-string-regexp "^1.0.5"
     fbjs "^0.8.17"
 
-"react-native@git+https://github.com/status-im/react-native.git#v0.59.9-status":
-  version "0.59.9"
-  resolved "git+https://github.com/status-im/react-native.git#4a70315cca3671a8a06a60ce5d710e9f085c6b43"
+"react-native@git+https://github.com/status-im/react-native.git#v0.59.10":
+  version "0.59.10"
+  resolved "git+https://github.com/status-im/react-native.git#b89933b2045e3f1e1e22b0935f92318f1c36d5bb"
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^1.2.1"


### PR DESCRIPTION
This is due to issues with 64 bit builds, for more details: https://github.com/facebook/react-native/issues/24261
This might make #8326 work and make it possible to have proper 64 bit builds required by Play Store.