### PR TITLE
use nix shell for nix-update-* targets, fix nix-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,19 +60,19 @@ nix-purge: SHELL := /bin/sh
 nix-purge: ##@nix Completely remove the complete Nix setup
 	sudo rm -rf /nix ~/.nix-profile ~/.nix-defexpr ~/.nix-channels ~/.cache/nix ~/.status .nix-gcroots
 
-nix-add-gcroots: SHELL := /bin/sh
+nix-add-gcroots: export TARGET_OS := none
 nix-add-gcroots: ##@nix Add Nix GC roots to avoid status-react expressions being garbage collected
 	scripts/add-nix-gcroots.sh
 
-nix-update-npm: SHELL := /bin/sh
+nix-update-npm: export TARGET_OS := none
 nix-update-npm: ##@nix Update node2nix expressions based on current package.json
 	nix/desktop/realm-node/generate-nix.sh
 
-nix-update-gradle: SHELL := /bin/sh
+nix-update-gradle: export TARGET_OS := android
 nix-update-gradle: ##@nix Update maven nix expressions based on current gradle setup
 	nix/mobile/android/maven-and-npm-deps/maven/generate-nix.sh
 
-nix-update-lein: SHELL := /bin/sh
+nix-update-lein: export TARGET_OS := none
 nix-update-lein: ##@nix Update maven nix expressions based on current lein setup
 	nix/tools/lein/generate-nix.sh nix/lein
 

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -45,7 +45,7 @@ pipeline {
         }
       } }
     }
-    stage('Build jsbundle') {
+    stage('Build android jsbundle') {
       steps { script {
         /* build/fetch things required to produce a js-bundle for android
          * (e.g. maven and node repos) */
@@ -71,7 +71,6 @@ pipeline {
     stage('Build nix shell deps') {
       steps { script {
         /* build/fetch things required to instantiate shell.nix for TARGET_OS=all */
-        nix.shell("nix-build ${args.join(' ')}", pure: false)
         nix.build(
           attr: 'shell',
           args: ['target-os': 'all'],
@@ -83,9 +82,8 @@ pipeline {
       steps { script {
         sshagent(credentials: ['nix-cache-ssh']) {
           nix.shell("""
-              find /nix/store/ -mindepth 1 -maxdepth 1 \
-                -not -name '.links' -and -not -name '*.lock' \
-                -and -not -name '*-status-react-*' \
+              find /nix/store/ -mindepth 1 -maxdepth 1 -type d \
+                -not -name '*.links' -and -not -name '*-status-react-*' \
                 | xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
             """,
             pure: false

--- a/nix/README.md
+++ b/nix/README.md
@@ -17,7 +17,7 @@ The Nix shell is started in this repo via the [`nix/shell.sh`](/nix/shell.sh) sc
 By default the shell starts without any specific target platform, if you want to change that you should export the `TARGET_OS` env variable with the right value:
 
 ```bash
-TARGET_OS=android make shell
+make shell TARGET_OS=android
 ```
 This way your shell and all other nix commands should run in a setup that is tailored towards Android development.
 

--- a/nix/desktop/realm-node/generate-nix.sh
+++ b/nix/desktop/realm-node/generate-nix.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -z "${IN_NIX_SHELL}" ]]; then
+    echo "Remember to call 'make shell'!"
+    exit 1
+fi
+
 #
 # Run this file to regenerate the Nix files in ./output.
 # Prerequisites: Node, npm, and node2nix (installed with npm i -g https://github.com/svanderburg/node2nix)
@@ -37,6 +42,11 @@ EOF
 
 node_required_version=$($toolversion node)
 node_major_version=$(echo $node_required_version | cut -d. -f1,1)
+
+if ! which node2nix > /dev/null; then
+    echo "Installing node2nix..."
+    nix-env -f '<nixpkgs>' -iA nodePackages.node2nix
+fi
 
 node2nix --nodejs-${node_major_version} --bypass-cache \
          --input             $input \

--- a/nix/mobile/android/maven-and-npm-deps/default.nix
+++ b/nix/mobile/android/maven-and-npm-deps/default.nix
@@ -31,7 +31,7 @@ let
       reactNativeDepsDir = "$NIX_BUILD_TOP/deps"; # Use local writable deps, otherwise (probably due to some interaction between Nix sandboxing and Java) gradle will fail copying directly from the nix store
     in 
       stdenv.mkDerivation {
-        name = "gradle-install-android-archives-and-patched-npm-modules";
+        name = "android-gradle-and-npm-modules";
         src =
           let path = ./../../../..; # Import the root /android and /mobile_files folders clean of any build artifacts
           in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control

--- a/nix/mobile/android/maven-and-npm-deps/maven/generate-nix.sh
+++ b/nix/mobile/android/maven-and-npm-deps/maven/generate-nix.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -z "${IN_NIX_SHELL}" ]]; then
+    echo "Remember to call 'make shell'!"
+    exit 1
+fi
+
 #
 # This script takes care of generating/updating the maven-sources.nix file
 # representing the offline Maven repo containing the dependencies
@@ -7,8 +12,6 @@
 #
 
 set -Eeu
-
-. ~/.nix-profile/etc/profile.d/nix.sh
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 current_dir=$(cd "${BASH_SOURCE%/*}" && pwd)

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -41,8 +41,7 @@ shellArgs=(
 if [[ -n "${TARGET_OS}" ]]; then
     shellArgs+=("--argstr target-os ${TARGET_OS}")
 else
-    echo -e "${YELLOW}Env is missing TARGET_OS, assuming no target platform.${NC}"
-    echo -e "See nix/README.md for more details."
+    echo -e "${YELLOW}Env is missing TARGET_OS, assuming no target platform.${NC} See nix/README.md for more details."
 fi
 
 if [[ "$TARGET_OS" =~ (linux|windows|darwin|macos) ]]; then
@@ -62,7 +61,7 @@ fi
 # ENTER_NIX_SHELL is the fake command used when `make shell` is run.
 # It is just a special string, not a variable, and a marker to not use `--run`.
 if [[ $@ == "ENTER_NIX_SHELL" ]]; then
-  echo -e "${GREEN}Configuring ${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS}'...${NC}"
+  echo -e "${GREEN}Configuring ${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS:-none}'...${NC}"
   exec nix-shell ${shellArgs[@]} ${entryPoint}
 else
   # Not all builds are ready to be run in a pure environment

--- a/nix/tools/lein/generate-nix.sh
+++ b/nix/tools/lein/generate-nix.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -z "${IN_NIX_SHELL}" ]]; then
+    echo "Remember to call 'make shell'!"
+    exit 1
+fi
+
 # This script takes care of generating/updating the nix files in the directory passed as a single argument.
 # For this, we start with a clean cache (in ./.m2~/repository/) and call cljsbuild
 #  to cause it to download all the artifacts. At the same time, we note them
@@ -7,8 +12,6 @@
 #  to ../maven/maven-inputs2nix.sh
 
 set -Eeuo pipefail
-
-. ~/.nix-profile/etc/profile.d/nix.sh
 
 output_dir=$1
 mkdir -p $output_dir

--- a/scripts/add-nix-gcroots.sh
+++ b/scripts/add-nix-gcroots.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-set -Eeu
+if [[ -z "${IN_NIX_SHELL}" ]]; then
+    echo "Remember to call 'make shell'!"
+    exit 1
+fi
 
-. ~/.nix-profile/etc/profile.d/nix.sh
+set -Eeu
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 


### PR DESCRIPTION
Changes:

* Remove `SHELL := /bin/sh` from definition of Makefile targets that update nix packages
* Check for Nix shell in those scripts and make `make shell` required for them
* Remove unnecessary command from `ci/Jenkinsfile.nix-cache`
* Add installation of `node2nix` if missing in `nix/desktop/realm-node/generate-nix.sh`
* Adjust the `find` for `nix-copy-closure` to use `-type d` which means we can't hit `*.lock`
* Changed `shell.nix` to load only most bare bones shell when `TARGET_OS=none`
* Changed `ci/Jenkinsfile.nix-cache` to use `TARGET_OS=none` by default.
* Made `make jsbundle-android` run in a pure shell in `ci/Jenkinsfile.nix-cache`