### PR TITLE
allow for TARGET_OS to be not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ shell: ##@prepare Enter into a pre-configured shell
 ifndef IN_NIX_SHELL
 	@ENTER_NIX_SHELL
 else
-	@echo "Nix shell is already active"
+	@echo "${YELLOW}Nix shell is already active$(RESET)"
 endif
 
 add-gcroots: SHELL := /bin/sh

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
   nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { inherit config; },
   pkgs ? nixpkgs-bootstrap.pkgs,
   stdenv ? pkgs.stdenv,
-  target-os ? "all" }:
+  target-os ? "none" }:
 
 let deriv = pkgs.callPackage ./nix/derivation.nix { inherit pkgs target-os; inherit (nixpkgs-bootstrap) config; };
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -14,3 +14,11 @@ In order to access an interactive Nix shell a user should run `make shell`.
 
 The Nix shell is started in this repo via the [`nix/shell.sh`](/nix/shell.sh) script, which is a wrapper around the `nix-shell` command and is intended for use with our main [`Makefile`](/Makefile). This allows for an implicit use of `nix-shell` as the default shell in the `Makefile`.
 
+By default the shell starts without any specific target platform, if you want to change that you should export the `TARGET_OS` env variable with the right value:
+
+```bash
+TARGET_OS=android make shell
+```
+This way your shell and all other nix commands should run in a setup that is tailored towards Android development.
+
+For valid values you can check the [`nix/platform.nix`](/nix/platform.nix) file.

--- a/nix/platform.nix
+++ b/nix/platform.nix
@@ -1,6 +1,8 @@
 { target-os, stdenv }:
 
-assert stdenv.lib.assertOneOf "target-os" target-os [ "linux" "android" "windows" "macos" "darwin" "ios" "all" ];
+# We allow for "none" value because `make shell` can be called with `TARGET_OS` not set.
+# We don't want to assume `all`, because that will rebuild status-go for all platforms.
+assert stdenv.lib.assertOneOf "target-os" target-os [ "linux" "android" "windows" "macos" "darwin" "ios" "all" "none" ];
 
 let
   inherit (stdenv) isDarwin isLinux;

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -11,6 +11,7 @@
 #
 
 GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
 NC='\033[0m'
 
 export TERM=xterm # fix for colors
@@ -27,38 +28,51 @@ if ! command -v "nix" >/dev/null 2>&1; then
   fi
 fi
 
-if command -v "nix" >/dev/null 2>&1; then
-  platform=${TARGET_OS:=all}
-  if [ "$platform" != 'all' ] && [ "$platform" != 'android' ] && [ "$platform" != 'ios' ]; then
-    # This is a dirty workaround to the fact that 'yarn install' is an impure operation, so we need to call it from an impure shell. Hopefull we'll be able to fix this later on with something like yarn2nix
-    nix-shell --show-trace --argstr target-os ${TARGET_OS} --run "scripts/prepare-for-desktop-platform.sh" || exit
-  fi
+if !command -v "nix" >/dev/null 2>&1; then
+  echo "Nix not available, sourcing profile failed!"
+  exit 1
+fi
 
-  entry_point='shell.nix'
-  attrset_option=''
-  if [ -n "${_NIX_ATTR}" ]; then
-    entry_point='default.nix'
-    attrset_option="-A ${_NIX_ATTR}"
-  fi
+shellArgs=(
+  "--show-trace"
+)
 
-  attrStr="${_NIX_ATTR}"
-  [ -n "$attrStr" ] && attrStr="$attrStr "
-  if [[ $@ == "ENTER_NIX_SHELL" ]]; then
-    echo -e "${GREEN}Configuring ${attrStr}Nix shell for target '${TARGET_OS}'...${NC}"
-    exec nix-shell --show-trace --argstr target-os ${TARGET_OS} ${attrset_option} ${entry_point}
-  else
-    is_pure=''
-    if [[ "${TARGET_OS}" != 'all' ]] && [[ "${TARGET_OS}" != 'ios' ]] && [[ "${TARGET_OS}" != 'windows' ]]; then
-      is_pure='--pure'
-      pure_desc='pure '
-    fi
-    # This variable allows specifying which env vars to keep for Nix pure shell
-    # The separator is a semicolon
-    keep_opts=''
-    if [[ -n "${_NIX_KEEP}" ]]; then
-      keep_opts="--keep ${_NIX_KEEP//;/ --keep }"
-    fi
-    echo -e "${GREEN}Configuring ${pure_desc}${attrStr}Nix shell for target '${TARGET_OS}'...${NC}"
-    exec nix-shell ${is_pure} ${keep_opts} --show-trace --argstr target-os ${TARGET_OS} ${attrset_option} --run "$@" ${entry_point}
+if [[ -n "${TARGET_OS}" ]]; then
+    shellArgs+=("--argstr target-os ${TARGET_OS}")
+else
+    echo -e "${YELLOW}Env is missing TARGET_OS, assuming no target platform.${NC}"
+    echo -e "See nix/README.md for more details."
+fi
+
+if [[ "$TARGET_OS" =~ (linux|windows) ]]; then
+  # This is a dirty workaround because 'yarn install' is an impure operation,
+  # so we need to call it from an impure shell.
+  # Hopefull we'll be able to fix this later on with something like yarn2nix
+  nix-shell ${shellArgs[@]} --run "scripts/prepare-for-desktop-platform.sh" || exit
+fi
+
+# if _NIX_ATTR is specified we shouldn't use shell.nix, the path will be different
+entryPoint="shell.nix"
+if [ -n "${_NIX_ATTR}" ]; then
+  shellArgs+=("--attr ${_NIX_ATTR}")
+  entryPoint="default.nix"
+fi
+
+# this happens if `make shell` is run already in a Nix shell
+if [[ $@ == "ENTER_NIX_SHELL" ]]; then
+  echo -e "${GREEN}Configuring ${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS}'...${NC}"
+  exec nix-shell ${shellArgs[@]} ${entryPoint}
+else
+  # Not all builds are ready to be run in a pure environment
+  if [[ "${TARGET_OS}" =~ (android|macos|linux) ]]; then
+    shellArgs+=("--pure")
+    pureDesc='pure '
   fi
+  # This variable allows specifying which env vars to keep for Nix pure shell
+  # The separator is a semicolon
+  if [[ -n "${_NIX_KEEP}" ]]; then
+    nixShelArgs+=("--keep ${_NIX_KEEP//;/ --keep }")
+  fi
+  echo -e "${GREEN}Configuring ${pureDesc}${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS}'...${NC}"
+  exec nix-shell ${shellArgs[@]} --run "$@" ${entryPoint}
 fi

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { },
   pkgs ? nixpkgs-bootstrap.pkgs,
-  target-os ? "all" }:
+  target-os ? "none" }:
 
 let
   project = import ./default.nix { inherit target-os pkgs nixpkgs-bootstrap; inherit (nixpkgs-bootstrap) config; };


### PR DESCRIPTION
This solves the issue that @cammellos found when running `make` in a specific combination:
```bash
 ./scripts/update-status-go.sh v0.30.0-beta.2
# changes the `status-go` version
make startdev-android-avd
# causes the building of `status-go` as expected
make shell
# rebuilds status-go again, but for linux, not android, due to empty `TARGET_OS`
```
In order to avoid this we will be starting the Nix shell using `make shell` without any `TARGET_OS` set by default. If the