### PR TITLE
Clear password input value when navigating away from login screen

### DIFF
--- a/src/status_im/ui/screens/routing/core.cljs
+++ b/src/status_im/ui/screens/routing/core.cljs
@@ -38,7 +38,10 @@
       (when-not modal?
         (status-bar/set-status-bar current-view-id)))
     :on-will-blur
-    (fn [] (reset! screen-focused? false))}])
+    (fn []
+      (reset! screen-focused? false)
+      (doseq [text-input @react/text-input-refs]
+        (.clear text-input)))}])
 
 (defn wrap
   "Wraps screen with main view and adds navigation-events component"


### PR DESCRIPTION
Fixes #8600

For some reason TextInput does not properly re-draw itself when navigating away and back again. Trying to erase a symbol or type a new one starts from scratch, as if there were no symbols input or visible before. Thus the visual representation of input's value does not match the actual value stored.

A workaround: use react-navigation's global `onWillBlur` event.