### PR TITLE
Show group name in group-chat header

### DIFF
--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -302,7 +302,7 @@
            :default-chat-icon-text style/intro-header-icon-text
            :size                   120}]]
         ;; Chat title section
-        [react/text {:style style/intro-header-chat-name} intro-name]
+        [react/text {:style style/intro-header-chat-name} (if group-chat chat-name intro-name)]
         ;; Description section
         (if group-chat
           [group-chat-description-container chat]


### PR DESCRIPTION
Fixes #8660

### Summary

Checks if a chat is a group chat when creating the header, and sets the text to the name of the chat accordingly.


### Additional
A quick Dev setup guide in the `Readme.md` would be much appreciated. 

Had to resort to AVD in the end. The real device just wouldnt connect back to the REPL :(