### PR TITLE
[#7015] Fix amount validation in chat input

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -107,8 +107,9 @@
   "command is complete, proceed with command processing"
   [cofx input-text command custom-params]
   (fx/merge cofx
-            (commands.sending/validate-and-send input-text command custom-params)
-            (set-chat-input-text nil)
+            (if-let [results (commands.sending/validate-and-send input-text command custom-params)]
+              results
+              (set-chat-input-text nil))
             (process-cooldown)))
 
 (defn command-not-complete-fx

--- a/src/status_im/ui/screens/chat/input/send_button.cljs
+++ b/src/status_im/ui/screens/chat/input/send_button.cljs
@@ -15,7 +15,7 @@
 
 (defview send-button-view [{:keys [input-text]} on-send-press]
   (letsubs [{:keys [command-completion]} [:chats/selected-chat-command]
-            disconnected? [:disconnected?]
+            disconnected? [:disconnected?] validation-result [:chats/validation-messages]
             {:keys [processing]} [:multiaccounts/login]]
     (when (and (sendable? input-text disconnected? processing)
                (or (not command-completion)
@@ -23,6 +23,7 @@
       [react/touchable-highlight
        {:on-press on-send-press}
        [vector-icons/icon :main-icons/arrow-up
-        {:container-style     style/send-message-container
-         :accessibility-label :send-message-button
-         :color               :white}]])))
+        (merge {:accessibility-label :send-message-button}
+               (if validation-result
+                 {:container-style style/send-message-container-error :color :red}
+                 {:container-style style/send-message-container       :color :white}))]])))

--- a/src/status_im/ui/screens/chat/input/validation_messages.cljs
+++ b/src/status_im/ui/screens/chat/input/validation_messages.cljs
@@ -2,6 +2,7 @@
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [re-frame.core :as re-frame]
             [status-im.ui.components.react :as react]
+            [status-im.ui.components.tooltip.views :as tooltip]
             [status-im.ui.screens.chat.styles.input.validation-message :as style]
             [status-im.i18n :as i18n]))
 
@@ -25,5 +26,7 @@
                       {:title       (i18n/label :t/error)
                        :description validation-result}
                       validation-result)]
-        [react/view (style/root (+ input-height chat-input-margin))
-         [messages-list [validation-message message]]]))))
+        [tooltip/tooltip (:description message)
+         {:box-shadow       "0px 4px 12px rgba(0, 34, 51, 0.08), 0px 2px 4px rgba(0, 34, 51, 0.16)"
+          :font-size        12
+          :bottom-value     -13}]))))

--- a/src/status_im/ui/screens/chat/styles/input/send_button.cljs
+++ b/src/status_im/ui/screens/chat/styles/input/send_button.cljs
@@ -10,3 +10,6 @@
    :margin           10
    :margin-left      8
    :margin-bottom    11})
+
+(def send-message-container-error
+  (merge send-message-container {:background-color colors/red-transparent-10}))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)


fixes #7015 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
A code is deleting (Cleaning) the validation errors, this occurs too quickly, so users don't be able to see any validation error and the text in the input chat is cleared after It. So, I added a validation and changed the style of the tooltip and send button as the [figma](https://www.figma.com/file/aS1ct66VQ6V0cio7vSqS8UoG/Chat?node-id=144%3A234) file describe.

##### Functional

- 1-1 chats


### Steps to test
<!-- (Specify exact steps to test if there are such) -->
As the issue #7015 describe.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
