### PR TITLE
Fix loading of filters

### DIFF
--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -52,7 +52,7 @@
                 id        1
                 params    []}} method-options
           on-error (or on-error
-                       #(log/warn :json-rpc/error method :params params :error %))]
+                       #(log/warn :json-rpc/error method :error % :params params))]
       (if (nil? method)
         (log/error :json-rpc/method-not-found method)
         (status/call-private-rpc

--- a/test/cljs/status_im/test/transport/filters/core.cljs
+++ b/test/cljs/status_im/test/transport/filters/core.cljs
@@ -62,6 +62,11 @@
            (transport.filters/chats->filter-requests [{:is-active true
                                                        :group-chat false
                                                        :chat-id "0xchat-id"}]))))
+  (testing "a malformed one to one chat"
+    (is (= []
+           (transport.filters/chats->filter-requests [{:is-active true
+                                                       :group-chat false
+                                                       :chat-id "malformed"}]))))
   (testing "a single public chat"
     (is (= [{:ChatID "chat-id"
              :OneToOne false}]


### PR DESCRIPTION
Currently on some devices there are still some legacy chats(?) that are
one-to-one but don't have a public key as an id (transactor,demo-bot).
We were wrongly sending those to status-go to create filters.

Given the impact of the change and the fact that I don't know how to replicate it, it would be a skip QA.

status: ready