### PR TITLE
[fix 8831] error when unblocking first blocked contact

### DIFF
--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -59,12 +59,12 @@
                      (:contacts/contacts db)
                      public-key)
                     (assoc :last-updated now)
-                    (update :system-tags conj :contact/blocked))
+                    (update :system-tags (fnil conj #{}) :contact/blocked))
         from-one-to-one-chat? (not (get-in db [:chats (:current-chat-id db) :group-chat]))]
     (fx/merge cofx
               {:db (-> db
                        ;; add the contact to blocked contacts
-                       (update :contacts/blocked conj public-key)
+                       (update :contacts/blocked (fnil conj #{}) public-key)
                        ;; update the contact in contacts list
                        (assoc-in [:contacts/contacts public-key] contact)
                        ;; remove the 1-1 chat if it exists


### PR DESCRIPTION
Fix #8831

when unlocking first blocked contact before relogin, an error occurs
this is because the first blocked contact is added to a list and you can't
disj an element from a list
this makes sure the first blocked contact is put into a set

## Testing

Tested on Android realm device

- create account
- join #status
- block first user
- go to profile contacts blocked
- unblock

status: ready