### PR TITLE
nix: fix target OS for add-nix-gcroots.sh

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -122,6 +122,6 @@ pipeline {
   post {
     success { script { load('ci/github.groovy').notifyPR(true) } }
     failure { script { load('ci/github.groovy').notifyPR(false) } }
-    always { sh 'make _fix-perms' }
+    always { sh 'make _fix-node-perms' }
   }
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -105,6 +105,6 @@ pipeline {
   post {
     success { script { load('ci/github.groovy').notifyPR(true) } }
     failure { script { load('ci/github.groovy').notifyPR(false) } }
-    always { sh 'make _fix-perms' }
+    always { sh 'make _fix-node-perms' }
   }
 }

--- a/scripts/add-nix-gcroots.sh
+++ b/scripts/add-nix-gcroots.sh
@@ -9,6 +9,6 @@ GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 rm -rf .nix-gcroots
 mkdir .nix-gcroots
 
-drv=$(nix-instantiate ${GIT_ROOT}/shell.nix)
+drv=$(nix-instantiate --argstr target-os all --add-root ${GIT_ROOT}/shell.nix)
 refs=$(nix-store --query --references $drv)
 nix-store -r $refs --indirect --add-root $GIT_ROOT/.nix-gcroots/shell.dep


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes `add-gcroots.sh` so that it passes a target-os value of `all` (since it recently started defaulting to `none`).

status: ready <!-- Can be ready or wip -->