### PR TITLE
Fix back button issues on Android

### DIFF
--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -75,7 +75,7 @@
                 (navigation/navigate-to-cofx :intro-wizard nil))
 
       (fx/merge {:db (dissoc db :intro-wizard)}
-                (navigation/navigate-to-clean (if first-time-setup? :intro :multiaccounts) nil)))))
+                (navigation/navigate-back)))))
 
 (fx/defn exit-wizard [{:keys [db] :as cofx}]
   (fx/merge {:db (dissoc db :intro-wizard)}

--- a/src/status_im/multiaccounts/recover/core.cljs
+++ b/src/status_im/multiaccounts/recover/core.cljs
@@ -210,8 +210,11 @@
 
 (fx/defn cancel-pressed
   {:events [:recover.ui/cancel-pressed]}
-  [cofx]
-  (navigation/navigate-back cofx))
+  [{:keys [db] :as cofx}]
+  ;; Workaround for multiple Cancel button clicks
+  ;; that can break navigation tree
+  (when-not (#{:multiaccounts :login} (:view-id db))
+    (navigation/navigate-back cofx)))
 
 (fx/defn select-storage-next-pressed
   {:events       [:recover.select-storage.ui/next-pressed]

--- a/src/status_im/ui/screens/keycard/recovery/views.cljs
+++ b/src/status_im/ui/screens/keycard/recovery/views.cljs
@@ -3,6 +3,7 @@
   (:require [status-im.ui.components.react :as react]
             [status-im.ui.screens.keycard.styles :as styles]
             [status-im.ui.screens.keycard.views :as views]
+            [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
@@ -22,7 +23,9 @@
    [toolbar/toolbar
     {:transparent? true
      :style        {:margin-top 32}}
-    toolbar/default-nav-back
+    (toolbar/nav-button
+     (actions/back #(re-frame/dispatch
+                     [:recover.ui/cancel-pressed])))
     nil]
    [react/view {:flex            1
                 :flex-direction  :column

--- a/src/status_im/ui/screens/multiaccounts/login/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/login/views.cljs
@@ -24,7 +24,7 @@
    {:style {:border-bottom-width 0
             :margin-top          0}}
    (when can-navigate-back?
-     [toolbar/nav-button (act/back #(re-frame/dispatch [:navigate-to-clean :multiaccounts]))])
+     [toolbar/nav-button (act/back #(re-frame/dispatch [:navigate-reset :multiaccounts]))])
    nil])
 
 (defn login-multiaccount [password-text-input]

--- a/src/status_im/ui/screens/multiaccounts/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/views.cljs
@@ -56,7 +56,7 @@
                         :key-fn    :address
                         :render-fn (fn [multiaccount] [multiaccount-view multiaccount])}]]
       [react/view
-       [components.common/button {:on-press #(re-frame/dispatch [:multiaccounts.create.ui/intro-wizard true])
+       [components.common/button {:on-press #(re-frame/dispatch [:multiaccounts.create.ui/intro-wizard false])
                                   :button-style styles/bottom-button
                                   :label    (i18n/label :t/generate-a-new-key)}]
        [react/view styles/bottom-button-container

--- a/src/status_im/ui/screens/routing/intro_login_stack.cljs
+++ b/src/status_im/ui/screens/routing/intro_login_stack.cljs
@@ -48,15 +48,17 @@
 (defn login-stack [view-id]
   {:name    :login-stack
    :screens (cond-> [:login
+                     :multiaccounts
+                     :intro-wizard
                      :progress
+                     :keycard-recovery-intro
                      :create-multiaccount
                      :recover-multiaccount
                      :recover-multiaccount-enter-phrase
                      :recover-multiaccount-select-storage
                      :recover-multiaccount-enter-password
                      :recover-multiaccount-confirm-password
-                     :recover-multiaccount-success
-                     :multiaccounts]
+                     :recover-multiaccount-success]
 
               config/hardwallet-enabled?
               (concat [:hardwallet-authentication-method
@@ -71,8 +73,8 @@
                        :hardwallet-setup
                        :hardwallet-success]))
    :config  (if
-                ;; add view-id here if you'd like that view to be
-                ;; first view when app is started
+              ;; add view-id here if you'd like that view to be
+              ;; first view when app is started
              (#{:login :progress :multiaccounts :enter-pin-login :keycard-login-pin} view-id)
               {:initialRouteName view-id}
               {:initialRouteName :login})})


### PR DESCRIPTION
Fixes #8735 
Fixes #8736

Kudos to @yenda for suggesting `navigate-reset`.

## Description
What happened there is that re-frame's `navigation-stack` and react-navigation's stack begin to differ once hardware Back button is pressed. So unless react-navigation's stack is properly reset, pressing hardware Back may lead to weird behaviors.

## QA notes
Current behavior is this: 
  - pressing hardware Back on multiaccounts screen: exits the app
  - pressing hardware/software Back on `Generate keys` step in the wizard - navigates to multiaccounts screen