### PR TITLE
Fix serialization of group-chats

### DIFF
--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -49,13 +49,17 @@
   (->> updates
        (group-by :signature)
        (map (fn [[signature events]]
-              {:events (map #(-> %
-                                 (assoc :clock-value (:clockValue %))
-                                 (dissoc :signature :from :id :clockValue)
-                                 remove-empty-vals) events)
+              {:events
+               (into []
+                     (sort-by :clock-value (map #(-> %
+                                                     (assoc :clock-value (:clockValue %))
+                                                     (update :members (fn [members] (into #{} members)))
+                                                     (dissoc :signature :from :id :clockValue)
+                                                     remove-empty-vals) events)))
                :from  (-> events first :from)
                :signature signature
-               :chat-id chat-id}))))
+               :chat-id chat-id}))
+       (into #{})))
 
 (defn type->rpc [{:keys [public? group-chat] :as chat}]
   (assoc chat :chatType (cond

--- a/test/cljs/status_im/test/data_store/chats.cljs
+++ b/test/cljs/status_im/test/data_store/chats.cljs
@@ -121,15 +121,15 @@
                        :admins #{"a" "b"}
                        :members-joined #{"a" "c"}
                        :name "name"
-                       :membership-updates [{:chat-id "chat-id"
-                                             :from "a"
-                                             :signature "b"
-                                             :events [{:type "chat-created"
-                                                       :name "test"
-                                                       :clock-value 1}
-                                                      {:type "members-added"
-                                                       :clock-value 2
-                                                       :members ["a" "b"]}]}]
+                       :membership-updates #{{:chat-id "chat-id"
+                                              :from "a"
+                                              :signature "b"
+                                              :events [{:type "chat-created"
+                                                        :name "test"
+                                                        :clock-value 1}
+                                                       {:type "members-added"
+                                                        :clock-value 2
+                                                        :members #{"a" "b"}}]}}
                        :unviewed-messages-count 2
                        :is-active true
                        :group-chat-local-version 1


### PR DESCRIPTION
fixes: #8744
events were duplicated as we were not using `#{}`

status: ready