### PR TITLE
[Fix #8605] Do nothing when clicking on sticker

### DIFF
--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -257,8 +257,6 @@
                       (if (and platform/desktop? (= "right" (.-button (.-nativeEvent arg))))
                         (open-chat-context-menu message)
                         (do
-                          (when (= content-type constants/content-type-sticker)
-                            (re-frame/dispatch [:stickers/open-sticker-pack (:pack content)]))
                           (re-frame/dispatch [:chat.ui/set-chat-ui-props {:messages-focused? true
                                                                           :show-stickers?    false}])
                           (when-not platform/desktop?


### PR DESCRIPTION

fixes #8605

### Summary

Do not do anything when clicking on a sticker

status: ready