### PR TITLE
nix: use sha1 for status-go output filename

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
-def getStatusGoVersion = { ->
+def getStatusGoSHA1 = { ->
     def jsonSlurper = new groovy.json.JsonSlurper()
     def content = new File('../status-go-version.json').text
     def object = jsonSlurper.parseText(content)
 
     assert object instanceof Map
 
-    return object.version
+    return object.get('commit-sha1').substring(0, 7)
 }
 
 android {
@@ -25,5 +25,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+' // from node_modules
     compile 'com.github.status-im:function:0.0.1'
 
-    implementation(group: 'status-im', name: 'status-go', version: getStatusGoVersion(), ext: 'aar')
+    implementation(group: 'status-im', name: 'status-go', version: getStatusGoSHA1(), ext: 'aar')
 }

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -16,13 +16,14 @@ let
   version = versionJSON.version;
   sha256 = versionJSON.src-sha256;
   rev = versionJSON.commit-sha1;
+  shortRev = strings.substring 0 7 rev;
   goPackagePath = "github.com/${owner}/${repo}";
-  src = fetchFromGitHub { inherit rev owner repo sha256; name = "${repo}-${strings.substring 0 7 rev}-source"; };
+  src = fetchFromGitHub { inherit rev owner repo sha256; name = "${repo}-${shortRev}-source"; };
 
   mobileConfigs = {
     android = {
       name = "android";
-      outputFileName = "status-go-${version}.aar";
+      outputFileName = "status-go-${shortRev}.aar";
       envVars = [
         "ANDROID_HOME=${androidPkgs.androidsdk}/libexec/android-sdk"
         "ANDROID_NDK_HOME=${androidPkgs.ndk-bundle}/libexec/android-sdk/ndk-bundle"


### PR DESCRIPTION
This fixes issue with branch names containing slashes.