### PR TITLE
[fix 8796] big number error when adding owned ens name

### DIFF
--- a/src/status_im/multiaccounts/update/core.cljs
+++ b/src/status_im/multiaccounts/update/core.cljs
@@ -52,8 +52,8 @@
                          [{:method "settings_saveConfig"
                            :params ["multiaccount" (types/serialize new-multiaccount)]
                            :on-success on-success}]}
-        {:keys [name photo-path]} new-multiaccount-fields]
-    (if (or name photo-path)
+        {:keys [name photo-path prefered-name]} new-multiaccount-fields]
+    (if (or name photo-path prefered-name)
       (fx/merge cofx
                 fx
                 (send-multiaccount-update))

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1807,8 +1807,9 @@
  :<- [:ens/registration]
  :<- [:ens.stateofus/registrar]
  :<- [:multiaccount]
- (fn [[{:keys [custom-domain? username-candidate] :as ens} registrar {:keys [accounts public-key]}] _]
-   {:state          (or (get-in ens [:states username-candidate]) :initial)
+ (fn [[{:keys [custom-domain? username-candidate registering?] :as ens} registrar {:keys [accounts public-key]}]]
+   {:state          (get-in ens [:states username-candidate])
+    :registering?   registering?
     :username       username-candidate
     :custom-domain? (or custom-domain? false)
     :contract       registrar
@@ -1819,7 +1820,7 @@
  :ens.name/screen
  :<- [:get-screen-params :ens-name-details]
  :<- [:ens/names]
- (fn [[name ens] _]
+ (fn [[name ens]]
    (let [{:keys [address public-key]} (get-in ens [:details name])]
      {:name       name
       :address    address
@@ -1831,7 +1832,7 @@
  :<- [:multiaccount]
  :<- [:ens/preferred-name]
  :<- [:ens/show?]
- (fn [[names multiaccount preferred-name show?] _]
+ (fn [[names multiaccount preferred-name show?]]
    {:names          names
     :multiaccount   multiaccount
     :preferred-name preferred-name


### PR DESCRIPTION
fix #8796

## Testing

Registering a username and adding a username that you already own from a recover account should work (only if the right public-key is registered)

status: ready