### PR TITLE
Remove old-message-id

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -87,12 +87,11 @@
 
 (fx/defn reply-to-message
   "Sets reference to previous chat message and focuses on input"
-  [{:keys [db] :as cofx} message-id old-message-id]
+  [{:keys [db] :as cofx} message-id]
   (let [current-chat-id (:current-chat-id db)]
     (fx/merge cofx
               {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message]
-                             {:message-id     message-id
-                              :old-message-id old-message-id})}
+                             {:message-id     message-id})}
               (chat-input-focus :input-ref))))
 
 (fx/defn cancel-message-reply
@@ -123,7 +122,7 @@
   "no command detected, when not empty, proceed by sending text message without command processing"
   [input-text current-chat-id {:keys [db] :as cofx}]
   (when-not (string/blank? input-text)
-    (let [{:keys [message-id old-message-id]}
+    (let [{:keys [message-id]}
           (get-in db [:chats current-chat-id :metadata :responding-to-message])
           show-name?     (get-in db [:multiaccount :show-name?])
           preferred-name (when show-name? (get-in db [:multiaccount :preferred-name]))]
@@ -134,8 +133,7 @@
                                             :content      (cond-> {:chat-id current-chat-id
                                                                    :text    input-text}
                                                             message-id
-                                                            (assoc :response-to old-message-id
-                                                                   :response-to-v2 message-id)
+                                                            (assoc :response-to-v2 message-id)
                                                             preferred-name
                                                             (assoc :name preferred-name))})
                 (commands.input/set-command-reference nil)

--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -43,13 +43,13 @@
 
 (defn- get-referenced-ids
   "Takes map of `message-id->messages` and returns set of maps of
-  `{:response-to old-message-id :response-to-v2 message-id}`,
+  `{:response-to-v2 message-id}`,
    excluding any `message-id` which is already in the original map"
   [message-id->messages]
   (into #{}
         (comp (keep (fn [{:keys [content]}]
                       (let [response-to-id
-                            (select-keys content [:response-to :response-to-v2])]
+                            (select-keys content [:response-to-v2])]
                         (when (some (complement nil?) (vals response-to-id))
                           response-to-id))))
               (remove #(some message-id->messages (vals %))))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -575,6 +575,21 @@
           contact-recovery/v1
           mailserver-requests-gap/v1])
 
+(def v48 [chat/v15
+          chat-requests-range/v1
+          transport/v10
+          contact/v8
+          message/v12
+          mailserver/v11
+          mailserver-topic/v2
+          membership-update/v1
+          installation/v3
+          browser/v8
+          dapp-permissions/v9
+          contact-device-info/v1
+          contact-recovery/v1
+          mailserver-requests-gap/v1])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -716,4 +731,7 @@
                :migration     migrations/v46}
               {:schema        v47
                :schemaVersion 47
+               :migration     (constantly nil)}
+              {:schema        v48
+               :schemaVersion 48
                :migration     (constantly nil)}])

--- a/src/status_im/data_store/realm/schemas/account/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/message.cljs
@@ -78,3 +78,6 @@
       (assoc-in [:properties :outgoing-status]
                 {:type :string
                  :optional true})))
+
+(def v12
+  (update v11 :properties dissoc :old-message-id))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -770,8 +770,8 @@
 
 (handlers/register-handler-fx
  :chat.ui/reply-to-message
- (fn [cofx [_ message-id old-message-id]]
-   (chat.input/reply-to-message cofx message-id old-message-id)))
+ (fn [cofx [_ message-id]]
+   (chat.input/reply-to-message cofx message-id)))
 
 (handlers/register-handler-fx
  :chat.ui/send-current-message

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -98,7 +98,6 @@
   (receive [this chat-id signature timestamp cofx]
     (let [received-message-fx {:chat-received-message/add-fx
                                [(assoc (into {} this)
-                                       :old-message-id (transport.utils/old-message-id this)
                                        :message-id (transport.utils/message-id
                                                     signature
                                                     (.-payload (:js-obj cofx)))

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -4,18 +4,16 @@
             [status-im.ethereum.core :as ethereum]
             [status-im.js-dependencies :as dependencies]))
 
-(defn old-message-id
-  [message]
-  (ethereum/sha3 (pr-str message)))
-
 (defn system-message-id
   [{:keys [from chat-id clock-value]}]
   (ethereum/sha3 (str from chat-id clock-value)))
 
 (defn message-id
-  "Get a message-id"
+  "Get a message-id by appending the hex-encoded pk of the sender to the raw-payload.
+  We strip 0x from the payload so web3 understand that the whole thing is to be
+  decoded as raw bytes"
   [from raw-payload]
-  (ethereum/sha3 (str from (ethereum/sha3 raw-payload))))
+  (ethereum/sha3 (str from (subs raw-payload 2))))
 
 (defn get-topic
   "Get the topic of a group chat or public chat from the chat-id"

--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -13,9 +13,9 @@
             (:url content))
     (.share react/sharing (clj->js content))))
 
-(defn- message-options [message-id old-message-id text]
+(defn- message-options [message-id text]
   [{:label  (i18n/label :t/message-reply)
-    :action #(re-frame/dispatch [:chat.ui/reply-to-message message-id old-message-id])}
+    :action #(re-frame/dispatch [:chat.ui/reply-to-message message-id])}
    {:label  (i18n/label :t/sharing-copy-to-clipboard)
     :action #(react/copy-to-clipboard text)}
    (when-not platform/desktop?
@@ -28,9 +28,9 @@
     platform/android? (dialog/show options)
     platform/desktop? (show-desktop-menu (->> (:options options) (remove nil?)))))
 
-(defn chat-message [message-id old-message-id text dialog-title]
+(defn chat-message [message-id text dialog-title]
   (show {:title       dialog-title
-         :options     (message-options message-id old-message-id text)
+         :options     (message-options message-id text)
          :cancel-text (i18n/label :t/message-options-cancel)}))
 
 (defn- platform-web-browser []

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -249,8 +249,8 @@
     [message-delivery-status message]]])
 
 (defn open-chat-context-menu
-  [{:keys [message-id old-message-id content] :as message}]
-  (list-selection/chat-message message-id old-message-id (:text content) (i18n/label :t/message)))
+  [{:keys [message-id content] :as message}]
+  (list-selection/chat-message message-id (:text content) (i18n/label :t/message)))
 
 (defn chat-message
   [{:keys [outgoing group-chat modal? current-public-key content-type content] :as message}]

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -101,7 +101,7 @@
   (not (#{:not-sent :sending} outgoing-status)))
 
 (views/defview message-without-timestamp
-  [text {:keys [chat-id message-id old-message-id content group-chat expanded? current-public-key outgoing-status] :as message} style]
+  [text {:keys [chat-id message-id content group-chat expanded? current-public-key outgoing-status] :as message} style]
   [react/view {:flex 1 :margin-vertical 5}
    [react/touchable-highlight {:on-press (fn [arg]
                                            (when (= "right" (.-button (.-nativeEvent arg)))
@@ -110,7 +110,7 @@
                                                 :on-select #(do (utils/show-popup "" "Message copied to clipboard") (react/copy-to-clipboard text))}
                                                {:text      (i18n/label :t/message-reply)
                                                 :on-select #(when (message-sent? outgoing-status)
-                                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id old-message-id]))}])))}
+                                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id]))}])))}
     (let [collapsible? (and (:should-collapse? content) group-chat)
           char-limit   (if (and collapsible? (not expanded?))
                          constants/chars-collapse-threshold constants/desktop-msg-chars-hard-limit)

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -47,6 +47,7 @@
             [status-im.test.sign-in.flow]
             [status-im.test.stickers.core]
             [status-im.test.transport.core]
+            [status-im.test.transport.utils]
             [status-im.test.tribute-to-talk.core]
             [status-im.test.tribute-to-talk.db]
             [status-im.test.tribute-to-talk.whitelist]
@@ -133,6 +134,7 @@
  'status-im.test.signing.core
  'status-im.test.signing.gas
  'status-im.test.transport.core
+ 'status-im.test.transport.utils
  'status-im.test.tribute-to-talk.core
  'status-im.test.tribute-to-talk.db
  'status-im.test.tribute-to-talk.whitelist

--- a/test/cljs/status_im/test/transport/utils.cljs
+++ b/test/cljs/status_im/test/transport/utils.cljs
@@ -1,0 +1,11 @@
+(ns status-im.test.transport.utils
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.fx :as fx]
+            [status-im.transport.utils :as transport]))
+
+(deftest test-message-id
+  (testing "test"
+    (let [pk "0x03d0370306168850aa1f06a2f22c9a756c7dd00e35dd797fcdf351e53ff6ae7b9f"
+          payload "0x74657374"
+          expected-message-id "0x642b7f39873aab69d5aee686f4ed0ca02f82e025242ea57569a70640a94aea34"]
+      (is (= expected-message-id (transport/message-id pk payload))))))


### PR DESCRIPTION
Old message id was used for compatibility of replies with older clients.
Given that v1 is breaking, this is not needed anymore and simplifies
moving messages to status-go. No protocol/data-store change is made, to minimize
changes.

### Testing

- replies from this build to this build

status: ready