### PR TITLE
fix subtitle in list items

### DIFF
--- a/src/status_im/ui/components/list_item/views.cljs
+++ b/src/status_im/ui/components/list_item/views.cljs
@@ -134,12 +134,12 @@
    (when title-row-accessory
      [react/view styles/title-row-accessory-container title-row-accessory])])
 
-(defn subtitle-row [{:keys [subtitle subtitle-max-lines subtitle-row-accessory]}
-                    icon? theme]
+(defn subtitle-row
+  [subtitle-row-elements icon? theme]
   (let [subtitle-row-accessory-width (reagent/atom 0)]
     (reagent/create-class
-     {:render
-      (fn []
+     {:reagent-render
+      (fn [{:keys [subtitle subtitle-max-lines subtitle-row-accessory]} icon? theme]
         [react/view styles/subtitle-row-container
          (cond
            (or (string? subtitle) (keyword? subtitle) (number? subtitle))


### PR DESCRIPTION
arguments were missing in reagent-render args so component wasn't reacting to changes

## Testing

Tested on Android emulator
By default I was always seeing `Available only on Mainnet and Testnet` on ENS username item in profile, now I see the proper subtitle

status: ready