### PR TITLE
[fix 8786] fix multiaccount recovery and add account

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -673,26 +673,6 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
-
-    @ReactMethod
-    public void recoverAccount(final String passphrase, final String password, final Callback callback) {
-        Log.d(TAG, "recoverAccount");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.recoverAccount(password, passphrase);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
-    }
-
     @ReactMethod
     public void multiAccountStoreAccount(final String json, final Callback callback) {
         Log.d(TAG, "multiAccountStoreAccount");

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -259,18 +259,6 @@ void RCTStatus::addPeer(QString enode, double callbackId) {
         }, enode, callbackId);
 }
 
-
-void RCTStatus::recoverAccount(QString passphrase, QString password, double callbackId) {
-    Q_D(RCTStatus);
-    qCInfo(RCTSTATUS) << "::recoverAccount call - callbackId:" << callbackId;
-    QtConcurrent::run([&](QString passphrase, QString password, double callbackId) {
-            const char* result = RecoverAccount(password.toUtf8().data(), passphrase.toUtf8().data());
-            logStatusGoResult("::recoverAccount RecoverAccount", result);
-            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
-        }, passphrase, password, callbackId);
-}
-
-
 void RCTStatus::saveAccountAndLogin(QString accountData, QString password, QString config, QString subAccountsData) {
 
     Q_D(RCTStatus);

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -40,7 +40,6 @@ public:
     Q_INVOKABLE void sendDataNotification(QString dataPayloadJSON, QString tokensJSON, double callbackId);
     Q_INVOKABLE void sendLogs(QString dbJSON, QString jsLogs, double callbackId);
     Q_INVOKABLE void addPeer(QString enode, double callbackId);
-    Q_INVOKABLE void recoverAccount(QString passphrase, QString password, double callbackId);
     Q_INVOKABLE void prepareDirAndUpdateConfig(QString configString, double callbackId);
     Q_INVOKABLE void login(QString accountData, QString password);
     Q_INVOKABLE void saveAccountAndLogin(QString accountData, QString password, QString config, QString subAccountsData);

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -252,17 +252,6 @@ RCT_EXPORT_METHOD(chaosModeUpdate:(BOOL)on
 #endif
 }
 
-//////////////////////////////////////////////////////////////////// recoverAccount
-RCT_EXPORT_METHOD(recoverAccount:(NSString *)passphrase
-                  password:(NSString *)password
-                  callback:(RCTResponseSenderBlock)callback) {
-#if DEBUG
-    NSLog(@"RecoverAccount() method called");
-#endif
-    NSString *result = StatusgoRecoverAccount(password, passphrase);
-    callback(@[result]);
-}
-
 //////////////////////////////////////////////////////////////////// multiAccountGenerateAndDeriveAddresses
 RCT_EXPORT_METHOD(multiAccountGenerateAndDeriveAddresses:(NSString *)json
                   callback:(RCTResponseSenderBlock)callback) {

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -174,40 +174,6 @@
  (fn [cofx _]
    (multiaccounts/confirm-wallet-set-up cofx)))
 
-;; multiaccounts recover module
-
-(handlers/register-handler-fx
- :multiaccounts.recover.ui/passphrase-input-changed
- (fn [cofx [_ recovery-phrase]]
-   (multiaccounts.recover/set-phrase cofx recovery-phrase)))
-
-(handlers/register-handler-fx
- :multiaccounts.recover.ui/passphrase-input-blured
- (fn [cofx _]
-   (multiaccounts.recover/validate-phrase cofx)))
-
-(handlers/register-handler-fx
- :multiaccounts.recover.ui/password-input-changed
- (fn [cofx [_ masked-password]]
-   (multiaccounts.recover/set-password cofx masked-password)))
-
-(handlers/register-handler-fx
- :multiaccounts.recover.ui/password-input-blured
- (fn [cofx _]
-   (multiaccounts.recover/validate-password cofx)))
-
-(handlers/register-handler-fx
- :multiaccounts.recover.ui/sign-in-button-pressed
- [(re-frame/inject-cofx :random-guid-generator)]
- (fn [cofx _]
-   (multiaccounts.recover/recover-multiaccount-with-checks cofx)))
-
-(handlers/register-handler-fx
- :multiaccounts.recover.ui/recover-multiaccount-confirmed
- [(re-frame/inject-cofx :random-guid-generator)]
- (fn [cofx _]
-   (multiaccounts.recover/recover-multiaccount cofx)))
-
 ;; multiaccounts login module
 (handlers/register-handler-fx
  :multiaccounts.login.ui/multiaccount-selected

--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -401,7 +401,7 @@
             (navigation/navigate-to-cofx :keycard-recovery-enter-mnemonic nil)))
 
 (fx/defn start-import-flow
-  {:events [:recover.ui/recover-with-keycard-pressed
+  {:events [::recover-with-keycard-pressed
             :keycard.login.ui/recover-key-pressed]}
   [{:keys [db] :as cofx}]
   (fx/merge cofx

--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -49,8 +49,9 @@
 (fx/defn create-multiaccount
   [{:keys [db] :as cofx}]
   (let [{:keys [selected-id address key-code]} (:intro-wizard db)
-        {:keys [address]} (get-selected-multiaccount cofx)]
-    {::store-multiaccount [selected-id address key-code]}))
+        {:keys [address]} (get-selected-multiaccount cofx)
+        callback #(re-frame/dispatch [::store-multiaccount-success key-code])]
+    {::store-multiaccount [selected-id address key-code callback]}))
 
 (fx/defn intro-wizard
   {:events [:multiaccounts.create.ui/intro-wizard]}
@@ -268,7 +269,7 @@
 
 (re-frame/reg-fx
  ::store-multiaccount
- (fn [[id address password]]
+ (fn [[id address password callback]]
    (status/multiaccount-store-account
     id
     (security/safe-unmask-data password)
@@ -282,7 +283,7 @@
             id
             [constants/path-whisper constants/path-default-wallet]
             password
-            #(re-frame/dispatch [::store-multiaccount-success password])))))))))
+            callback))))))))
 
 (re-frame/reg-fx
  ::save-account-and-login

--- a/src/status_im/multiaccounts/recover/core.cljs
+++ b/src/status_im/multiaccounts/recover/core.cljs
@@ -27,20 +27,8 @@
         (not (mnemonic/valid-words? recovery-phrase)) :recovery-phrase-invalid
         (not (mnemonic/status-generated-phrase? recovery-phrase)) :recovery-phrase-unknown-words))
 
-(defn recover-multiaccount! [masked-passphrase password]
-  (status/recover-multiaccount
-   (mnemonic/sanitize-passphrase (security/safe-unmask-data masked-passphrase))
-   password
-   (fn [result]
-     ;; here we deserialize result, dissoc mnemonic and serialize the result again
-     ;; because we want to have information about the result printed in logs, but
-     ;; don't want secure data to be printed
-     (let [data (-> (types/json->clj result)
-                    (dissoc :mnemonic)
-                    (types/clj->json))]
-       (re-frame/dispatch [:multiaccounts.recover.callback/recover-multiaccount-success data password])))))
-
 (fx/defn set-phrase
+  {:events [::passphrase-input-changed]}
   [{:keys [db]} masked-recovery-phrase]
   (let [recovery-phrase (security/safe-unmask-data masked-recovery-phrase)]
     (fx/merge
@@ -51,6 +39,7 @@
                                              (not (mnemonic/valid-length? recovery-phrase))))})))
 
 (fx/defn validate-phrase
+  {:events [::passphrase-input-blured]}
   [{:keys [db]}]
   (let [recovery-phrase (get-in db [:multiaccounts/recover :passphrase])]
     {:db (update db :multiaccounts/recover assoc
@@ -63,6 +52,8 @@
                  :passphrase-error (check-phrase-warnings recovery-phrase))}))
 
 (fx/defn set-password
+  {:events [::password-input-changed
+            ::enter-password-input-changed]}
   [{:keys [db]} masked-password]
   (let [password (security/safe-unmask-data masked-password)]
     {:db (update db :multiaccounts/recover assoc
@@ -71,11 +62,15 @@
                  :password-valid? (not (check-password-errors password)))}))
 
 (fx/defn validate-password
+  {:events [::password-input-blured]}
   [{:keys [db]}]
   (let [password (get-in db [:multiaccounts/recover :password])]
     {:db (assoc-in db [:multiaccounts/recover :password-error] (check-password-errors password))}))
 
-(fx/defn validate-recover-result
+(fx/defn on-store-multiaccount-success
+  {:events       [::store-multiaccount-success]
+   :interceptors [(re-frame/inject-cofx :random-guid-generator)
+                  (re-frame/inject-cofx ::multiaccounts.create/get-signing-phrase)]}
   [{:keys [db] :as cofx} password]
   (let [multiaccount (get-in db [:multiaccounts/recover :root-key])
         multiaccount-address (-> (:address multiaccount)
@@ -90,47 +85,33 @@
                               :passphrase-error :recover-keycard-multiaccount-not-supported)
                       (update :multiaccounts/recover dissoc
                               :passphrase-valid?))}
-      (let [multiaccount' (assoc multiaccount :derived (get-in db [:multiaccounts/recover :derived]))]
+      (let [multiaccount (assoc multiaccount :derived (get-in db [:multiaccounts/recover :derived]))]
         (multiaccounts.create/on-multiaccount-created cofx
-                                                      multiaccount'
+                                                      multiaccount
                                                       password
                                                       {:seed-backed-up? true})))))
 
-(fx/defn on-multiaccount-recovered
-  {:events       [:multiaccounts.recover.callback/recover-multiaccount-success]
-   :interceptors [(re-frame/inject-cofx :random-guid-generator)
-                  (re-frame/inject-cofx ::multiaccounts.create/get-signing-phrase)]}
-  [cofx password]
-  (validate-recover-result cofx password))
+(fx/defn store-multiaccount
+  {:events [::recover-multiaccount-confirmed]}
+  [{:keys [db] :as cofx}]
+  (let [{:keys [password passphrase root-key]} (:multiaccounts/recover db)
+        {:keys [id address]} root-key
+        callback #(re-frame/dispatch [::store-multiaccount-success password])]
+    {:db (assoc-in db [:multiaccounts/recover :processing?] true)
+     ::multiaccounts.create/store-multiaccount [id address password callback]}))
 
-(fx/defn multiaccount-store-derived
-  [{:keys [db]}]
-  (let [id (get-in db [:multiaccounts/recover :root-key :id])
-        password (get-in db [:multiaccounts/recover :password])]
-    (status/multiaccount-store-derived
-     id
-     [constants/path-whisper constants/path-default-wallet]
-     password
-     #(re-frame/dispatch [:multiaccounts.recover.callback/recover-multiaccount-success password]))))
-
-(fx/defn recover-multiaccount
-  [{:keys [db random-guid-generator] :as cofx}]
-  (let [{:keys [password passphrase]} (:multiaccounts/recover db)]
-    {:db (-> db
-             (assoc-in [:multiaccounts/recover :processing?] true)
-             (assoc :multiaccounts/new-installation-id (random-guid-generator)))
-     :multiaccounts.recover/recover-multiaccount [(security/mask-data passphrase) password]}))
-
-(fx/defn recover-multiaccount-with-checks [{:keys [db] :as cofx}]
+(fx/defn recover-multiaccount-with-checks
+  {:events [::sign-in-button-pressed]}
+  [{:keys [db] :as cofx}]
   (let [{:keys [passphrase processing?]} (:multiaccounts/recover db)]
     (when-not processing?
       (if (mnemonic/status-generated-phrase? passphrase)
-        (recover-multiaccount cofx)
+        (store-multiaccount cofx)
         {:ui/show-confirmation
          {:title               (i18n/label :recovery-typo-dialog-title)
           :content             (i18n/label :recovery-typo-dialog-description)
           :confirm-button-text (i18n/label :recovery-confirm-phrase)
-          :on-accept           #(re-frame/dispatch [:multiaccounts.recover.ui/recover-multiaccount-confirmed])}}))))
+          :on-accept           #(re-frame/dispatch [::recover-multiaccount-confirmed])}}))))
 
 (fx/defn navigate-to-recover-multiaccount-screen [{:keys [db] :as cofx}]
   (fx/merge cofx
@@ -138,54 +119,57 @@
             (navigation/navigate-to-cofx :recover-multiaccount nil)))
 
 (re-frame/reg-fx
- :multiaccounts.recover/recover-multiaccount
- (fn [[masked-passphrase password]]
-   (recover-multiaccount! masked-passphrase password)))
+ ::store-multiaccount
+ (fn [[id address password]]
+   (status/multiaccount-store-account
+    id
+    (security/safe-unmask-data password)
+    (fn []
+      (status/multiaccount-load-account
+       address
+       password
+       (fn [value]
+         (let [{:keys [id]} (types/json->clj value)]
+           (status/multiaccount-store-derived
+            id
+            [constants/path-whisper constants/path-default-wallet]
+            password
+            #(re-frame/dispatch [::store-multiaccount-success password])))))))))
 
 (re-frame/reg-fx
- :multiaccounts.recover/import-mnemonic
+ ::import-multiaccount
  (fn [{:keys [passphrase password]}]
-   (status-im.native-module.core/multiaccount-import-mnemonic
+   (status/multiaccount-import-mnemonic
     passphrase
     password
     (fn [result]
-      (re-frame/dispatch [:multiaccounts.recover/import-mnemonic-success result])))))
+      (let [{:keys [id] :as root-data} (types/json->clj result)]
+        (status-im.native-module.core/multiaccount-derive-addresses
+         id
+         [constants/path-default-wallet constants/path-whisper]
+         (fn [result]
+           (let [derived-data (types/json->clj result)]
+             (re-frame/dispatch [::import-multiaccount-success
+                                 root-data derived-data])))))))))
 
-(re-frame/reg-fx
- :multiaccounts.recover/derive-addresses
- (fn [{:keys [account-id paths]}]
-   (status-im.native-module.core/multiaccount-derive-addresses
-    account-id
-    paths
-    (fn [result]
-      (re-frame/dispatch [:multiaccounts.recover/derive-addresses-success result])))))
-
-(fx/defn on-import-mnemonic-success
-  {:events [:multiaccounts.recover/import-mnemonic-success]}
-  [{:keys [db] :as cofx} result]
-  (let [{:keys [id] :as data} (types/json->clj result)]
-    {:db                                     (assoc-in db [:multiaccounts/recover :root-key] data)
-     :multiaccounts.recover/derive-addresses {:account-id id
-                                              :paths      [constants/path-default-wallet
-                                                           constants/path-whisper]}}))
-
-(fx/defn on-derive-addresses-success
-  {:events [:multiaccounts.recover/derive-addresses-success]}
-  [{:keys [db] :as cofx} result]
-  (let [data (types/json->clj result)]
-    (fx/merge cofx
-              {:db (assoc-in db [:multiaccounts/recover :derived] data)}
-              (navigation/navigate-to-cofx :recover-multiaccount-success nil))))
+(fx/defn on-import-multiaccount-success
+  {:events [::import-multiaccount-success]}
+  [{:keys [db] :as cofx} root-data derived-data]
+  (fx/merge cofx
+            {:db (-> db
+                     (assoc-in [:multiaccounts/recover :root-key] root-data)
+                     (assoc-in [:multiaccounts/recover :derived] derived-data))}
+            (navigation/navigate-to-cofx :recover-multiaccount-success nil)))
 
 (fx/defn re-encrypt-pressed
-  {:events [:recover.success.ui/re-encrypt-pressed]}
+  {:events [::re-encrypt-pressed]}
   [{:keys [db] :as cofx}]
   (fx/merge cofx
             {:db (assoc-in db [:intro-wizard :selected-storage-type] :default)}
             (navigation/navigate-to-cofx :recover-multiaccount-select-storage nil)))
 
 (fx/defn enter-phrase-pressed
-  {:events [:recover.ui/enter-phrase-pressed]}
+  {:events [::enter-phrase-pressed]}
   [{:keys [db] :as cofx}]
   (fx/merge cofx
             {:db       (assoc db :multiaccounts/recover {:next-button-disabled? true})
@@ -193,23 +177,15 @@
             (navigation/navigate-to-cofx :recover-multiaccount-enter-phrase nil)))
 
 (fx/defn proceed-to-import-mnemonic
-  [{:keys [db random-guid-generator] :as cofx}]
+  {:events [::enter-phrase-input-submitted ::enter-phrase-next-pressed]}
+  [{:keys [db] :as cofx}]
   (let [{:keys [password passphrase]} (:multiaccounts/recover db)]
     (when (mnemonic/valid-length? passphrase)
-      (fx/merge cofx
-                {:db (assoc db :multiaccounts/new-installation-id (random-guid-generator))
-                 :multiaccounts.recover/import-mnemonic {:passphrase passphrase
-                                                         :password   password}}))))
-
-(fx/defn enter-phrase-next-button-pressed
-  {:events       [:recover.enter-passphrase.ui/input-submitted
-                  :recover.enter-passphrase.ui/next-pressed]
-   :interceptors [(re-frame/inject-cofx :random-guid-generator)]}
-  [{:keys [db] :as cofx}]
-  (proceed-to-import-mnemonic cofx))
+      {::import-multiaccount {:passphrase passphrase
+                              :password password}})))
 
 (fx/defn cancel-pressed
-  {:events [:recover.ui/cancel-pressed]}
+  {:events [::cancel-pressed]}
   [{:keys [db] :as cofx}]
   ;; Workaround for multiple Cancel button clicks
   ;; that can break navigation tree
@@ -217,7 +193,7 @@
     (navigation/navigate-back cofx)))
 
 (fx/defn select-storage-next-pressed
-  {:events       [:recover.select-storage.ui/next-pressed]
+  {:events       [::select-storage-next-pressed]
    :interceptors [(re-frame/inject-cofx :random-guid-generator)]}
   [{:keys [db] :as cofx}]
   (let [storage-type (get-in db [:intro-wizard :selected-storage-type])]
@@ -231,23 +207,23 @@
     (navigation/navigate-to-cofx cofx :recover-multiaccount-confirm-password nil)))
 
 (fx/defn enter-password-next-button-pressed
-  {:events [:recover.enter-password.ui/input-submitted
-            :recover.enter-password.ui/next-pressed]}
+  {:events [::enter-password-input-submitted
+            ::enter-password-next-pressed]}
   [{:keys [db] :as cofx}]
   (fx/merge cofx
             (validate-password)
             (proceed-to-password-confirm)))
 
 (fx/defn confirm-password-next-button-pressed
-  {:events       [:recover.confirm-password.ui/input-submitted
-                  :recover.confirm-password.ui/next-pressed]
+  {:events [::confirm-password-input-submitted
+            ::confirm-password-next-pressed]
    :interceptors [(re-frame/inject-cofx :random-guid-generator)]}
   [{:keys [db] :as cofx}]
   (let [{:keys [password password-confirmation]} (:multiaccounts/recover db)]
     (if (= password password-confirmation)
       (fx/merge cofx
                 {:db (assoc db :intro-wizard nil)}
-                (multiaccount-store-derived)
+                (store-multiaccount)
                 (navigation/navigate-to-cofx :keycard-welcome nil))
       {:db (assoc-in db [:multiaccounts/recover :password-error] :password_error1)})))
 
@@ -265,20 +241,15 @@
                 (validate-phrase-for-warnings)))))
 
 (fx/defn enter-phrase-input-changed
-  {:events [:recover.enter-passphrase.ui/input-changed]}
+  {:events [::enter-phrase-input-changed]}
   [cofx input]
   (fx/merge cofx
             (set-phrase input)
             (count-words)
             (run-validation)))
 
-(fx/defn enter-password-input-changed
-  {:events [:recover.enter-password.ui/input-changed]}
-  [cofx input]
-  (set-password cofx input))
-
 (fx/defn confirm-password-input-changed
-  {:events [:recover.confirm-password.ui/input-changed]}
+  {:events [::confirm-password-input-changed]}
   [{:keys [db]} input]
   {:db (-> db
            (assoc-in [:multiaccounts/recover :password-confirmation] input)

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -38,9 +38,6 @@
 (defn multiaccount-derive-addresses [account-id paths callback]
   (native-module/multiaccount-derive-addresses account-id paths callback))
 
-(defn recover-multiaccount [passphrase password callback]
-  (native-module/recover-account passphrase password callback))
-
 (defn multiaccount-store-account [account-id password callback]
   (native-module/multiaccount-store-account account-id password callback))
 

--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -76,10 +76,6 @@
   (when (status)
     (.addPeer (status) enode on-result)))
 
-(defn recover-account [passphrase password on-result]
-  (when (status)
-    (.recoverAccount (status) passphrase password on-result)))
-
 (defn multiaccount-generate-and-derive-addresses [n mnemonic-length paths on-result]
   (.multiAccountGenerateAndDeriveAddresses (status)
                                            (types/clj->json {:n n

--- a/src/status_im/ui/screens/multiaccounts/recover/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/recover/views.cljs
@@ -7,6 +7,8 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
+            [status-im.multiaccounts.recover.core :as multiaccounts.recover]
+            [status-im.hardwallet.core :as hardwallet]
             [status-im.i18n :as i18n]
             [status-im.ui.screens.multiaccounts.recover.styles :as styles]
             [status-im.ui.components.styles :as components.styles]
@@ -40,8 +42,8 @@
       :multiline           true
       :default-value       passphrase
       :auto-correct        false
-      :on-change-text      #(re-frame/dispatch [:multiaccounts.recover.ui/passphrase-input-changed (security/mask-data %)])
-      :on-blur             #(re-frame/dispatch [:multiaccounts.recover.ui/passphrase-input-blured])
+      :on-change-text      #(re-frame/dispatch [::multiaccounts.recover/passphrase-input-changed (security/mask-data %)])
+      :on-blur             #(re-frame/dispatch [::multiaccounts.recover/passphrase-input-blured])
       :error               (cond error (i18n/label error)
                                  warning (i18n/label warning))}]))
 
@@ -61,8 +63,8 @@
        :placeholder         (i18n/label :t/enter-password)
        :default-value       password
        :auto-focus          false
-       :on-change-text      #(re-frame/dispatch [:multiaccounts.recover.ui/password-input-changed (security/mask-data %)])
-       :on-blur             #(re-frame/dispatch [:multiaccounts.recover.ui/password-input-blured])
+       :on-change-text      #(re-frame/dispatch [::multiaccounts.recover/password-input-changed (security/mask-data %)])
+       :on-blur             #(re-frame/dispatch [::multiaccounts.recover/password-input-blured])
        :secure-text-entry   true
        :error               (when error (i18n/label error))
        :on-submit-editing   on-submit-editing
@@ -80,7 +82,7 @@
                           processing?
                           (not valid-form?)
                           (not node-stopped?))
-          sign-in     #(re-frame/dispatch [:multiaccounts.recover.ui/sign-in-button-pressed])]
+          sign-in     #(re-frame/dispatch [::multiaccounts.recover/sign-in-button-pressed])]
       [react/keyboard-avoiding-view {:style styles/screen-container}
        [status-bar/status-bar]
        [toolbar/toolbar nil toolbar/default-nav-back
@@ -113,7 +115,7 @@
       :accessibility-label :enter-seed-phrase-button
       :icon                :main-icons/text
       :icon-opts           {:color colors/blue}
-      :on-press            #(re-frame/dispatch [:recover.ui/enter-phrase-pressed])}]
+      :on-press            #(re-frame/dispatch [::multiaccounts.recover/enter-phrase-pressed])}]
     [action-button/action-button
      {:label               (i18n/label :t/recover-with-keycard)
       :label-style         (if config/hardwallet-enabled? {} {:color colors/gray})
@@ -121,7 +123,7 @@
       :image               :keycard-logo-blue
       :image-opts          {:style {:width 24 :height 24}}
       :on-press            #(when config/hardwallet-enabled?
-                              (re-frame/dispatch [:recover.ui/recover-with-keycard-pressed]))}]]])
+                              (re-frame/dispatch [::hardwallet/recover-with-keycard-pressed]))}]]])
 
 (def bottom-sheet
   {:content        bottom-sheet-view
@@ -140,7 +142,7 @@
       {:transparent? true
        :style        {:margin-top 32}}
       [toolbar/nav-text
-       {:handler #(re-frame/dispatch [:recover.ui/cancel-pressed])
+       {:handler #(re-frame/dispatch [::multiaccounts.recover/cancel-pressed])
         :style   {:padding-left 21}}
        (i18n/label :t/cancel)]
       [react/text {:style {:color colors/gray}}
@@ -158,9 +160,9 @@
          (i18n/label :t/multiaccounts-recover-enter-phrase-title)]]
        [react/view {:margin-top 16}
         [text-input/text-input-with-label
-         {:on-change-text    #(re-frame/dispatch [:recover.enter-passphrase.ui/input-changed (security/mask-data %)])
+         {:on-change-text    #(re-frame/dispatch [::multiaccounts.recover/enter-phrase-input-changed (security/mask-data %)])
           :auto-focus        true
-          :on-submit-editing #(re-frame/dispatch [:recover.enter-passphrase.ui/input-submitted])
+          :on-submit-editing #(re-frame/dispatch [::multiaccounts.recover/enter-phrase-input-submitted])
           :error             (when passphrase-error (i18n/label passphrase-error))
           :placeholder       nil
           :height            120
@@ -208,7 +210,7 @@
        (when-not processing?
          [react/view {:margin-right 20}
           [components.common/bottom-button
-           {:on-press  #(re-frame/dispatch [:recover.enter-passphrase.ui/next-pressed])
+           {:on-press  #(re-frame/dispatch [::multiaccounts.recover/enter-phrase-next-pressed])
             :label     (i18n/label :t/next)
             :disabled? next-button-disabled?
             :forward?  true}]])]]]))
@@ -270,7 +272,7 @@
            (utils/get-shortened-address pubkey)]]]
         [react/view {:margin-bottom 50}
          [react/touchable-highlight
-          {:on-press #(re-frame/dispatch [:recover.success.ui/re-encrypt-pressed])}
+          {:on-press #(re-frame/dispatch [::multiaccounts.recover/re-encrypt-pressed])}
           [react/view {:background-color colors/blue-light
                        :align-items      :center
                        :justify-content  :center
@@ -291,7 +293,7 @@
       {:transparent? true
        :style        {:margin-top 32}}
       [toolbar/nav-text
-       {:handler #(re-frame/dispatch [:recover.ui/cancel-pressed])
+       {:handler #(re-frame/dispatch [::multiaccounts.recover/cancel-pressed])
         :style   {:padding-left 21}}
        (i18n/label :t/cancel)]
       nil]
@@ -318,7 +320,7 @@
        [react/view components.styles/flex]
        [react/view {:margin-right 20}
         [components.common/bottom-button
-         {:on-press #(re-frame/dispatch [:recover.select-storage.ui/next-pressed])
+         {:on-press #(re-frame/dispatch [::multiaccounts.recover/select-storage-next-pressed])
           :forward? true}]]]]]))
 
 (defview enter-password []
@@ -330,7 +332,7 @@
       {:transparent? true
        :style        {:margin-top 32}}
       [toolbar/nav-text
-       {:handler #(re-frame/dispatch [:recover.ui/cancel-pressed])
+       {:handler #(re-frame/dispatch [::multiaccounts.recover/cancel-pressed])
         :style   {:padding-left 21}}
        (i18n/label :t/cancel)]
       [react/text {:style {:color colors/gray}}
@@ -354,9 +356,9 @@
          (i18n/label :t/password-description)]]
        [react/view {:margin-top 16}
         [text-input/text-input-with-label
-         {:on-change-text    #(re-frame/dispatch [:recover.enter-password.ui/input-changed (security/mask-data %)])
+         {:on-change-text    #(re-frame/dispatch [::multiaccounts.recover/enter-password-input-changed (security/mask-data %)])
           :auto-focus        true
-          :on-submit-editing #(re-frame/dispatch [:recover.enter-password.ui/input-submitted])
+          :on-submit-editing #(re-frame/dispatch [::multiaccounts.recover/enter-password-input-submitted])
           :secure-text-entry true
           :error             (when password-error (i18n/label password-error))
           :placeholder       nil
@@ -378,7 +380,7 @@
        [react/view]
        [react/view {:margin-right 20}
         [components.common/bottom-button
-         {:on-press  #(re-frame/dispatch [:recover.enter-password.ui/next-pressed])
+         {:on-press  #(re-frame/dispatch [::multiaccounts.recover/enter-password-next-pressed])
           :label     (i18n/label :t/next)
           :disabled? (empty? password)
           :forward?  true}]]]]]))
@@ -392,7 +394,7 @@
       {:transparent? true
        :style        {:margin-top 32}}
       [toolbar/nav-text
-       {:handler #(re-frame/dispatch [:recover.ui/cancel-pressed])
+       {:handler #(re-frame/dispatch [::multiaccounts.recover/cancel-pressed])
         :style   {:padding-left 21}}
        (i18n/label :t/cancel)]
       [react/text {:style {:color colors/gray}}
@@ -416,9 +418,9 @@
          (i18n/label :t/password-description)]]
        [react/view {:margin-top 16}
         [text-input/text-input-with-label
-         {:on-change-text    #(re-frame/dispatch [:recover.confirm-password.ui/input-changed %])
+         {:on-change-text    #(re-frame/dispatch [::multiaccounts.recover/confirm-password-input-changed %])
           :auto-focus        true
-          :on-submit-editing #(re-frame/dispatch [:recover.confirm-password.ui/input-submitted])
+          :on-submit-editing #(re-frame/dispatch [::multiaccounts.recover/confirm-password-input-submitted])
           :error             (when password-error (i18n/label password-error))
           :secure-text-entry true
           :placeholder       nil
@@ -440,7 +442,7 @@
        [react/view]
        [react/view {:margin-right 20}
         [components.common/bottom-button
-         {:on-press  #(re-frame/dispatch [:recover.confirm-password.ui/next-pressed])
+         {:on-press  #(re-frame/dispatch [::multiaccounts.recover/confirm-password-next-pressed])
           :label     (i18n/label :t/next)
           :disabled? (empty? password-confirmation)
           :forward?  true}]]]]]))

--- a/test/cljs/status_im/test/multiaccounts/recover/core.cljs
+++ b/test/cljs/status_im/test/multiaccounts/recover/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.test.multiaccounts.recover.core
   (:require [cljs.test :refer-macros [deftest is testing]]
             [status-im.multiaccounts.recover.core :as models]
+            [status-im.multiaccounts.create.core :as multiaccounts.create]
             [clojure.string :as string]
             [status-im.utils.security :as security]
             [status-im.i18n :as i18n]))
@@ -99,22 +100,18 @@
                                        :password-error nil}}}
          (models/validate-password {:db {:multiaccounts/recover {:password "thisisapaswoord"}}}))))
 
-(deftest recover-multiaccount
-  (let [new-cofx (models/recover-multiaccount {:random-guid-generator (constantly "random")
-                                               :db {:multiaccounts/recover
-                                                    {:passphrase "game buzz method pretty zeus fat quit display velvet unveil marine crater"
-                                                     :password   "thisisapaswoord"}}})]
-    (is (= "random" (get-in new-cofx [:db :multiaccounts/new-installation-id])))
-    (is (not (nil? (get new-cofx :multiaccounts.recover/recover-multiaccount))))))
+(deftest store-multiaccount
+  (let [new-cofx (models/store-multiaccount {:db {:multiaccounts/recover
+                                                  {:passphrase "game buzz method pretty zeus fat quit display velvet unveil marine crater"
+                                                   :password   "thisisapaswoord"}}})]
+    (is (::multiaccounts.create/store-multiaccount new-cofx))))
 
 (deftest recover-multiaccount-with-checks
-  (let [new-cofx (models/recover-multiaccount-with-checks {:random-guid-generator (constantly "random")
-                                                           :db {:multiaccounts/recover
+  (let [new-cofx (models/recover-multiaccount-with-checks {:db {:multiaccounts/recover
                                                                 {:passphrase "game buzz method pretty olympic fat quit display velvet unveil marine crater"
                                                                  :password   "thisisapaswoord"}}})]
-    (is (= "random" (get-in new-cofx [:db :multiaccounts/new-installation-id]))))
-  (let [new-cofx (models/recover-multiaccount-with-checks {:random-guid-generator (constantly "random")
-                                                           :db {:multiaccounts/recover
+    (is (::multiaccounts.create/store-multiaccount new-cofx)))
+  (let [new-cofx (models/recover-multiaccount-with-checks {:db {:multiaccounts/recover
                                                                 {:passphrase "game buzz method pretty zeus fat quit display velvet unveil marine crater"
                                                                  :password   "thisisapaswoord"}}})]
     (is (= (i18n/label :recovery-typo-dialog-title) (-> new-cofx :ui/show-confirmation :title)))


### PR DESCRIPTION
fix #8786

- multiaccount recovery wasn't saving the root key properly
- this resulted in the impossibility to add new accounts in the wallet

## Tests

tested for happy path on emulator during dev and android build and OnePlus5T

- import account with seed phrase
- add account in wallet should work now

status: ready