### PR TITLE
[fix #8813] status-go version is shown as N/A

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -94,10 +94,8 @@
 
 (fx/defn initialize-web3-client-version
   {:events [::initialize-web3-client-version]}
-  [{:keys [db]} resp]
-  (if-let [node-version (second (re-find #"StatusIM/v(.*)/.*/.*" resp))]
-    {:db (assoc db :web3-node-version node-version)}
-    (log/warn (str "unexpected web3 version format: " "'" resp "'"))))
+  [{:keys [db]} node-version]
+  {:db (assoc db :web3-node-version node-version)})
 
 (fx/defn save-user-password
   [cofx address password]

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -285,7 +285,7 @@
    (get search :filter)))
 
 (defn- node-version [web3-node-version]
-  (str "status-go v" (or web3-node-version "N/A") ""))
+  (or web3-node-version "N/A"))
 
 (def app-short-version
   (let [version (if platform/desktop? build/version build/build-no)]

--- a/src/status_im/ui/screens/about_app/views.cljs
+++ b/src/status_im/ui/screens/about_app/views.cljs
@@ -24,7 +24,7 @@
      {:type                :small
       :title               (i18n/label :t/version)
       :accessibility-label :version
-      :accessories         [(str app-version "; " node-version)]}]]])
+      :accessories         [(str app-version ";\n" node-version)]}]]])
 
 (views/defview about-app []
   (views/letsubs [app-version  [:get-app-short-version]


### PR DESCRIPTION
fix #8813

### Testing notes
Tested on emulator, the version is partially shown (not enough space) but can be copied

status: ready