### PR TITLE
Features/move contacts

### DIFF
--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -82,14 +82,15 @@
                 (navigation/navigate-back)))))
 
 (fx/defn unblock-contact
-  [{:keys [db now]} public-key]
+  [{:keys [db now] :as cofx} public-key]
   (let [contact (-> (get-in db [:contacts/contacts public-key])
                     (assoc :last-updated now)
                     (update :system-tags disj :contact/blocked))]
-    {:db (-> db
-             (update :contacts/blocked disj public-key)
-             (assoc-in [:contacts/contacts public-key] contact))
-     :data-store/tx [(contacts-store/save-contact-tx contact)]}))
+    (fx/merge cofx
+              {:db (-> db
+                       (update :contacts/blocked disj public-key)
+                       (assoc-in [:contacts/contacts public-key] contact))}
+              (contacts-store/save-contact-tx contact))))
 
 (fx/defn block-contact-confirmation
   [cofx public-key]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -130,7 +130,6 @@
 (handlers/register-handler-fx
  :init.callback/multiaccount-change-success
  [(re-frame/inject-cofx :web3/get-web3)
-  (re-frame/inject-cofx :data-store/get-all-contacts)
   (re-frame/inject-cofx :data-store/get-all-installations)
   (re-frame/inject-cofx :data-store/all-chat-requests-ranges)]
  multiaccount-change-success)

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -236,7 +236,6 @@
     (fx/merge cofx
               {:notifications/get-fcm-token nil}
               (initialize-multiaccount-db address)
-              (contact/load-contacts)
               #(when (dev-mode? %)
                  (models.dev-server/start))
               (extensions.module/initialize)

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -6,6 +6,7 @@
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.ethereum.subscriptions :as ethereum.subscriptions]
             [status-im.chat.models.loading :as chat.loading]
+            [status-im.contact.core :as contact]
             [status-im.ethereum.transactions.core :as transactions]
             [status-im.fleet.core :as fleet]
             [status-im.i18n :as i18n]
@@ -209,6 +210,7 @@
          (mobile-network/on-network-status-change)
          (protocol/initialize-protocol)
          (chat.loading/initialize-chats {:to -1})
+         (contact/initialize-contacts)
          (universal-links/process-stored-event)
          (chaos-mode/check-chaos-mode)
          (finish-keycard-setup)

--- a/src/status_im/transport/filters/core.cljs
+++ b/src/status_im/transport/filters/core.cljs
@@ -206,10 +206,11 @@
    :topic topic})
 
 (fx/defn set-filters-initialized [{:keys [db]}]
-  {:db (assoc db :filters/initialized true)})
+  {:db (update db :filters/initialized inc)})
 
+;; We check that both chats & contacts have been initialized
 (defn filters-initialized? [db]
-  (:filters/initialized db))
+  (>= (:filters/initialized db) 2))
 
 (fx/defn handle-filters-added
   "Called every time we load a filter from statusgo, either from explicit call

--- a/src/status_im/tribute_to_talk/whitelist.cljs
+++ b/src/status_im/tribute_to_talk/whitelist.cljs
@@ -35,8 +35,8 @@
                     (update :system-tags conj tag))]
     (fx/merge cofx
               {:db (-> db
-                       (assoc-in [:contacts/contacts public-key] contact))
-               :data-store/tx [(contacts-store/save-contact-tx contact)]}
+                       (assoc-in [:contacts/contacts public-key] contact))}
+              (contacts-store/save-contact-tx contact)
               (add-to-whitelist public-key))))
 
 (fx/defn mark-tribute-paid

--- a/test/cljs/status_im/test/data_store/contacts.cljs
+++ b/test/cljs/status_im/test/data_store/contacts.cljs
@@ -1,0 +1,68 @@
+(ns status-im.test.data-store.contacts
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.data-store.contacts :as c]))
+
+(deftest contact->rpc
+  (let [contact {:public-key "pk"
+                 :address "address"
+                 :name "name"
+                 :photo-path "photo-path"
+                 :tribute-to-talk "tribute-to-talk"
+                 :device-info {"1" {:id "1"
+                                    :timestamp 1
+                                    :fcm-token "1"}
+                               "2" {:id "2"
+                                    :timestamp 2
+                                    :fcm-token 3}}
+                 :last-updated 1
+                 :system-tags #{:a :b}}
+        expected-contact {:id "pk"
+                          :address "address"
+                          :name "name"
+                          :photoPath "photo-path"
+                          :tributeToTalk "[\"~#'\",\"tribute-to-talk\"]"
+                          :deviceInfo [{:installationId "1"
+                                        :timestamp 1
+                                        :fcmToken "1"}
+                                       {:installationId "2"
+                                        :timestamp 2
+                                        :fcmToken 3}]
+                          :lastUpdated 1
+                          :systemTags #{":a" ":b"}}]
+    (testing "->rpc"
+      (is (= expected-contact (update
+                               (c/->rpc contact)
+                               :systemTags
+                               #(into #{} %)))))))
+
+(deftest contact<-rpc
+  (let [contact {:id "pk"
+                 :address "address"
+                 :name "name"
+                 :photoPath "photo-path"
+                 :tributeToTalk "[\"~#'\",\"tribute-to-talk\"]"
+
+                 :deviceInfo [{:installationId "1"
+                               :timestamp 1
+                               :fcmToken "1"}
+                              {:installationId "2"
+                               :timestamp 2
+                               :fcmToken 3}]
+                 :lastUpdated 1
+                 :systemTags [":a" ":b"]}
+        expected-contact {:public-key "pk"
+                          :address "address"
+                          :name "name"
+                          :photo-path "photo-path"
+                          :tribute-to-talk "tribute-to-talk"
+                          :device-info {"1" {:id "1"
+                                             :timestamp 1
+                                             :fcm-token "1"}
+                                        "2" {:id "2"
+                                             :timestamp 2
+                                             :fcm-token 3}}
+                          :last-updated 1
+                          :system-tags #{:a :b}}]
+    (testing "<-rpc"
+      (is (= expected-contact (c/<-rpc contact))))))
+

--- a/test/cljs/status_im/test/models/contact.cljs
+++ b/test/cljs/status_im/test/models/contact.cljs
@@ -1,149 +1,145 @@
 (ns status-im.test.models.contact
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.contact.core :as model]))
 
 (def public-key "0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917")
 (def address "71adb0644e2b590e37dafdfea8bd58f0c7668c7f")
 
 (deftest handle-contact-update-test
-  (testing "the contact is not in contacts"
-    (let [actual (model/handle-contact-update
-                  public-key
-                  1
-                  {:name "name"
-                   :profile-image "image"
-                   :address "address"
-                   :device-info [{:id "1"
-                                  :fcm-token "token-1"}]
-                   :fcm-token "token"}
-                  {:db {}})
-          contact (get-in actual [:db :contacts/contacts public-key])]
-      (testing "it stores the contact in the database"
-        (is (:data-store/tx actual)))
-      (testing "it adds a new contact"
-        (is (=  {:public-key       public-key
-                 :photo-path       "image"
-                 :name             "name"
-                 :last-updated     1000
-                 :system-tags      #{:contact/request-received}
-                 :device-info      {"1" {:id "1"
-                                         :timestamp 1
-                                         :fcm-token "token-1"}}
-                 :fcm-token        "token"
-                 :address          "address"}
-                contact)))))
-  (testing "the contact is already in contacts"
-    (testing "timestamp is greater than last-updated"
+  (with-redefs [json-rpc/call (constantly nil)]
+    (testing "the contact is not in contacts"
+      (let [actual (model/handle-contact-update
+                    public-key
+                    1
+                    {:name "name"
+                     :profile-image "image"
+                     :address "address"
+                     :device-info [{:id "1"
+                                    :fcm-token "token-1"}]
+                     :fcm-token "token"}
+                    {:db {}})
+            contact (get-in actual [:db :contacts/contacts public-key])]
+        (testing "it adds a new contact"
+          (is (=  {:public-key       public-key
+                   :photo-path       "image"
+                   :name             "name"
+                   :last-updated     1000
+                   :system-tags      #{:contact/request-received}
+                   :device-info      {"1" {:id "1"
+                                           :timestamp 1
+                                           :fcm-token "token-1"}}
+                   :fcm-token        "token"
+                   :address          "address"}
+                  contact)))))
+    (testing "the contact is already in contacts"
+      (testing "timestamp is greater than last-updated"
+        (let [actual (model/handle-contact-update
+                      public-key
+                      1
+                      {:name "new-name"
+                       :profile-image "new-image"
+                       :device-info [{:id "2"
+                                      :fcm-token "token-2"}
+                                     {:id "3"
+                                      :fcm-token "token-3"}]
+                       :address "new-address"
+                       :fcm-token "new-token"}
+                      {:db {:contacts/contacts
+                            {public-key {:public-key       public-key
+                                         :photo-path       "old-image"
+                                         :name             "old-name"
+                                         :last-updated     0
+                                         :device-info      {"1" {:id "1"
+                                                                 :timestamp 0
+                                                                 :fcm-token "token-1"}
+                                                            "2" {:id "2"
+                                                                 :timestamp 0
+                                                                 :fcm-token "token-2"}}
+                                         :system-tags      #{:contact/added}
+                                         :fcm-token        "old-token"
+                                         :address          "old-address"}}}})
+              contact (get-in actual [:db :contacts/contacts public-key])]
+          (testing "it updates the contact and adds contact/request-received to system tags"
+            (is (=  {:public-key       public-key
+                     :photo-path       "new-image"
+                     :name             "new-name"
+                     :last-updated     1000
+                     :device-info      {"1" {:id "1"
+                                             :fcm-token "token-1"
+                                             :timestamp 0}
+                                        "2" {:id "2"
+                                             :fcm-token "token-2"
+                                             :timestamp 1}
+                                        "3" {:id "3"
+                                             :fcm-token "token-3"
+                                             :timestamp 1}}
+                     :system-tags      #{:contact/added :contact/request-received}
+                     :fcm-token        "new-token"
+                     :address          "new-address"}
+                    contact)))))
+      (testing "timestamp is equal to last-updated"
+        (let [actual (model/handle-contact-update
+                      public-key
+                      1
+                      {:name "new-name"
+                       :profile-image "new-image"
+                       :address "new-address"
+                       :fcm-token "new-token"}
+                      {:db {:contacts/contacts
+                            {public-key {:public-key       public-key
+                                         :photo-path       "old-image"
+                                         :name             "old-name"
+                                         :last-updated     1000
+                                         :system-tags      #{:contact/added}
+                                         :fcm-token        "old-token"
+                                         :address          "old-address"}}}})
+              contact (get-in actual [:db :contacts/contacts public-key])]
+          (testing "it does nothing"
+            (is (nil? actual)))))
+      (testing "timestamp is less than last-updated"
+        (let [actual (model/handle-contact-update
+                      public-key
+                      0
+                      {:name "new-name"
+                       :profile-image "new-image"
+                       :address "new-address"
+                       :fcm-token "new-token"}
+                      {:db {:contacts/contacts
+                            {public-key {:public-key       public-key
+                                         :photo-path       "old-image"
+                                         :name             "old-name"
+                                         :last-updated     1000
+                                         :system-tags      #{:contact/added :contact/request-received}
+                                         :fcm-token        "old-token"
+                                         :address          "old-address"}}}})
+              contact (get-in actual [:db :contacts/contacts public-key])]
+          (testing "it does nothing"
+            (is (nil? actual))))))
+    (testing "backward compatibility"
       (let [actual (model/handle-contact-update
                     public-key
                     1
                     {:name "new-name"
-                     :profile-image "new-image"
-                     :device-info [{:id "2"
-                                    :fcm-token "token-2"}
-                                   {:id "3"
-                                    :fcm-token "token-3"}]
-                     :address "new-address"
-                     :fcm-token "new-token"}
+                     :profile-image "new-image"}
                     {:db {:contacts/contacts
                           {public-key {:public-key       public-key
                                        :photo-path       "old-image"
+                                       :device-info      {"1" {:id "1"
+                                                               :fcm-token "token-1"}}
                                        :name             "old-name"
                                        :last-updated     0
-                                       :device-info      {"1" {:id "1"
-                                                               :timestamp 0
-                                                               :fcm-token "token-1"}
-                                                          "2" {:id "2"
-                                                               :timestamp 0
-                                                               :fcm-token "token-2"}}
-                                       :system-tags      #{:contact/added}
-                                       :fcm-token        "old-token"
-                                       :address          "old-address"}}}})
+                                       :system-tags      #{:contact/added}}}}})
             contact (get-in actual [:db :contacts/contacts public-key])]
-        (testing "it stores the contact in the database"
-          (is (:data-store/tx actual)))
-        (testing "it updates the contact and adds contact/request-received to system tags"
+        (testing "it updates the contact"
           (is (=  {:public-key       public-key
                    :photo-path       "new-image"
                    :name             "new-name"
-                   :last-updated     1000
                    :device-info      {"1" {:id "1"
-                                           :fcm-token "token-1"
-                                           :timestamp 0}
-                                      "2" {:id "2"
-                                           :fcm-token "token-2"
-                                           :timestamp 1}
-                                      "3" {:id "3"
-                                           :fcm-token "token-3"
-                                           :timestamp 1}}
+                                           :fcm-token "token-1"}}
+                   :last-updated     1000
                    :system-tags      #{:contact/added :contact/request-received}
-                   :fcm-token        "new-token"
-                   :address          "new-address"}
-                  contact)))))
-    (testing "timestamp is equal to last-updated"
-      (let [actual (model/handle-contact-update
-                    public-key
-                    1
-                    {:name "new-name"
-                     :profile-image "new-image"
-                     :address "new-address"
-                     :fcm-token "new-token"}
-                    {:db {:contacts/contacts
-                          {public-key {:public-key       public-key
-                                       :photo-path       "old-image"
-                                       :name             "old-name"
-                                       :last-updated     1000
-                                       :system-tags      #{:contact/added}
-                                       :fcm-token        "old-token"
-                                       :address          "old-address"}}}})
-            contact (get-in actual [:db :contacts/contacts public-key])]
-        (testing "it does nothing"
-          (is (nil? actual)))))
-    (testing "timestamp is less than last-updated"
-      (let [actual (model/handle-contact-update
-                    public-key
-                    0
-                    {:name "new-name"
-                     :profile-image "new-image"
-                     :address "new-address"
-                     :fcm-token "new-token"}
-                    {:db {:contacts/contacts
-                          {public-key {:public-key       public-key
-                                       :photo-path       "old-image"
-                                       :name             "old-name"
-                                       :last-updated     1000
-                                       :system-tags      #{:contact/added :contact/request-received}
-                                       :fcm-token        "old-token"
-                                       :address          "old-address"}}}})
-            contact (get-in actual [:db :contacts/contacts public-key])]
-        (testing "it does nothing"
-          (is (nil? actual))))))
-  (testing "backward compatibility"
-    (let [actual (model/handle-contact-update
-                  public-key
-                  1
-                  {:name "new-name"
-                   :profile-image "new-image"}
-                  {:db {:contacts/contacts
-                        {public-key {:public-key       public-key
-                                     :photo-path       "old-image"
-                                     :device-info      {"1" {:id "1"
-                                                             :fcm-token "token-1"}}
-                                     :name             "old-name"
-                                     :last-updated     0
-                                     :system-tags      #{:contact/added}}}}})
-          contact (get-in actual [:db :contacts/contacts public-key])]
-      (testing "it stores the contact in the database"
-        (is (:data-store/tx actual)))
-      (testing "it updates the contact"
-        (is (=  {:public-key       public-key
-                 :photo-path       "new-image"
-                 :name             "new-name"
-                 :device-info      {"1" {:id "1"
-                                         :fcm-token "token-1"}}
-                 :last-updated     1000
-                 :system-tags      #{:contact/added :contact/request-received}
-                 :address          address} contact)))))
-  (testing "the message is coming from us"
-    (testing "it does not update contacts"
-      (is (nil? (model/handle-contact-update "me" 1 {} {:db {:multiaccount {:public-key "me"}}}))))))
+                   :address          address} contact)))))
+    (testing "the message is coming from us"
+      (testing "it does not update contacts"
+        (is (nil? (model/handle-contact-update "me" 1 {} {:db {:multiaccount {:public-key "me"}}})))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -16,6 +16,7 @@
             [status-im.test.contact-recovery.core]
             [status-im.test.contacts.device-info]
             [status-im.test.data-store.chats]
+            [status-im.test.data-store.contacts]
             [status-im.test.data-store.core]
             [status-im.test.data-store.realm.core]
             [status-im.test.ethereum.abi-spec]
@@ -100,6 +101,7 @@
  'status-im.test.contacts.db
  'status-im.test.contacts.device-info
  'status-im.test.data-store.chats
+ 'status-im.test.data-store.contacts
  'status-im.test.data-store.core
  'status-im.test.data-store.realm.core
  'status-im.test.ethereum.abi-spec

--- a/test/cljs/status_im/test/sign_in/flow.cljs
+++ b/test/cljs/status_im/test/sign_in/flow.cljs
@@ -37,7 +37,6 @@
                   :multiaccounts/multiaccounts data/multiaccounts}
           cofx   {:db                   db
                   :web3                 :web3
-                  :all-contacts         data/all-contacts
                   :all-installations    []}
           efx    (events/multiaccount-change-success cofx [nil "address"])
           new-db (:db efx)]
@@ -50,9 +49,7 @@
       (testing "Navigate to :home."
         (is (= [:home nil] (efx :status-im.ui.screens.navigation/navigate-to))))
       (testing "Multiaccount selected."
-        (is (contains? new-db :multiaccount)))
-      (testing "Contacts initialized."
-        (is (= 2 (count (:contacts/contacts new-db))))))))
+        (is (contains? new-db :multiaccount))))))
 
 (deftest decryption-failure-on-multiaccount-change
   (testing ":init.callback/multiaccount-change-error event received."

--- a/test/cljs/status_im/test/tribute_to_talk/whitelist.cljs
+++ b/test/cljs/status_im/test/tribute_to_talk/whitelist.cljs
@@ -51,9 +51,7 @@
     (testing "contact was tagged as tribute paid"
       (is (= (get-in result
                      [:db :contacts/contacts "bob" :system-tags])
-             #{:tribute-to-talk/paid})))
-    (testing "change is persisted"
-      (is (:data-store/tx result)))))
+             #{:tribute-to-talk/paid})))))
 
 (deftest mark-tribute-received
   (let [result (whitelist/mark-tribute-received {:db {}} "bob")]
@@ -64,9 +62,7 @@
     (testing "contact was tagged as tribute paid"
       (is (= (get-in result
                      [:db :contacts/contacts "bob" :system-tags])
-             #{:tribute-to-talk/received})))
-    (testing "change is persisted"
-      (is (:data-store/tx result)))))
+             #{:tribute-to-talk/received})))))
 
 (def sender-pk "0x04263d74e55775280e75b4a4e9a45ba59fc372793a869c5d9c4fa2100556d9963e3f4fbfa1724ec94a46e6da057540ab248ed1f5eb956e36e3129ecd50fade2c97")
 (def sender-address "0xdff1a5e4e57d9723b3294e0f4413372e3ea9a8ff")


### PR DESCRIPTION
Move contacts to status-go
    
Contacts are now in status-go, no migration of contacts is provided so all contacts will be lost upon installing this build.
    
I have left the initialization of filters a bit sketchy (we wait that load-filters is called twice), as the next step will be to avoid calling load-filters altogether, as now that both contacts & chats are in called directly from status-go on loading.

### Testing
- Adding/Removing/Blocking contacts login/logout

depends on #8679 , please review only the last commit

status: ready