### PR TITLE
Comment away react-native-screens

### DIFF
--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -43,7 +43,8 @@
                         (when-not (zero? @keyboard-height)
                           (dispatch [:set :keyboard-height 0]))))
         (.hide react/splash-screen)
-        (.useScreens rn-dependencies/react-native-screens)
+        ;; TODO Temporarily comment away due to current bug https://github.com/kmagiera/react-native-screens/issues/54
+        ;(.useScreens rn-dependencies/react-native-screens)
         (.addEventListener react/app-state "change" app-state-change-handler)
         (.addEventListener rn-dependencies/react-native-languages "change" on-languages-change)
         (.addEventListener rn-dependencies/react-native-shake


### PR DESCRIPTION
Temporarily comments away react-native-screens for Android.

https://github.com/status-im/status-react/issues/8708 might be caused by https://github.com/kmagiera/react-native-screens/issues/54