### PR TITLE
[DO NOT MERGE!] [Fix #8569] Allow to edit custom name again

### DIFF
--- a/src/status_im/accounts/core.cljs
+++ b/src/status_im/accounts/core.cljs
@@ -13,12 +13,8 @@
             [status-im.utils.utils :as utils]
             [status-im.utils.handlers :as handlers]))
 
-(defn displayed-name [account]
-  (let [name (or (:preferred-name account) (:name account))]
-    (if (ens/is-valid-eth-name? name)
-      (let [username (stateofus/username name)]
-        (str "@" (or username name)))
-      (or name (gfycat/generate-gfy (:public-key account))))))
+(defn displayed-name [{:keys [name public-key]}]
+  (or name (gfycat/generate-gfy public-key)))
 
 (re-frame/reg-fx
  ::chaos-mode-changed

--- a/src/status_im/accounts/update/core.cljs
+++ b/src/status_im/accounts/update/core.cljs
@@ -11,8 +11,8 @@
 (fx/defn account-update-message [{:keys [db] :as cofx}]
   (let [account (:account/account db)
         fcm-token (get-in db [:notifications :fcm-token])
-        {:keys [name preferred-name photo-path address]} account]
-    (message.contact/ContactUpdate. (or preferred-name name) photo-path address fcm-token (device-info/all cofx))))
+        {:keys [name photo-path address]} account]
+    (message.contact/ContactUpdate. name photo-path address fcm-token (device-info/all cofx))))
 
 (fx/defn send-account-update [cofx]
   (protocol/send

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -124,9 +124,7 @@
   [input-text current-chat-id {:keys [db] :as cofx}]
   (when-not (string/blank? input-text)
     (let [{:keys [message-id old-message-id]}
-          (get-in db [:chats current-chat-id :metadata :responding-to-message])
-          show-name?     (get-in db [:account/account :show-name?])
-          preferred-name (when show-name? (get-in db [:account/account :preferred-name]))]
+          (get-in db [:chats current-chat-id :metadata :responding-to-message])]
       (fx/merge cofx
                 {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message] nil)}
                 (chat.message/send-message {:chat-id      current-chat-id
@@ -135,9 +133,7 @@
                                                                    :text    input-text}
                                                             message-id
                                                             (assoc :response-to old-message-id
-                                                                   :response-to-v2 message-id)
-                                                            preferred-name
-                                                            (assoc :name preferred-name))})
+                                                                   :response-to-v2 message-id))})
                 (commands.input/set-command-reference nil)
                 (set-chat-input-text nil)
                 (process-cooldown)))))

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -34,9 +34,9 @@
 
 (defn- own-info
   [db]
-  (let [{:keys [name preferred-name photo-path address]} (:account/account db)
+  (let [{:keys [name photo-path address]} (:account/account db)
         fcm-token (get-in db [:notifications :fcm-token])]
-    {:name          (or preferred-name name)
+    {:name          name
      :profile-image photo-path
      :address       address
      :device-info   (device-info/all {:db db})

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -216,9 +216,9 @@
           (if outgoing-status
             [text-status outgoing-status]))))))
 
-(defview message-author-name [from name]
+(defview message-author-name [from message-username name]
   (letsubs [username [:contacts/contact-name-by-identity from]]
-    (chat.utils/format-author from style/message-author-name name)))
+    (chat.utils/format-author from (or username message-username) style/message-author-name)))
 
 (defn message-body
   [{:keys [last-in-group?
@@ -227,7 +227,8 @@
            from
            outgoing
            modal?
-           content] :as message} child]
+           username
+           name] :as message} child]
   [react/view (style/group-message-wrapper message)
    [react/view (style/message-body message)
     (when display-photo?
@@ -239,7 +240,7 @@
     [react/view (style/group-message-view outgoing display-photo?)
      (when display-username?
        [react/touchable-opacity {:on-press #(re-frame/dispatch [:chat.ui/show-profile from])}
-        [message-author-name from (:name content)]])
+        [message-author-name from username name]])
      [react/view {:style (style/timestamp-content-wrapper outgoing)}
       child]]]
    [react/view (style/delivery-status outgoing)

--- a/src/status_im/ui/screens/chat/utils.cljs
+++ b/src/status_im/ui/screens/chat/utils.cljs
@@ -10,23 +10,22 @@
             [status-im.ui.components.colors :as colors]
             [status-im.utils.http :as http]))
 
-(defn format-author [from style name]
-  (cond
-    (ens/is-valid-eth-name? name)
-    [react/text {:style {:color colors/blue :font-size 13 :font-weight "500"}}
-     (str "@" (or (stateofus/username name) name))]
-    name
-    [react/text {:style {:color colors/blue :font-size 13 :font-weight "500"}}
-     name]
-    :else
-    [react/text {:style {:color colors/gray :font-size 12 :font-weight "400"}}
-     (gfycat/generate-gfy from)]))
+(defn format-author [from username style]
+  [react/nested-text {:style           (style false)
+                      :number-of-lines 1
+                      :ellipsize-mode  :tail}
+   (when username
+     [{:style (style true)
+       :number-of-lines 1
+       :ellipsize-mode  :tail}
+      (str username " • ")])
+   (gfycat/generate-gfy from)])
 
 (defn format-reply-author [from username current-public-key style]
   (or (and (= from current-public-key)
            [react/text {:style (style true)}
             (i18n/label :t/You)])
-      (format-author from style nil)))
+      (format-author from username style)))
 
 (def ^:private styling->prop
   {:bold      {:style {:font-weight "700"}}

--- a/src/status_im/ui/screens/profile/components/views.cljs
+++ b/src/status_im/ui/screens/profile/components/views.cljs
@@ -58,7 +58,9 @@
     [react/view styles/modal-menu
      [chat-icon.screen/my-profile-icon {:account contact
                                         :edit?   allow-icon-change?}]]]
-   [names contact]])
+   [react/view styles/profile-header-name-container
+    [profile-name-input name on-change-text-event
+     (when group-chat {:accessibility-label :chat-name-input})]]])
 
 (defn profile-header
   [{:keys [contact edited-contact editing? allow-icon-change? options on-change-text-event]}]

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -17,14 +17,14 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 
     @marks.testrail_id(5305)
     @marks.critical
-    @marks.skip  # re-enable after 8234 for new onboarding merged
     def test_text_message_1_1_chat(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
         username_1 = 'user_%s' % get_current_time()
-        device_1_home, device_2_home = device_1.create_user(username=username_1), device_2.create_user()
+        device_1_home, device_2_home = device_1.create_user(), device_2.create_user()
         profile_1 = device_1_home.profile_button.click()
-        default_username_1 = profile_1.default_username_text.text
+        # default_username_1 = profile_1.default_username_text.text
+        profile_1.edit_profile_username(username_1)
         device_1_home = profile_1.get_back_to_home_view()
         device_2_public_key = device_2_home.get_public_key()
         device_2_home.home_button.click()
@@ -35,7 +35,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         device_1_chat.chat_message_input.send_keys(message)
         device_1_chat.send_message_button.click()
 
-        device_2_chat = device_2_home.get_chat_with_user(default_username_1).click()
+        device_2_chat = device_2_home.get_chat_with_user(username_1).click()
         device_2_chat.chat_element_by_text(message).wait_for_visibility_of_element()
 
     @marks.testrail_id(5310)

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -1,7 +1,7 @@
 import time
 from selenium.common.exceptions import TimeoutException
 from support.utilities import generate_timestamp
-from tests import marks
+from tests import marks, get_current_time
 from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
 from views.sign_in_view import SignInView
 from datetime import datetime, timedelta

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -17,6 +17,8 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
         home_1, home_2 = device_1.create_user(), device_2.create_user()
         profile_1 = home_1.profile_button.click()
+        username_1 = 'user_%s' % get_current_time()
+        profile_1.edit_profile_username(username_1)
         default_username_1 = profile_1.default_username_text.text
         profile_1.home_button.click()
         public_key_2 = home_2.get_public_key()
@@ -32,14 +34,11 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
         chat_1.chat_message_input.send_keys(message)
         chat_1.send_message_button.click()
 
-        chat_2.verify_message_is_under_today_text(message, self.errors)
+        # chat_2.verify_message_is_under_today_text(message, self.errors)
         # TODO: should be replaced with ens name after https://github.com/status-im/status-react/pull/8487
-        # full_username = '%s • %s' % (username_1, default_username_1)
-        if chat_2.chat_element_by_text(message).username.text != default_username_1:
-            self.errors.append("Default username '%s' is not shown next to the received message" % default_username_1)
-
-        # if chat_1.element_by_text_part(username_1).is_element_displayed():
-        #     self.errors.append("Username '%s' is shown for the sender" % username_1)
+        full_username = '%s • %s' % (username_1, default_username_1)
+        if chat_2.chat_element_by_text(message).username.text != full_username:
+            self.errors.append("Default username '%s' is not shown next to the received message" % full_username)
 
         self.verify_no_errors()
 


### PR DESCRIPTION
fixes #8569

### Summary

Do not display ENS name anymore (neither in profile nor chat).
Allow to edit custom name: it should be shown in both chat and profiles.

### Steps to test

- Open Status
- Go to profile, edit name
- See it in profile, displayed in chat messages

status: ready