### PR TITLE
[fix #8638] issues with wallet transaction list

### DIFF
--- a/src/status_im/ethereum/transactions/core.cljs
+++ b/src/status_im/ethereum/transactions/core.cljs
@@ -124,10 +124,15 @@
         transfer-by-id   (get-in db [:wallet :transaction id])
         unique-id (when-not (or transfer-by-id
                                 (= transfer transfer-by-hash))
-                    (if transfer-by-hash id hash))]
+                    (if (and transfer-by-hash
+                             (not (= :pending
+                                     (:type transfer-by-hash))))
+                      id
+                      hash))]
     (when unique-id
       (fx/merge cofx
-                {:db (assoc-in db [:wallet :transactions unique-id] transfer)}
+                {:db (assoc-in db [:wallet :transactions unique-id]
+                               (assoc transfer :hash unique-id))}
                 (check-transaction transfer)))))
 
 (fx/defn new-transfers


### PR DESCRIPTION
fix #8638 

does not include the `2.` because it isn't a bug but `improvement` as all transfers are shown to the user now, next step is to improve UX but at least it properly shows all the transfers that occurs within a transaction to the user. ERC20 is shown when the token name is unknown to Status.

### Summary

pending transaction was using hash so mined transaction was using it's id
to have a unique id, the fix adds a rule when the existing transaction by hash
is in :pending state, the mined transaction overwrites it

### Steps to test

- send a transaction
- check history, transaction should be in pending state
- after transaction has been added to a block, transaction turns into sent transaction
- while transaction is pending, if looking at transaction details, confirmations start incrementing as soon as the transaction has been mined

status: ready <!-- Can be ready or wip -->