### PR TITLE
[DO NOT MERGE] Use last-message-timestamp in mainchat

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -146,6 +146,7 @@
                                  :message-groups            {}
                                  :last-message-content      nil
                                  :last-message-content-type nil
+                                 :last-message-timestamp    nil
                                  :unviewed-messages-count   0
                                  :deleted-at-clock-value    last-message-clock-value})}
      (messages-store/delete-messages-by-chat-id chat-id)

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -224,7 +224,7 @@
 (defn- update-last-message [all-chats chat-id]
   (let [{:keys [messages message-groups]}
         (get all-chats chat-id)
-        {:keys [content content-type clock-value]}
+        {:keys [content content-type clock-value timestamp]}
         (->> (chat.db/sort-message-groups message-groups messages)
              last
              second
@@ -234,6 +234,7 @@
     (chat-model/upsert-chat
      {:chat-id                   chat-id
       :last-message-content      content
+      :last-message-timestamp    timestamp
       :last-message-content-type content-type})))
 
 (fx/defn update-last-messages
@@ -348,6 +349,7 @@
               (chat-model/upsert-chat
                {:chat-id                   chat-id
                 :timestamp                 now
+                :last-message-timestamp    (:timestamp message)
                 :last-message-content      (:content message)
                 :last-message-content-type (:content-type message)
                 :last-clock-value          (:clock-value message)})

--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -22,6 +22,7 @@
    {:keys [chat-id
            unviewed-messages-count
            last-message-content
+           last-message-timestamp
            last-message-content-type]}]
   (let [removed-messages-ids (keep
                               (fn [[message-id {:keys [from]}]]
@@ -39,6 +40,7 @@
                           assoc
                           :unviewed-messages-count unviewed-messages-count
                           :last-message-content last-message-content
+                          :last-message-timestamp last-message-timestamp
                           :last-message-content-type last-message-content-type))]
     (fx/merge cofx
               {:db db}

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -117,6 +117,7 @@
                                 :unviewed-messages-count :unviewedMessagesCount
                                 :last-message-content :lastMessageContent
                                 :last-message-content-type :lastMessageContentType
+                                :last-message-timestamp :lastMessageTimestamp
                                 :deleted-at-clock-value :deletedAtClockValue
                                 :is-active :active
                                 :last-clock-value :lastClockValue})
@@ -135,6 +136,7 @@
                                 :unviewedMessagesCount :unviewed-messages-count
                                 :lastMessageContent :last-message-content
                                 :lastMessageContentType :last-message-content-type
+                                :lastMessageTimestamp :last-message-timestamp
                                 :deletedAtClockValue :deleted-at-clock-value
                                 :active :is-active
                                 :lastClockValue :last-clock-value})

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -25,13 +25,14 @@
            color public? public-key
            timestamp chat-name
            last-message-content
+           last-message-timestamp
            last-message-content-type]
     :as chat-item}]
   (views/letsubs [photo-path              [:contacts/chat-photo chat-id]
                   unviewed-messages-count [:chats/unviewed-messages-count chat-id]
                   current-chat-id         [:chats/current-chat-id]]
     (let [last-message {:content      last-message-content
-                        :timestamp    timestamp
+                        :timestamp    (if (pos? last-message-timestamp) last-message-timestamp timestamp)
                         :content-type last-message-content-type}
           name (or chat-name
                    (gfycat/generate-gfy public-key))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -91,6 +91,7 @@
                 name color online
                 group-chat public?
                 public-key contact
+                last-message-timestamp
                 timestamp
                 last-message-content
                 last-message-content-type]} home-item
@@ -110,7 +111,7 @@
        [react/view styles/item-upper-container
         [chat-list-item-name truncated-chat-name group-chat public? public-key]
         [react/view styles/message-status-container
-         [message-timestamp timestamp]]]
+         [message-timestamp (if (pos? last-message-timestamp) last-message-timestamp timestamp)]]]
        [react/view styles/item-lower-container
         (let [{:keys [tribute-status tribute-label]} (:tribute-to-talk contact)]
           (if (not (#{:require :pending} tribute-status))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,6 +3,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "develop",
-    "commit-sha1": "b8ea79a3f005116ce1496a75a26e107b9e6c9c10",
-    "src-sha256": "0xxvh9sxn1rh7ll2lyirqb1zjm2szbi759xnhc3rz7fk1j4srmvz"
+    "commit-sha1": "1a47893e75bccc99af3ce4b2c7fbedf6481dae6a",
+    "src-sha256": "1mcdm48bs9wz2nndicss3kia0rm4zk861a7qv6qaxjw12y6n8man"
 }


### PR DESCRIPTION
Fixes: #7270 

We use the timestamp of the last message in the chat preview.
In case there's no message, the old timestamp will be displayed (last
time the chat has been updated).

### Testing 
in the chat preview it should display the timestamp of the last message if any, otherwise the timestamp as before. Ordering is unchanged, so last updated chat first.

status: ready