### PR TITLE
Move from componentWillMount to componentDidMount

### DIFF
--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -26,8 +26,8 @@
 (defn app-root [props]
   (let [keyboard-height (subscribe [:keyboard-height])]
     (reagent/create-class
-     {:component-will-mount
-      (fn []
+     {:component-did-mount
+      (fn [this]
         (.addListener (react/keyboard)
                       "keyboardDidShow"
                       (fn [e]
@@ -48,9 +48,7 @@
         (.addEventListener rn-dependencies/react-native-languages "change" on-languages-change)
         (.addEventListener (rn-dependencies/react-native-shake)
                            "ShakeEvent"
-                           on-shake))
-      :component-did-mount
-      (fn [this]
+                           on-shake)
         (dispatch [:set-initial-props (reagent/props this)]))
       :component-will-unmount
       (fn []

--- a/src/status_im/desktop/core.cljs
+++ b/src/status_im/desktop/core.cljs
@@ -22,11 +22,9 @@
 (defn app-root [props]
   (if config/mobile-ui-for-desktop?
     (reagent/create-class
-     {:component-will-mount
-      (fn []
-        (.addEventListener (react/app-state) "change" app-state-change-handler))
-      :component-did-mount
+     {:component-did-mount
       (fn [this]
+        (.addEventListener (react/app-state) "change" app-state-change-handler)
         (re-frame/dispatch [:set-initial-props (reagent/props this)]))
       :component-will-unmount
       (fn []

--- a/src/status_im/ios/core.cljs
+++ b/src/status_im/ios/core.cljs
@@ -25,8 +25,8 @@
 (defn app-root [props]
   (let [keyboard-height (subscribe [:keyboard-height])]
     (reagent/create-class
-     {:component-will-mount
-      (fn []
+     {:component-did-mount
+      (fn [this]
         (.addListener (react/keyboard)
                       "keyboardWillShow"
                       (fn [e]
@@ -44,9 +44,7 @@
         (.addEventListener rn-dependencies/react-native-languages "change" on-languages-change)
         (.addEventListener (rn-dependencies/react-native-shake)
                            "ShakeEvent"
-                           on-shake))
-      :component-did-mount
-      (fn [this]
+                           on-shake)
         (dispatch [:set-initial-props (reagent/props this)]))
       :component-will-unmount
       (fn []

--- a/src/status_im/ui/components/bottom_bar/core.cljs
+++ b/src/status_im/ui/components/bottom_bar/core.cljs
@@ -151,7 +151,7 @@
   (let [keyboard-shown? (reagent/atom false)
         listeners       (atom [])]
     (reagent/create-class
-     {:component-will-mount
+     {:component-did-mount
       (fn []
         (when platform/android?
           (reset!

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -145,7 +145,7 @@
   (letsubs [status-properties [:connectivity/status-properties]
             view-id           [:view-id]
             window-width (reagent/atom 0)]
-    {:component-will-mount
+    {:component-did-mount
      (fn []
        (when anim-translate-y
          (if (:connected? status-properties)

--- a/src/status_im/ui/components/webview_bridge.cljs
+++ b/src/status_im/ui/components/webview_bridge.cljs
@@ -16,7 +16,7 @@
   (if (and config/cached-webviews-enabled? platform/android? dapp?)
     (reagent.core/create-class
      (let [dapp-name-sent? (reagent.core/atom false)]
-       {:component-will-mount
+       {:component-did-mount
         (fn []
           ;; unfortunately it's impossible to pass some initial params
           ;; to view, that's why we have to pass dapp-name to the module

--- a/src/status_im/ui/screens/chat/stickers/views.cljs
+++ b/src/status_im/ui/screens/chat/stickers/views.cljs
@@ -129,7 +129,7 @@
             installed-packs [:stickers/installed-packs-vals]
             bottom-anim-value  (anim/create-value (styles/stickers-panel-height))
             alpha-value        (anim/create-value 0)]
-    {:component-will-mount #(show-panel-anim bottom-anim-value alpha-value)}
+    {:component-did-mount #(show-panel-anim bottom-anim-value alpha-value)}
     [react/animated-view {:style {:background-color :white
                                   :height           (styles/stickers-panel-height)
                                   :transform        [{:translateY bottom-anim-value}]

--- a/src/status_im/ui/screens/hardwallet/setup/views.cljs
+++ b/src/status_im/ui/screens/hardwallet/setup/views.cljs
@@ -375,16 +375,15 @@
   (letsubs [progress-bar (atom nil)
             listener (atom nil)
             card-state [:hardwallet-card-state]]
-    {:component-will-mount (fn []
-                             (when @listener
-                               (.removeListener @listener)))
-     :component-did-mount  (fn []
-                             (reset! listener
-                                     (.addListener (event-emitter)
-                                                   "keycardInstallationProgress"
-                                                   (fn [params]
-                                                     (when @progress-bar
-                                                       (.setNativeProps @progress-bar params))))))}
+    {:component-did-mount (fn []
+                            (when @listener
+                              (.removeListener @listener))
+                            (reset! listener
+                                    (.addListener (event-emitter)
+                                                  "keycardInstallationProgress"
+                                                  (fn [params]
+                                                    (when @progress-bar
+                                                      (.setNativeProps @progress-bar params))))))}
     [react/view styles/loading-view-container
      [react/view styles/center-container
       [react/text {:style styles/center-title-text}

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -104,11 +104,6 @@
     (reagent/create-class
      {:component-did-mount
       (fn []
-        (re-frame/dispatch [:set-two-pane-ui-enabled @two-pane?])
-        (log/debug :main-component-did-mount @view-id)
-        (utils.universal-links/initialize))
-      :component-will-mount
-      (fn []
         (.addEventListener (react/dimensions)
                            "change"
                            (fn [dimensions]
@@ -121,7 +116,10 @@
         (when-not @initial-view-id
           (reset! initial-view-id @view-id))
         (reset-component-on-mount view-id main-component false)
-        (reset-component-on-mount view-id main-component-two-pane true))
+        (reset-component-on-mount view-id main-component-two-pane true)
+        (re-frame/dispatch [:set-two-pane-ui-enabled @two-pane?])
+        (log/debug :main-component-did-mount @view-id)
+        (utils.universal-links/initialize))
       :component-will-unmount
       utils.universal-links/finalize
       :component-will-update

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -69,10 +69,10 @@
   (let [amount-input (atom nil)
         handler #(when (and scroll @scroll @amount-input (.isFocused @amount-input)) (.scrollToEnd @scroll))]
     (reagent/create-class
-     {:component-will-mount (fn [_]
-                              ;;NOTE(goranjovic): keyboardDidShow is for android and keyboardWillShow for ios
-                              (.addListener (react/keyboard)  "keyboardDidShow" handler)
-                              (.addListener (react/keyboard)  "keyboardWillShow" handler))
+     {:component-did-mount (fn [_]
+                             ;;NOTE(goranjovic): keyboardDidShow is for android and keyboardWillShow for ios
+                             (.addListener (react/keyboard)  "keyboardDidShow" handler)
+                             (.addListener (react/keyboard)  "keyboardWillShow" handler))
       :reagent-render       (fn [opts] (render-send-transaction-view
                                         (assoc opts :amount-input amount-input)))})))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR migrates code from using the deprecated `componentWillMount` to using `componentDidMount`. It probably introduces some visual oddities as things are initialized later, but we can either leave that for fixing later or address it in this PR (although help will be needed in that case).

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

I'd appreciate a sanity check, as the replacements I did were mostly mechanical and might not make the most sense.

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

Test navigating across the different screens of the app, namely wallet, connectivity warning, situations where keyboard should show up automatically, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->