### PR TITLE
fix profile photo icon - no border in non-identicon photo

### DIFF
--- a/src/status_im/ui/screens/chat/photos.cljs
+++ b/src/status_im/ui/screens/chat/photos.cljs
@@ -2,18 +2,21 @@
   (:require [clojure.string :as string]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.chat.styles.photos :as style]
+            [status-im.ui.screens.profile.db :as profile.db]
             [status-im.utils.identicon :as identicon]
             [status-im.utils.image :as utils.image])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn photo [photo-path {:keys [size
                                 accessibility-label]}]
-  [react/view {:style (style/photo-container size)}
-   [react/image {:source              (utils.image/source photo-path)
-                 :style               (style/photo size)
-                 :resize-mode         :cover
-                 :accessibility-label (or accessibility-label :chat-icon)}]
-   [react/view {:style (style/photo-border size)}]])
+  (let [identicon? (when photo-path (profile.db/base64-png? photo-path))]
+    [react/view {:style (style/photo-container size)}
+     [react/image {:source              (utils.image/source photo-path)
+                   :style               (style/photo size)
+                   :resize-mode         :cover
+                   :accessibility-label (or accessibility-label :chat-icon)}]
+     (when identicon?
+       [react/view {:style (style/photo-border size)}])]))
 
 (defview member-photo [from & [size]]
   (letsubs [photo-path [:chats/photo-path from]]

--- a/src/status_im/ui/screens/profile/db.cljs
+++ b/src/status_im/ui/screens/profile/db.cljs
@@ -9,9 +9,15 @@
             [(string/blank? username)
              (string/includes? username chat.constants/command-char)])))
 
+(defn base64-png? [photo-path]
+  (string/starts-with? photo-path "data:image/png;base64,"))
+
+(defn base64-jpeg? [photo-path]
+  (string/starts-with? photo-path "data:image/jpeg;base64,"))
+
 (defn base64-encoded-image-path? [photo-path]
-  (or (string/starts-with? photo-path "data:image/jpeg;base64,")
-      (string/starts-with? photo-path "data:image/png;base64,")))
+  (or (base64-png? photo-path)
+      (base64-jpeg? photo-path)))
 
 (spec/def :profile/name correct-name?)
 (spec/def :profile/status (spec/nilable string?))


### PR DESCRIPTION
Small nitpick
- while fixing chat-list list-items I noticed in figma there was no border in profile pic with user chosen photo, but only on identicon
- visible in photos with light background
- seemed like it was done for a reason, like maybe allowing for users to get creative with borderless profile photo, maybe to stand out from the rest

- takes advantage of the fact that in current implementation identicons are saved as PNG and user chosen photos are saved as JPEG

Status: ready