### PR TITLE
don't allow overrides of TARGET_OS for startdev targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,15 +312,15 @@ _startdev-%:
 		$(MAKE) watch-$(SYSTEM)-$(DEVICE) || $(MAKE) _unknown-startdev-target-$@; \
 	fi
 
-startdev-android-avd: export TARGET_OS ?= android
+startdev-android-avd: export TARGET_OS = android
 startdev-android-avd: _startdev-android-avd
-startdev-android-genymotion: export TARGET_OS ?= android
+startdev-android-genymotion: export TARGET_OS = android
 startdev-android-genymotion: _startdev-android-genymotion
-startdev-android-real: export TARGET_OS ?= android
+startdev-android-real: export TARGET_OS = android
 startdev-android-real: _startdev-android-real
 startdev-desktop: export TARGET_OS ?= $(HOST_OS)
 startdev-desktop: _startdev-desktop
-startdev-ios-real: export TARGET_OS ?= ios
+startdev-ios-real: export TARGET_OS = ios
 startdev-ios-real: _startdev-ios-real
-startdev-ios-simulator: export TARGET_OS ?= ios
+startdev-ios-simulator: export TARGET_OS = ios
 startdev-ios-simulator: _startdev-ios-simulator


### PR DESCRIPTION
The issue was that the `startdev-*` targets in the `Makefile` were using the `?=` assignment form, which allowed `make shell` to override `TARGET_OS` value with `none` which resulted in:
```
[nix-shell:~/work/status-react]$ make startdev-android-avd
make[1]: Entering directory '/home/sochan/work/status-react'
make[2]: Entering directory '/home/sochan/work/status-react'
clj -R:dev build.clj watch --platform android --android-device avd
bash: clj: command not found
```
When running it within `make shell` without specifying `TARGET_OS`.

Related to https://github.com/status-im/status.im/pull/390.