### PR TITLE
Move gaps to status-go

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -443,7 +443,6 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             @Override
             public void run() {
                   String result = Statusgo.loginWithKeycard(whisperPrivateKey, encryptionPublicKey, configJSON);
-
                   callback.invoke(result);
             }
         };

--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -84,8 +84,7 @@
 
 (fx/defn messages-loaded
   "Loads more messages for current chat"
-  {:events [::messages-loaded]
-   :interceptors [(re-frame/inject-cofx :data-store/all-gaps)]}
+  {:events [::messages-loaded]}
   [{{:keys [current-chat-id] :as db} :db :as cofx}
    chat-id
    {:keys [cursor messages]}]
@@ -113,11 +112,10 @@
                          (assoc-in [:chats current-chat-id :cursor] cursor)
                          (assoc-in [:chats current-chat-id :all-loaded?]
                                    (empty? cursor)))}
-                (mailserver/load-gaps current-chat-id)
                 (group-chat-messages current-chat-id new-messages)
                 (chat-model/mark-messages-seen current-chat-id)))))
 
-(defn load-more-messages
+(fx/defn load-more-messages
   [{:keys [db]}]
   (when-let [current-chat-id (:current-chat-id db)]
     (when-not (get-in db [:chats current-chat-id :all-loaded?])

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -63,6 +63,10 @@
    "browsers_getBrowsers" {}
    "browsers_addBrowser" {}
    "browsers_deleteBrowser" {}
+   "mailservers_getMailserverRequestGaps" {}
+   "mailservers_addMailserverRequestGaps" {}
+   "mailservers_deleteMailserverRequestGaps" {}
+   "mailservers_deleteMailserverRequestGapsByChatID" {}
    "permissions_addDappPermissions" {}
    "permissions_getDappPermissions" {}
    "permissions_deleteDappPermissions" {}

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -547,7 +547,10 @@
 (handlers/register-handler-fx
  :chat.ui/load-more-messages
  (fn [cofx _]
-   (chat.loading/load-more-messages cofx)))
+   (let [chat-id (get-in cofx [:db :current-chat-id])]
+     (fx/merge cofx
+               (chat.loading/load-more-messages)
+               (mailserver/load-gaps-fx chat-id)))))
 
 (handlers/register-handler-fx
  :chat.ui/start-chat

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -119,6 +119,7 @@
       (assoc :WalletConfig {:Enabled true}
              :BrowsersConfig {:Enabled true}
              :PermissionsConfig {:Enabled true}
+             :MailserversConfig {:Enabled true}
              :WhisperConfig           {:Enabled true
                                        :LightClient true
                                        :MinimumPoW 0.001

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1596,11 +1596,11 @@
 (re-frame/reg-sub
  :mailserver/connected?
  :<- [:mailserver/state]
- :<- [:network-status]
- (fn [[mail-state network-status]]
-   (let [connected? (= :connected mail-state)
-         online?    (= :online network-status)]
-     (and connected? online?))))
+ :<- [:disconnected?]
+ (fn [[mail-state disconnected?]]
+   (let [mailserver-connected? (= :connected mail-state)]
+     (and mailserver-connected?
+          (not disconnected?)))))
 
 (re-frame/reg-sub
  :mailserver/preferred-id

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,6 +3,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "develop",
-    "commit-sha1": "42199e682fdf90a82e59451a58b9ae07749a8e12",
-    "src-sha256": "11ykhcx057l6s0zg5cansv5x8728k0j86ygsj12m8ax86xjkdzyc"
+    "commit-sha1": "b27779aa4e202a13a387897332dea377bf9b6552",
+    "src-sha256": "0yab9pjsg9583b7x89ywbbyxxw4fy03dyw260ybjb9g26z166064"
 }

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -116,7 +116,7 @@
     (testing "it adds the relevant transactions for realm"
       (let [actual (chat/remove-chat cofx chat-id)]
         (is (:data-store/tx actual))
-        (is (= 2 (count (:data-store/tx actual))))))))
+        (is (= 1 (count (:data-store/tx actual))))))))
 
 (deftest multi-user-chat?
   (let [chat-id "1"]


### PR DESCRIPTION
Fixes: #8869
This commit moves gaps to status-go.

I had to disable some methods in keycard as a breaking change commit has been merged in status-go without corresponding fix being merged in status-react.

### Testing
- gaps in 1-to-1/public/group chats

status: ready