### PR TITLE
rename prod-build to jsbundle so it means something

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -81,9 +81,9 @@ pipeline {
           }
         } }
         stage('Build') { stages {
-          stage('Clojure') {
+          stage('JSBundle') {
             steps {
-              script { cmn.nix.build(attr: "targets.mobile.prod-build") }
+              script { cmn.nix.build(attr: 'targets.mobile.jsbundle') }
             }
           }
           stage('Bundle') {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -64,9 +64,9 @@ pipeline {
           }
         } }
         stage('Build') { stages {
-          stage('Clojure') {
+          stage('JSBundle') {
             steps {
-              script { cmn.nix.shell('make prod-build-ios') }
+              script { cmn.nix.shell('make jsbundle-ios') }
             }
           }
           stage('Bundle') {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -68,9 +68,9 @@ pipeline {
           }
         } }
         stage('Build') { stages {
-          stage('Clojure') {
+          stage('JSBundle') {
             steps {
-              script { desktop.buildClojureScript() }
+              script { desktop.buildJSBundle() }
             }
           }
           stage('Compile') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -64,9 +64,9 @@ pipeline {
           }
         } }
         stage('Build') { stages {
-          stage('Clojure') {
+          stage('JSBundle') {
             steps {
-              script { desktop.buildClojureScript() }
+              script { desktop.buildJSBundle() }
             }
           }
           stage('Compile') {

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -42,11 +42,11 @@ pipeline {
         }
       } }
     }
-    stage('Build prod-build-android') {
+    stage('Build jsbundle-android') {
       steps {
-        // Run a Nix build to build/fetch everything that is necessary to produce a prod-build for TARGET_OS=android (e.g. maven and node repos)
+        // Run a Nix build to build/fetch everything that is necessary to produce a jsbundle for TARGET_OS=android (e.g. maven and node repos)
         sh '''
-          args="--argstr target-os android --show-trace -A targets.mobile.prod-build"
+          args="--argstr target-os android --show-trace -A targets.mobile.jsbundle"
 
           . ~/.nix-profile/etc/profile.d/nix.sh && \
           nix-build --pure --no-out-link $args
@@ -74,9 +74,9 @@ pipeline {
             . ~/.nix-profile/etc/profile.d/nix.sh && \
             find /nix/store/ -mindepth 1 -maxdepth 1 \
               -not -name '.links' -and -not -name '*.lock' \
-              -and -not -name '*-status-react-prod-build-source' \
+              -and -not -name '*-status-react-jsbundle-source' \
               -and -not -name '*-status-react-release-android-source' \
-              -and -not -name '*-prod-build-*' \
+              -and -not -name '*-jsbundle-*' \
               -and -not -name '*-release-android' | \
               xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
           """

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -71,9 +71,9 @@ pipeline {
           }
         } }
         stage('Build') { stages {
-          stage('Clojure') {
+          stage('JSBundle') {
             steps {
-              script { desktop.buildClojureScript() }
+              script { desktop.buildJSBundle() }
             }
           }
           stage('Compile') {

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -3,11 +3,11 @@ utils = load 'ci/utils.groovy'
 
 packageFolder = './StatusImPackage'
 
-def buildClojureScript() {
+def buildJSBundle() {
   nix.shell(
     '''
-      make prod-build-desktop && \
-      ./scripts/build-desktop.sh buildClojureScript
+      make jsbundle-desktop && \
+      ./scripts/build-desktop.sh buildJSBundle
     ''',
     keep: ['VERBOSE_LEVEL']
   )

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -18,13 +18,11 @@ let
   go = pkgs.callPackage ./patched-go { inherit baseGo; };
   buildGoPackage = pkgs.buildGoPackage.override { inherit go; };
   desktop = pkgs.callPackage ./desktop { inherit target-os stdenv status-go pkgs go nodejs; inherit (pkgs) darwin; };
-  mobile = pkgs.callPackage ./mobile { inherit target-os config stdenv pkgs mkShell nodejs yarn status-go maven localMavenRepoBuilder mkFilter prod-build-fn; inherit (pkgs.xcodeenv) composeXcodeWrapper; };
+  mobile = pkgs.callPackage ./mobile { inherit target-os config stdenv pkgs mkShell nodejs yarn status-go maven localMavenRepoBuilder mkFilter; inherit (pkgs.xcodeenv) composeXcodeWrapper; };
   status-go = pkgs.callPackage ./status-go { inherit target-os go buildGoPackage; inherit (mobile.ios) xcodeWrapper; androidPkgs = mobile.android.androidComposition; };
   # mkFilter is a function that allows filtering a directory structure (used for filtering source files being captured in a closure)
   mkFilter = import ./tools/mkFilter.nix { inherit (stdenv) lib; };
   localMavenRepoBuilder = pkgs.callPackage ./tools/maven/maven-repo-builder.nix { inherit (pkgs) stdenv; };
-  # Import a function that can build a prod-build target with specified node dependencies Nix expression 
-  prod-build-fn = pkgs.callPackage ./targets/prod-build.nix { inherit stdenv pkgs target-os nodejs localMavenRepoBuilder mkFilter; };
   nodejs = pkgs.nodejs-10_x;
   yarn = pkgs.yarn.override { inherit nodejs; };
   selectedSources =

--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, stdenvNoCC, target-os, callPackage, mkShell,
   mkFilter, androidenv, fetchurl, openjdk, nodejs, bash, maven, zlib,
-  status-go, localMavenRepoBuilder, projectNodePackage, prod-build-fn }:
+  status-go, localMavenRepoBuilder, projectNodePackage, jsbundle }:
 
 let
   platform = callPackage ../../platform.nix { inherit target-os; };
@@ -12,8 +12,7 @@ let
   mavenAndNpmDeps = callPackage ./maven-and-npm-deps { inherit stdenv stdenvNoCC gradle bash nodejs zlib localMavenRepoBuilder mkFilter projectNodePackage status-go; androidEnvShellHook = androidEnv.shellHook; };
 
   # TARGETS
-  prod-build = (prod-build-fn { inherit projectNodePackage; });
-  release = callPackage ./targets/release-android.nix { inherit target-os gradle mavenAndNpmDeps mkFilter nodejs prod-build status-go zlib; androidEnvShellHook = androidEnv.shellHook; };
+  release = callPackage ./targets/release-android.nix { inherit target-os gradle mavenAndNpmDeps mkFilter nodejs jsbundle status-go zlib; androidEnvShellHook = androidEnv.shellHook; };
   generate-maven-and-npm-deps-shell = callPackage ./maven-and-npm-deps/maven/shell.nix { inherit gradle maven projectNodePackage status-go; androidEnvShellHook = androidEnv.shellHook; };
   adb-shell = mkShell {
     buildInputs = [ androidEnv.licensedAndroidEnv ];

--- a/nix/mobile/android/targets/release-android.nix
+++ b/nix/mobile/android/targets/release-android.nix
@@ -1,5 +1,5 @@
 { stdenv, stdenvNoCC, lib, target-os, callPackage,
-  mkFilter, bash, file, gnumake, watchman, gradle, androidEnvShellHook, mavenAndNpmDeps, nodejs, openjdk, prod-build, status-go, zlib }:
+  mkFilter, bash, file, gnumake, watchman, gradle, androidEnvShellHook, mavenAndNpmDeps, nodejs, openjdk, jsbundle, status-go, zlib }:
 
 { build-number ? "9999",
   build-type ? "nightly", # Build type (e.g. nightly, release, e2e). Default is to use .env.nightly file
@@ -54,7 +54,7 @@ in stdenv.mkDerivation {
     cp -f $sourceRoot/${envFileName} $sourceRoot/.env
 
     # Copy index.*.js input file
-    cp -a --no-preserve=ownership ${prod-build}/index*.js $sourceRoot/
+    cp -a --no-preserve=ownership ${jsbundle}/index*.js $sourceRoot/
 
     # Copy android/ directory
     cp -a --no-preserve=ownership ${sourceProjectDir}/android/ $sourceRoot/

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -1,5 +1,5 @@
 { config, stdenv, pkgs, callPackage, mkShell, fetchurl, fetchFromGitHub, target-os,
-  mkFilter, localMavenRepoBuilder, maven, status-go, composeXcodeWrapper, nodejs, yarn, prod-build-fn }:
+  mkFilter, localMavenRepoBuilder, maven, status-go, composeXcodeWrapper, nodejs, yarn }:
 
 let
   inherit (stdenv.lib) catAttrs concatStrings optional unique;
@@ -9,7 +9,7 @@ let
     version = "10.2.1";
   };
   xcodeWrapper = composeXcodeWrapper xcodewrapperArgs;
-  androidPlatform = callPackage ./android { inherit config target-os mkShell mkFilter nodejs maven localMavenRepoBuilder projectNodePackage prod-build-fn; status-go = status-go.android; };
+  androidPlatform = callPackage ./android { inherit config target-os mkShell mkFilter nodejs maven localMavenRepoBuilder projectNodePackage jsbundle; status-go = status-go.android; };
   iosPlatform = callPackage ./ios { inherit config mkFilter mkShell xcodeWrapper projectNodePackage; status-go = status-go.ios; };
   fastlane = callPackage ./fastlane { inherit stdenv target-os mkShell; };
   selectedSources = [
@@ -23,7 +23,7 @@ let
   projectNodePackage = callPackage ./node-package.nix { inherit pkgs nodejs yarn; };
 
   # TARGETS
-  prod-build = prod-build-fn { inherit projectNodePackage; };
+  jsbundle = pkgs.callPackage ../targets/jsbundle.nix { inherit stdenv pkgs target-os nodejs localMavenRepoBuilder mkFilter projectNodePackage; };
 
 in {
   buildInputs = unique (catAttrs "buildInputs" selectedSources);
@@ -34,5 +34,5 @@ in {
   ios = iosPlatform;
 
   # TARGETS
-  inherit prod-build fastlane;
+  inherit jsbundle fastlane;
 }

--- a/nix/targets/jsbundle.nix
+++ b/nix/targets/jsbundle.nix
@@ -3,23 +3,20 @@
 #
 
 { stdenv, stdenvNoCC, lib, target-os, callPackage, pkgs,
-  mkFilter, clojure, leiningen, maven, nodejs, localMavenRepoBuilder }:
-
-# The Nix expression takes a second argument to specify the node dependencies
-{ projectNodePackage }:
+  mkFilter, clojure, leiningen, maven, nodejs, localMavenRepoBuilder, projectNodePackage }:
 
 let
-  lein-command = if target-os == "all" then "lein prod-build" else "lein prod-build-${target-os}";
+  lein-command = if target-os == "all" then "lein jsbundle" else "lein jsbundle-${target-os}";
   lein-project-deps = import ../lein/lein-project-deps.nix { };
   leinProjectDepsLocalRepo = localMavenRepoBuilder "lein-project-deps" lein-project-deps;
 
 in stdenv.mkDerivation {
-  name = "prod-build-${target-os}";
+  name = "jsbundle-${target-os}";
   src =
     let path = ./../..;
     in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
       inherit path;
-      name = "status-react-prod-build-source";
+      name = "status-react-jsbundle-source";
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {

--- a/project.clj
+++ b/project.clj
@@ -30,18 +30,18 @@
              :pre-commit   ["lein cljfmt check src/status_im/core.cljs $(git diff --diff-filter=d --cached --name-only src test/cljs)"]}
   :cljfmt {:indents {letsubs [[:inner 0]]}}
   :clean-targets ["target/" "index.ios.js" "index.android.js" "status-modules/cljs"]
-  :aliases {"prod-build"         ^{:doc "Recompile code with prod profile."}
+  :aliases {"jsbundle"         ^{:doc "Recompile code with prod profile."}
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "ios"]
              ["with-profile" "prod" "cljsbuild" "once" "android"]
              ["with-profile" "prod" "cljsbuild" "once" "desktop"]]
-            "prod-build-android" ^{:doc "Recompile code for Android with prod profile."}
+            "jsbundle-android" ^{:doc "Recompile code for Android with prod profile."}
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "android"]]
-            "prod-build-ios"     ^{:doc "Recompile code for iOS with prod profile."}
+            "jsbundle-ios"     ^{:doc "Recompile code for iOS with prod profile."}
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "ios"]]
-            "prod-build-desktop" ^{:doc "Recompile code for desktop with prod profile."}
+            "jsbundle-desktop" ^{:doc "Recompile code for desktop with prod profile."}
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "desktop"]]
             "figwheel-repl"      ["with-profile" "+figwheel" "run" "-m" "clojure.main" "env/dev/run.clj"]

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -128,7 +128,7 @@ function joinStrings() {
   echo ${var[@]}
 }
 
-function buildClojureScript() {
+function buildJSBundle() {
   # create directory for all work related to bundling
   rm -rf $WORKFOLDER
   mkdir -p $WORKFOLDER
@@ -490,7 +490,7 @@ function bundle() {
 init
 
 if [ -z "$@" ]; then
-  buildClojureScript
+  buildJSBundle
   compile
   bundle
 else

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -22,7 +22,7 @@ function cleanup() {
       local releaseSrcPath=$(nix-store -q --binding src $releaseDrv)
       local releaseOutPath=$(nix-store -q --outputs $releaseDrv)
       local releaseRefs=( $(nix-store -q --references $releaseDrv) )
-      local prodBuildDrv=$(printf -- '%s\n' "${releaseRefs[@]}" | grep -e "prod-build-android.drv")
+      local prodBuildDrv=$(printf -- '%s\n' "${releaseRefs[@]}" | grep -e "jsbundle-android.drv")
       local prodBuildSrcPath=$(nix-store -q --binding src $prodBuildDrv)
       local prodBuildOutPath=$(nix-store -q --outputs $prodBuildDrv)
       nix-store --delete $prodBuildDrv $prodBuildSrcPath $prodBuildOutPath $releaseDrv $releaseSrcPath $releaseOutPath 2> /dev/null


### PR DESCRIPTION
>There are only two hard things in Computer Science: cache invalidation and naming things.
> &mdash; <cite>Phil Karlton</cite>

I've been meaning to do this for a while. `prod-build` is far too generic, it means almost nothing. A `Makefile` or a Nix target name should indicate what is actually going to be built. If I do `make prod-build` I have no idea what that means, but if it's `make jsbundle` I have some inkling as to what it does.

It also simplifies `nix/targets/jsbundle.nix`(previously `prod-build.nix`) so it doesn't return a lambda that returns a derivation and just returns a derivation directly.

This is also a prep PR to slim down changes in #8574.