### PR TITLE
nix: Use build.sh for release-android make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Xcode
 #
+result/
 build/
 *.pbxuser
 !default.pbxuser

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -26,6 +26,7 @@ pipeline {
     LC_ALL   = "en_US.UTF-8"
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'android'
+    BUILD_ENV = 'prod'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
     FASTLANE_DISABLE_COLORS = 1
     REALM_DISABLE_ANALYTICS = 1
@@ -83,7 +84,9 @@ pipeline {
         stage('Build') { stages {
           stage('JSBundle') {
             steps {
-              script { cmn.nix.build(attr: 'targets.mobile.jsbundle') }
+              script {
+                cmn.nix.shell('make jsbundle-android', pure: false)
+              }
             }
           }
           stage('Bundle') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -12,7 +12,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 25, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -23,73 +23,81 @@ pipeline {
   }
 
   stages {
+    stage('Prep') {
+      steps { script {
+        nix = load('ci/nix.groovy')
+      } }
+    }
     stage('Setup') {
-      steps {
+      steps { script {
         sh 'scripts/setup'
-        sh '''
-          . ~/.nix-profile/etc/profile.d/nix.sh && \
-          nix-env -i openssh
-        '''
-      }
+        nix.shell('nix-env -i openssh', pure: false)
+      } }
     }
     stage('Build status-go') {
       steps { script {
         ['android', 'desktop', 'ios'].each { os ->
-          sh """
-            . ~/.nix-profile/etc/profile.d/nix.sh && \
-            nix-build --argstr target-os all -A targets.status-go.${os}.buildInputs
-          """
+          nix.build(
+            attr: "targets.status-go.${os}.buildInputs",
+            args: ['target-os': 'all'],
+            link: false
+          )
         }
       } }
     }
-    stage('Build jsbundle-android') {
-      steps {
-        // Run a Nix build to build/fetch everything that is necessary to produce a jsbundle for TARGET_OS=android (e.g. maven and node repos)
-        sh '''
-          args="--argstr target-os android --show-trace -A targets.mobile.jsbundle"
-
-          . ~/.nix-profile/etc/profile.d/nix.sh && \
-          nix-build --pure --no-out-link $args
-
-          prodBuildDrv=$(nix-instantiate --quiet $args) && \
-          prodBuildSrcPath=$(nix-store -q --binding src $prodBuildDrv) && \
-          prodBuildOutPath=$(nix-store -q --outputs $prodBuildDrv) && \
-          nix-store --delete $prodBuildDrv $prodBuildSrcPath $prodBuildOutPath
-        '''
-      }
+    stage('Build jsbundle') {
+      steps { script {
+        /* build/fetch things required to produce a js-bundle for android
+         * (e.g. maven and node repos) */
+        nix.build(
+          attr: 'targets.mobile.jsbundle',
+          args: ['target-os': 'android'],
+          pure: false,
+          link: false
+        )
+      } }
+    }
+    stage('Build android deps') {
+      steps { script {
+        /* build/fetch things required to build jsbundle and android */
+        nix.build(
+          attr: 'targets.mobile.android.buildInputs',
+          args: ['target-os': 'android'],
+          pure: false,
+          link: false
+        )
+      } }
     }
     stage('Build nix shell deps') {
-      steps {
-        // Run a Nix build to build/fetch everything that is necessary to instantiate shell.nix for TARGET_OS=all
-        sh '''
-          . ~/.nix-profile/etc/profile.d/nix.sh && \
-          nix-shell --argstr target-os all --pure --show-trace shell.nix
-        '''
-      }
+      steps { script {
+        /* build/fetch things required to instantiate shell.nix for TARGET_OS=all */
+        nix.shell("nix-build ${args.join(' ')}", pure: false)
+        nix.build(
+          attr: 'shell',
+          args: ['target-os': 'all'],
+          link: false
+        )
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { script {
         sshagent(credentials: ['nix-cache-ssh']) {
-          sh """
-            . ~/.nix-profile/etc/profile.d/nix.sh && \
-            find /nix/store/ -mindepth 1 -maxdepth 1 \
-              -not -name '.links' -and -not -name '*.lock' \
-              -and -not -name '*-status-react-jsbundle-source' \
-              -and -not -name '*-status-react-release-android-source' \
-              -and -not -name '*-jsbundle-*' \
-              -and -not -name '*-release-android' | \
-              xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
-          """
+          nix.shell("""
+              find /nix/store/ -mindepth 1 -maxdepth 1 \
+                -not -name '.links' -and -not -name '*.lock' \
+                -and -not -name '*-status-react-*' \
+                | xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
+            """,
+            pure: false
+          )
         }
-      }
+      } }
     }
   }
   post {
-    always {
-      sh '''
-        . ~/.nix-profile/etc/profile.d/nix.sh && \
-        nix-store --optimize
-      '''
-   }
+    always { script {
+      nix.shell('nix-store --optimize', pure: false)
+      nix.shell('nix/clean.sh', pure: false)
+    } }
   }
 }

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -54,6 +54,7 @@ def bundle() {
       )
     }
   }
+  /* because nix-build was run in `android` dir that's where `result` is */
   def outApk = "android/result/app.apk"
   def pkg = utils.pkgFilename(btype, 'apk')
   /* rename for upload */

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -256,7 +256,7 @@ platform :ios do
 
   desc "`fastlane ios saucelabs` - upload .app to sauce labs"
   desc "also notifies in a GitHub comments"
-  desc "expects to have an .apk prepared: `android/result/app.apk`"
+  desc "expects to have an .apk prepared: `result/app.apk`"
   desc "expects to have a saucelabs access key as SAUCE_ACCESS_KEY env variable"
   desc "expects to have a saucelabs username token as SAUCE_USERNAME env variable"
   desc "expects to have a saucelabs destination name as SAUCE_LABS_NAME env variable"
@@ -276,7 +276,7 @@ end
 
 platform :android do
   # Optional env variables
-  APK_PATH = ENV["APK_PATH"] || "android/result/app.apk"
+  APK_PATH = ENV["APK_PATH"] || "result/app.apk"
 
   desc "Deploy a new internal build to Google Play"
   desc "expects GOOGLE_PLAY_JSON_KEY environment variable"
@@ -311,7 +311,7 @@ platform :android do
   end
 
   desc "`fastlane android upload_diawi` - upload .apk to diawi"
-  desc "expects to have an .apk prepared: `android/result/app.apk`"
+  desc "expects to have an .apk prepared: `result/app.apk`"
   desc "expects to have a diawi token as DIAWI_TOKEN env variable"
   desc "expects to have a github token as GITHUB_TOKEN env variable"
   desc "will fails if file isn't there"
@@ -322,7 +322,7 @@ platform :android do
   end
 
   desc "`fastlane android saucelabs` - upload .apk to sauce labs"
-  desc "expects to have an .apk prepared: `android/result/app.apk`"
+  desc "expects to have an .apk prepared: `result/app.apk`"
   desc "expects to have a saucelabs access key as SAUCE_ACCESS_KEY env variable"
   desc "expects to have a saucelabs username token as SAUCE_USERNAME env variable"
   desc "expects to have a saucelabs destination name as SAUCE_LABS_NAME env variable"

--- a/nix/build.sh
+++ b/nix/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+# cleanup for artifacts created during builds
+function cleanup() {
+  # clear trapped signals
+  trap - EXIT ERR INT QUIT
+  # do the actual cleanup
+  ./nix/clean.sh ${nixOpts[@]}
+}
+
+trap cleanup EXIT ERR INT QUIT
+
+# build output will end up under /nix, we have to extract it
+function extractResults() {
+  local nixResultPath="$1"
+  echo "Saving build result: ${nixResultPath}"
+  mkdir -p result
+  cp -vfr ${nixResultPath}/* result/
+  chmod u+w -R result/
+}
+
+targetAttr="${1}"
+shift
+
+if [[ -z "${targetAttr}" ]]; then
+  echo "First argument is madatory and has to specify the Nix attribute!"
+  exit 1
+fi
+
+# Some defaults flags, --pure could be optional in the future
+nixOpts=(
+  "--pure"
+  "--fallback"
+  "--no-out-link"
+  "--show-trace"
+  "--argstr target-os ${TARGET_OS}"
+  "--attr ${targetAttr}"
+  "${@}"
+  "default.nix"
+)
+
+# Run the actual build
+echo "Running: nix-build ${nixOpts[@]}"
+nixResultPath=$(nix-build ${nixOpts[@]})
+
+extractResults "${nixResultPath}"
+
+echo "SUCCESS"

--- a/nix/clean.sh
+++ b/nix/clean.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+function getSources() {
+    nix-store --query --binding src "${1}"
+}
+
+function getOutputs() {
+    nix-store --query --outputs "${1}"
+}
+
+function getDrvFiles() {
+    nix-store --query --deriver "${1}"
+}
+
+function getReferrers() {
+    nix-store --query --referrers "${1}"
+}
+
+# list of store entries to delete
+declare -a toDelete
+
+echo "Cleanup of /nix/store after build..."
+
+# regular expression that should match all status-react build artifacts
+searchRegex='.*-status-react-(shell|source|build).*'
+
+# search for matching entries in the store
+drvPaths=$(
+  find /nix/store -maxdepth 1 -type d -regextype egrep -regex "${searchRegex}"
+)
+
+# for each entry find the source and derivation
+for path in ${drvPaths}; do
+    toDelete+=("${path}")
+    if [[ "${path}" =~ .*.chroot ]]; then
+        echo " ! Chroot:    ${path}"
+        continue
+    fi
+    echo " ? Checking:   ${path}"
+    drv=$(getDrvFiles "${path}")
+    # if drv is unknown-deriver then path is a source
+    if [[ "${drv}" == "unknown-deriver" ]]; then
+        drv=$(getReferrers "${path}")
+        src="${path}"
+    elif [[ -f "${drv}" ]]; then
+        src=$(getSources "${drv}")
+    fi
+    echo " - Derivation: ${drv}"
+    echo " - Source:     ${src}"
+
+    toDelete+=("${drv}" "${src}")
+done
+
+# remove dupicates
+cleanToDelete=$(echo "${toDelete[@]}" | sort | uniq)
+
+echo "Deleting..."
+nix-store --ignore-liveness --delete ${cleanToDelete[@]}

--- a/nix/mobile/android/maven-and-npm-deps/default.nix
+++ b/nix/mobile/android/maven-and-npm-deps/default.nix
@@ -36,7 +36,7 @@ let
           let path = ./../../../..; # Import the root /android and /mobile_files folders clean of any build artifacts
           in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
             inherit path;
-            name = "status-react-gradle-install-source";
+            name = "status-react-source-gradle-install";
             filter =
               # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
               mkFilter {

--- a/nix/mobile/android/targets/release-android.nix
+++ b/nix/mobile/android/targets/release-android.nix
@@ -1,5 +1,7 @@
 { stdenv, stdenvNoCC, lib, target-os, callPackage,
-  mkFilter, bash, file, gnumake, watchman, gradle, androidEnvShellHook, mavenAndNpmDeps, nodejs, openjdk, jsbundle, status-go, zlib }:
+  mkFilter, bash, file, gnumake, watchman, gradle,
+  androidEnvShellHook, mavenAndNpmDeps,
+  nodejs, openjdk, jsbundle, status-go, zlib }:
 
 { build-number ? "9999",
   build-type ? "nightly", # Build type (e.g. nightly, release, e2e). Default is to use .env.nightly file
@@ -10,7 +12,8 @@
 }:
 
 let
-  name = "release-${target-os}";
+  baseName = "release-${target-os}";
+  name = "status-react-build-${baseName}";
   gradleHome = "$NIX_BUILD_TOP/.gradle";
   localMavenRepo = "${mavenAndNpmDeps.deriv}/.m2/repository";
   sourceProjectDir = "${mavenAndNpmDeps.deriv}/project";
@@ -27,7 +30,7 @@ in stdenv.mkDerivation {
     let path = ./../../../..;
     in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
       inherit path;
-      name = "status-react-${name}-source";
+      name = "status-react-source-${baseName}";
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {

--- a/nix/mobile/ios/default.nix
+++ b/nix/mobile/ios/default.nix
@@ -16,7 +16,7 @@ let
     let path = ./../../..;
     in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
       inherit path;
-      name = "status-react-npm-deps-source";
+      name = "status-react-source-npm-deps";
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {

--- a/nix/targets/jsbundle.nix
+++ b/nix/targets/jsbundle.nix
@@ -11,12 +11,12 @@ let
   leinProjectDepsLocalRepo = localMavenRepoBuilder "lein-project-deps" lein-project-deps;
 
 in stdenv.mkDerivation {
-  name = "jsbundle-${target-os}";
+  name = "status-react-build-jsbundle-${target-os}";
   src =
     let path = ./../..;
     in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
       inherit path;
-      name = "status-react-jsbundle-source";
+      name = "status-react-source-jsbundle";
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -47,7 +47,7 @@ nixOpts="--option extra-sandbox-paths ${STORE_FILE} \
          --argstr build-type ${BUILD_TYPE} \
          --argstr keystore-file ${STORE_FILE} \
          --show-trace \
-         $exportedEnvFlag \
+         ${exportedEnvFlag} \
          -A targets.mobile.${TARGET_OS}.release"
 
 # Run the build

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@ let
   stdenv = pkgs.stdenvNoCC;
 
 in mkShell {
+  name = "status-react-shell";
   buildInputs = with pkgs; [
     # utilities
     bash


### PR DESCRIPTION
I(@jakubgs) overtook this PR from Pedro and it kinda grew, ah well.
Changes:

* Adds `nix/build.sh` as a generalized way to call `nix-build` for specific targets from `Makefile`
* Adds `nix/clean.sh` as a generic way to clean build artifacts from `/nix/store`
  - All of those things should have in the name `status-react-(shell|build|source)`
* Renames `nix-clean` to `nix-purge` for clarity and adds `nix-clean` to call `nix/clean.sh`
* Rename various build artifacts from Nix to match the `status-react-(shell|build|source)-*` schema
* Refactors `ci/Jenkinsfile.nix-cache` to use `nix.shell()` and `nix.build()` methods from `ci/nix.groovy`
* Adds `link` argument to `nix.build()` to allow adding `--no-out-link` flag to builds
* Sets `TMPDIR` in `Makefile` to `/tmp` to avoid running out of space in `/run/user/${UID}`
* Adds `_NIX_PURE` env variable to control if `nix/shell.sh` creates a pure shell
* Sets name for Nix shells we create to `status-react-shell` to make cleanup easier

If you want me to extract some of these changes to a separate PR I can do that.