### PR TITLE
Fix Hide 'add account' option in wallet

### DIFF
--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -163,6 +163,5 @@
      [total-value]
      [react/scroll-view {:horizontal true}
       [react/view {:flex-direction :row :padding-top 11 :padding-bottom 12}
-       [account-card "Status account"]
-       [add-card]]]]
+       [account-card "Status account"]]]]
     [assets-and-collections]]])


### PR DESCRIPTION
Fixes #8568 

Add account panel is hidden/removed, just as specified in **Expected behavior**

tested in iOS-simulator

status: ready