### PR TITLE
integrate status-go mailserver and mailserver-topics apis

### DIFF
--- a/src/status_im/data_store/core.cljs
+++ b/src/status_im/data_store/core.cljs
@@ -201,10 +201,11 @@
 
 (fx/defn handle-change-multiaccount-success
   {:events [::multiaccount-change-success]
-   :interceptors [(re-frame/inject-cofx :data-store/get-all-mailservers)
-                  (re-frame/inject-cofx :data-store/mailserver-topics)]}
-  [cofx]
-  (protocol/initialize-protocol cofx))
+   :interceptors [(re-frame/inject-cofx :data-store/mailserver-topics)
+                  (re-frame/inject-cofx :data-store/all-chat-requests-ranges)]}
+  [{:data-store/keys [mailserver-topics mailserver-ranges] :as cofx}]
+  (protocol/initialize-protocol cofx {:mailserver-topics mailserver-topics
+                                      :mailserver-ranges mailserver-ranges}))
 
 (defn change-multiaccount!
   [address password create-database-if-not-exist?]

--- a/src/status_im/data_store/core.cljs
+++ b/src/status_im/data_store/core.cljs
@@ -1,21 +1,17 @@
 (ns status-im.data-store.core
   (:require [cljs.core.async :as async]
             [re-frame.core :as re-frame]
-            [taoensso.timbre :as log]
             [status-im.data-store.realm.core :as realm]
-            [status-im.utils.keychain.core :as keychain]
-            [status-im.utils.handlers :as handlers]
-            [status-im.utils.security :as security]
-            [status-im.native-module.core :as status]
-            [status-im.multiaccounts.model :as multiaccounts.model]
-            [status-im.utils.types :as types]
             [status-im.i18n :as i18n]
-            status-im.data-store.chats
-            status-im.data-store.messages
-            status-im.data-store.contacts
-            status-im.data-store.mailservers
+            [status-im.multiaccounts.model :as multiaccounts.model]
+            [status-im.native-module.core :as status]
+            [status-im.protocol.core :as protocol]
             [status-im.utils.fx :as fx]
-            [status-im.protocol.core :as protocol]))
+            [status-im.utils.handlers :as handlers]
+            [status-im.utils.keychain.core :as keychain]
+            [status-im.utils.security :as security]
+            [status-im.utils.types :as types]
+            [taoensso.timbre :as log]))
 
 (fx/defn multiaccount-db-removed
   {:events [::multiaccount-db-removed]}
@@ -201,11 +197,9 @@
 
 (fx/defn handle-change-multiaccount-success
   {:events [::multiaccount-change-success]
-   :interceptors [(re-frame/inject-cofx :data-store/mailserver-topics)
-                  (re-frame/inject-cofx :data-store/all-chat-requests-ranges)]}
-  [{:data-store/keys [mailserver-topics mailserver-ranges] :as cofx}]
-  (protocol/initialize-protocol cofx {:mailserver-topics mailserver-topics
-                                      :mailserver-ranges mailserver-ranges}))
+   :interceptors [(re-frame/inject-cofx :data-store/all-chat-requests-ranges)]}
+  [{:data-store/keys [mailserver-ranges] :as cofx}]
+  (protocol/initialize-protocol cofx {:mailserver-ranges mailserver-ranges}))
 
 (defn change-multiaccount!
   [address password create-database-if-not-exist?]

--- a/src/status_im/data_store/mailservers.cljs
+++ b/src/status_im/data_store/mailservers.cljs
@@ -1,6 +1,5 @@
 (ns status-im.data-store.mailservers
-  (:require [cljs.tools.reader.edn :as edn]
-            [re-frame.core :as re-frame]
+  (:require [re-frame.core :as re-frame]
             [status-im.data-store.realm.core :as core]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.utils.fx :as fx]
@@ -43,45 +42,6 @@
                      :params [chat-id]
                      :on-success #(log/info "deleted gaps successfully")
                      :on-failure #(log/error "failed to delete gap" %)}]})
-
-(defn deserialize-mailserver-topic
-  [serialized-mailserver-topic]
-  (-> serialized-mailserver-topic
-      (update :chat-ids edn/read-string)))
-
-(re-frame/reg-cofx
- :data-store/mailserver-topics
- (fn [cofx _]
-   (assoc cofx
-          :data-store/mailserver-topics
-          (reduce (fn [acc {:keys [topic] :as mailserver-topic}]
-                    (assoc acc topic (deserialize-mailserver-topic mailserver-topic)))
-                  {}
-                  (-> @core/account-realm
-                      (core/get-all :mailserver-topic)
-                      (core/all-clj :mailserver-topic))))))
-
-(defn save-mailserver-topic-tx
-  "Returns tx function for saving mailserver topic"
-  [{:keys [topic mailserver-topic]}]
-  (fn [realm]
-    (log/debug "saving mailserver-topic:" topic mailserver-topic)
-    (core/create realm
-                 :mailserver-topic
-                 (-> mailserver-topic
-                     (assoc :topic topic)
-                     (update :chat-ids pr-str))
-                 true)))
-
-(defn delete-mailserver-topic-tx
-  "Returns tx function for deleting mailserver topic"
-  [topic]
-  (fn [realm]
-    (log/debug "deleting mailserver-topic:" topic)
-    (let [mailserver-topic (.objectForPrimaryKey realm
-                                                 "mailserver-topic"
-                                                 topic)]
-      (core/delete realm mailserver-topic))))
 
 (defn save-chat-requests-range
   [chat-requests-range]

--- a/src/status_im/data_store/mailservers.cljs
+++ b/src/status_im/data_store/mailservers.cljs
@@ -1,27 +1,19 @@
 (ns status-im.data-store.mailservers
   (:require [cljs.tools.reader.edn :as edn]
             [re-frame.core :as re-frame]
-            [taoensso.timbre :as log]
-            [status-im.utils.fx :as fx]
+            [status-im.data-store.realm.core :as core]
             [status-im.ethereum.json-rpc :as json-rpc]
-            [status-im.data-store.realm.core :as core]))
+            [status-im.utils.fx :as fx]
+            [taoensso.timbre :as log]))
 
-(re-frame/reg-cofx
- :data-store/get-all-mailservers
- (fn [cofx _]
-   (assoc cofx :data-store/mailservers (mapv #(-> %
-                                                  (update :id keyword)
-                                                  (update :fleet keyword))
-                                             (-> @core/account-realm
-                                                 (core/get-all :mailserver)
-                                                 (core/all-clj :mailserver))))))
-
-(defn mailserver-request-gaps->rpc [{:keys [chat-id] :as gap}]
+(defn mailserver-request-gaps->rpc
+  [{:keys [chat-id] :as gap}]
   (-> gap
       (assoc :chatId chat-id)
       (dissoc :chat-id)))
 
-(fx/defn load-gaps [cofx chat-id success-fn]
+(fx/defn load-gaps
+  [cofx chat-id success-fn]
   {::json-rpc/call [{:method "mailservers_getMailserverRequestGaps"
                      :params [chat-id]
                      :on-success #(let [indexed-gaps (reduce (fn [acc {:keys [id] :as g}]
@@ -31,41 +23,29 @@
                                     (success-fn chat-id indexed-gaps))
                      :on-failure #(log/error "failed to fetch gaps" %)}]})
 
-(fx/defn save-gaps [cofx gaps]
+(fx/defn save-gaps
+  [cofx gaps]
   {::json-rpc/call [{:method "mailservers_addMailserverRequestGaps"
                      :params [(map mailserver-request-gaps->rpc gaps)]
                      :on-success #(log/info "saved gaps successfully")
                      :on-failure #(log/error "failed to save gap" %)}]})
 
-(fx/defn delete-gaps [cofx ids]
+(fx/defn delete-gaps
+  [cofx ids]
   {::json-rpc/call [{:method "mailservers_deleteMailserverRequestGaps"
                      :params [ids]
                      :on-success #(log/info "deleted gaps successfully")
                      :on-failure #(log/error "failed to delete gap" %)}]})
 
-(fx/defn delete-gaps-by-chat-id [cofx chat-id]
+(fx/defn delete-gaps-by-chat-id
+  [cofx chat-id]
   {::json-rpc/call [{:method "mailservers_deleteMailserverRequestGapsByChatID"
                      :params [chat-id]
                      :on-success #(log/info "deleted gaps successfully")
                      :on-failure #(log/error "failed to delete gap" %)}]})
 
-(defn save-tx
-  "Returns tx function for saving a mailserver"
-  [{:keys [id] :as mailserver}]
-  (fn [realm]
-    (core/create realm
-                 :mailserver
-                 mailserver
-                 true)))
-
-(defn delete-tx
-  "Returns tx function for deleting a mailserver"
-  [id]
-  (fn [realm]
-    (core/delete realm
-                 (core/get-by-field realm :mailserver :id (name id)))))
-
-(defn deserialize-mailserver-topic [serialized-mailserver-topic]
+(defn deserialize-mailserver-topic
+  [serialized-mailserver-topic]
   (-> serialized-mailserver-topic
       (update :chat-ids edn/read-string)))
 
@@ -109,15 +89,16 @@
     (log/debug "saving ranges" chat-requests-range)
     (core/create realm :chat-requests-range chat-requests-range true)))
 
-(re-frame/reg-fx
- ::all-chat-requests-ranges
- (fn [on-success]
-   (on-success (reduce (fn [acc {:keys [chat-id] :as range}]
-                         (assoc acc chat-id range))
-                       {}
-                       (-> @core/account-realm
-                           (core/get-all :chat-requests-range)
-                           (core/all-clj :chat-requests-range))))))
+(re-frame/reg-cofx
+ :data-store/all-chat-requests-ranges
+ (fn [cofx _]
+   (assoc cofx :data-store/mailserver-ranges
+          (reduce (fn [acc {:keys [chat-id] :as range}]
+                    (assoc acc chat-id range))
+                  {}
+                  (-> @core/account-realm
+                      (core/get-all :chat-requests-range)
+                      (core/all-clj :chat-requests-range))))))
 
 (defn delete-range
   [chat-id]

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -75,7 +75,10 @@
    "settings_getConfigs" {}
    "settings_saveNodeConfig" {}
    "accounts_getAccounts" {}
-   "accounts_saveAccounts" {}})
+   "accounts_saveAccounts" {}
+   "mailservers_addMailserver" {}
+   "mailservers_getMailservers" {}
+   "mailservers_deleteMailserver" {}})
 
 (defn call
   [{:keys [method params on-success on-error] :as p}]

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -78,7 +78,10 @@
    "accounts_saveAccounts" {}
    "mailservers_addMailserver" {}
    "mailservers_getMailservers" {}
-   "mailservers_deleteMailserver" {}})
+   "mailservers_deleteMailserver" {}
+   "mailservers_addMailserverTopic" {}
+   "mailservers_getMailserverTopics" {}
+   "mailservers_deleteMailserverTopic" {}})
 
 (defn call
   [{:keys [method params on-success on-error] :as p}]

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -734,11 +734,13 @@
                                                       gaps)))
                                           (update :mailserver/planned-gap-requests
                                                   dissoc gap))
-                       :data-store/tx (mapv (fn [[topic mailserver-topic]]
-                                              (data-store.mailservers/save-mailserver-topic-tx
-                                               {:topic            topic
-                                                :mailserver-topic mailserver-topic}))
-                                            mailserver-topics)}
+                       ::json-rpc/call
+                       (mapv (fn [[topic mailserver-topic]]
+                               {:method "mailservers_addMailserverTopic"
+                                :params [(assoc mailserver-topic :topic topic)]
+                                :on-success #(log/debug "added mailserver-topic successfully")
+                                :on-failure #(log/error "failed to delete mailserver topic" %)})
+                             mailserver-topics)}
                       (process-next-messages-request))))))))
 
 (fx/defn retry-next-messages-request

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -8,12 +8,12 @@
             [status-im.contact.core :as contact]
             [status-im.data-store.core :as data-store]
             [status-im.ethereum.json-rpc :as json-rpc]
-            [status-im.protocol.core :as protocol]
             [status-im.ethereum.transactions.core :as transactions]
             [status-im.fleet.core :as fleet]
             [status-im.i18n :as i18n]
             [status-im.native-module.core :as status]
             [status-im.notifications.core :as notifications]
+            [status-im.protocol.core :as protocol]
             [status-im.stickers.core :as stickers]
             [status-im.ui.screens.mobile-network-settings.events :as mobile-network]
             [status-im.ui.screens.navigation :as navigation]
@@ -27,8 +27,7 @@
             [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.utils :as utils]
             [status-im.wallet.core :as wallet]
-            [taoensso.timbre :as log]
-            [status-im.mailserver.core :as mailserver]))
+            [taoensso.timbre :as log]))
 
 (def rpc-endpoint "https://goerli.infura.io/v3/f315575765b14720b32382a61a89341a")
 (def contract-address "0xfbf4c8e2B41fAfF8c616a0E49Fb4365a5355Ffaf")
@@ -162,7 +161,9 @@
               {:db (assoc db :chats/loading? true)
                ::data-store/change-multiaccount [address password]
                ::json-rpc/call
-               [{:method "browsers_getBrowsers"
+               [{:method "mailservers_getMailserverTopics"
+                 :on-success #(re-frame/dispatch [::protocol/initialize-protocol {:mailserver-topics (or % {})}])}
+                {:method "browsers_getBrowsers"
                  :on-success #(re-frame/dispatch [::initialize-browsers %])}
                 {:method "permissions_getDappPermissions"
                  :on-success #(re-frame/dispatch [::initialize-dapp-permissions %])}

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -3,7 +3,6 @@
             [status-im.mailserver.core :as mailserver]
             [status-im.node.core :as node]
             [status-im.transport.core :as transport]
-            [status-im.tribute-to-talk.core :as tribute-to-talk]
             [status-im.utils.fx :as fx]))
 
 ;;TODO move this logic to status-go
@@ -48,6 +47,18 @@
           db
           custom-mailservers))
 
+(defn add-mailserver-topics
+  [db mailserver-topics]
+  (assoc db
+         :mailserver/topics
+         (reduce (fn [acc {:keys [topic chat-ids]
+                           :as mailserver-topic}]
+                   (assoc acc topic
+                          (update mailserver-topic :chat-ids
+                                  #(into #{} %))))
+                 {}
+                 mailserver-topics)))
+
 (fx/defn initialize-protocol
   {:events [::initialize-protocol]}
   [{:keys [db] :as cofx}
@@ -68,7 +79,7 @@
                      mailserver-ranges
                      (assoc :mailserver/ranges mailserver-ranges)
                      mailserver-topics
-                     (assoc :mailserver/topics mailserver-topics)
+                     (add-mailserver-topics mailserver-topics)
                      mailservers
                      (add-custom-mailservers mailservers)
                      initialization-complete?

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -34,13 +34,48 @@
             (update-sync-state error sync)
             (node/update-sync-state error sync)))
 
+(defn add-custom-mailservers
+  [db custom-mailservers]
+  (reduce (fn [db {:keys [fleet] :as mailserver}]
+            (let [{:keys [id] :as mailserver}
+                  (-> mailserver
+                      (update :id keyword)
+                      (dissoc :fleet)
+                      (assoc :user-defined true))]
+              (assoc-in db
+                        [:mailserver/mailservers (keyword fleet) id]
+                        mailserver)))
+          db
+          custom-mailservers))
+
 (fx/defn initialize-protocol
-  [{:data-store/keys [mailserver-topics mailservers] :keys [db] :as cofx}]
-  (fx/merge cofx
-            {:db (assoc db
-                        :rpc-url constants/ethereum-rpc-url
-                        :mailserver/topics mailserver-topics)}
-            (tribute-to-talk/init)
-            (mailserver/initialize-ranges)
-            (mailserver/initialize-mailserver mailservers)
-            (transport/init-whisper)))
+  {:events [::initialize-protocol]}
+  [{:keys [db] :as cofx}
+   {:keys [mailserver-ranges mailserver-topics mailservers] :as data}]
+  ;; NOTE: we need to wait for `:mailservers` `:mailserver-ranges` and
+  ;; `:mailserver-topics` before we can proceed to init whisper
+  ;; since those are populated by separate events, we check here
+  ;; that everything has been initialized before moving forward
+  (let [initialization-protocol (apply conj (get db :initialization-protocol #{})
+                                       (keys data))
+        initialization-complete? (= initialization-protocol
+                                    #{:mailservers
+                                      :mailserver-ranges
+                                      :mailserver-topics
+                                      :default-mailserver})]
+    (fx/merge cofx
+              {:db (cond-> db
+                     mailserver-ranges
+                     (assoc :mailserver/ranges mailserver-ranges)
+                     mailserver-topics
+                     (assoc :mailserver/topics mailserver-topics)
+                     mailservers
+                     (add-custom-mailservers mailservers)
+                     initialization-complete?
+                     (assoc :rpc-url constants/ethereum-rpc-url)
+                     initialization-complete?
+                     (dissoc :initialization-protocol)
+                     (not initialization-complete?)
+                     (assoc :initialization-protocol initialization-protocol))}
+              (when initialization-complete?
+                (transport/init-whisper)))))

--- a/src/status_im/transport/core.cljs
+++ b/src/status_im/transport/core.cljs
@@ -42,6 +42,7 @@
             (fetch-node-info-fx)
             (pairing/init)
             (publisher/start-fx)
+            (mailserver/initialize-mailserver)
             (mailserver/connect-to-mailserver)))
 
 (fx/defn stop-whisper

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,6 +3,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "develop",
-    "commit-sha1": "b27779aa4e202a13a387897332dea377bf9b6552",
-    "src-sha256": "0yab9pjsg9583b7x89ywbbyxxw4fy03dyw260ybjb9g26z166064"
+    "commit-sha1": "9df64efe2c3d88596ab5cfe358741ed8f9be86b7",
+    "src-sha256": "0yc76v2kcamxjv7g7b9x4ywmbzch4azzb4sj49rhcdkg0wz8qi5j"
 }

--- a/test/cljs/status_im/test/mailserver/core.cljs
+++ b/test/cljs/status_im/test/mailserver/core.cljs
@@ -1,5 +1,6 @@
 (ns status-im.test.mailserver.core
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.transport.utils :as utils]
             [status-im.mailserver.core :as mailserver]
             [status-im.mailserver.constants :as constants]
@@ -257,7 +258,7 @@
       (testing "it removes the mailserver from the list"
         (is (not (mailserver/fetch actual "a"))))
       (testing "it stores it in the db"
-        (is (= 1 (count (:data-store/tx actual)))))))
+        (is (= 1 (count (::json-rpc/call actual)))))))
   (testing "the mailserver is not user-defined"
     (let [cofx {:random-id-generator (constantly "random-id")
                 :db {:mailserver/mailservers {:eth.beta {"a" {:id      "a"
@@ -295,7 +296,7 @@
         (is (= [:navigate-back]
                (:dispatch actual))))
       (testing "it stores it in the db"
-        (is (= 1 (count (:data-store/tx actual)))))))
+        (is (= 1 (count (::json-rpc/call actual)))))))
   (testing "existing mailserver"
     (let [cofx {:random-id-generator (constantly "random-id")
                 :db {:mailserver.edit/mailserver {:id   {:value  :a}
@@ -317,12 +318,7 @@
                                :user-defined true}}}
                (get-in actual [:db :mailserver/mailservers]))))
       (testing "it stores it in the db"
-        (is (= 1 (count (:data-store/tx actual)))))
-      (testing "it logs the user out if connected to the current mailserver"
-        (let [actual (mailserver/upsert (assoc-in cofx
-                                                  [:db :mailserver/current-id] :a))]
-          (is (= [:multiaccounts.logout.ui/logout-confirmed]
-                 (-> actual :data-store/tx first :success-event))))))))
+        (is (= 1 (count (::json-rpc/call actual))))))))
 
 (defn cofx-fixtures [sym-key registered-peer?]
   {:db {:mailserver/state :connected

--- a/test/cljs/status_im/test/sign_in/flow.cljs
+++ b/test/cljs/status_im/test/sign_in/flow.cljs
@@ -3,11 +3,9 @@
   flow has been changed. Such changes should be reflected in both these tests
   and documents which describe the whole \"sign in\" flow."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [status-im.ethereum.json-rpc :as json-rpc]
-            [status-im.events :as events]
             [status-im.data-store.core :as data-store]
+            [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.multiaccounts.login.core :as login.core]
-            [status-im.signals.core :as signals]
             [status-im.test.sign-in.data :as data]))
 
 (deftest on-password-input-submitted
@@ -29,9 +27,7 @@
     (let [db           {:multiaccounts/login  {:address  "address"
                                                :password "password"}
                         :multiaccount data/multiaccount}
-          cofx         {:db                           db
-                        :data-store/mailservers       []
-                        :data-store/mailserver-topics data/topics}
+          cofx         {:db                           db}
           login-result "{\"error\":\"\"}"
           efx          (login.core/multiaccount-login-success cofx)
           new-db       (:db efx)

--- a/test/cljs/status_im/test/transport/core.cljs
+++ b/test/cljs/status_im/test/transport/core.cljs
@@ -8,42 +8,40 @@
 (deftest init-whisper
   (let [cofx {:db {:multiaccount {:public-key "1"}}}]
     (testing "custom mailservers"
-      (let [ms-1            {:id "1"
+      (let [ms-1            {:id :a
                              :fleet :eth.beta
                              :name "name-1"
                              :address "address-1"
                              :password "password-1"}
-            ms-2            {:id "2"
+            ms-2            {:id :b
                              :fleet :eth.beta
                              :name "name-2"
                              :address "address-2"
                              :password "password-2"}
-            ms-3            {:id "3"
+            ms-3            {:id :c
                              :fleet :eth.test
                              :name "name-3"
                              :address "address-3"
                              :password "password-3"}
-            expected-mailservers {:eth.beta {"1" (-> ms-1
-                                                     (dissoc :fleet)
-                                                     (assoc :user-defined true))
-                                             "2" (-> ms-2
-                                                     (dissoc ms-2 :fleet)
-                                                     (assoc :user-defined true))}
-                                  :eth.test {"3" (-> ms-3
-                                                     (dissoc :fleet)
-                                                     (assoc :user-defined true))}}
-            cofx-with-ms    (assoc cofx
-                                   :data-store/mailservers
-                                   [ms-1
-                                    ms-2
-                                    ms-3])]
+            expected-mailservers {:eth.beta {:a (-> ms-1
+                                                    (dissoc :fleet)
+                                                    (assoc :user-defined true))
+                                             :b (-> ms-2
+                                                    (dissoc ms-2 :fleet)
+                                                    (assoc :user-defined true))}
+                                  :eth.test {:c (-> ms-3
+                                                    (dissoc :fleet)
+                                                    (assoc :user-defined true))}}]
         (is (= expected-mailservers
                (-> (get-in
-                    (protocol/initialize-protocol cofx-with-ms)
+                    (protocol/initialize-protocol cofx {:mailservers [ms-1 ms-2 ms-3]
+                                                        :mailserver-ranges {}
+                                                        :mailserver-topics {}
+                                                        :default-mailserver true})
                     [:db :mailserver/mailservers])
-                   (update-in [:eth.beta "1"] dissoc :generating-sym-key?)
-                   (update-in [:eth.beta "2"] dissoc :generating-sym-key?)
-                   (update-in [:eth.test "3"] dissoc :generating-sym-key?))))))))
+                   (update-in [:eth.beta :a] dissoc :generating-sym-key?)
+                   (update-in [:eth.beta :b] dissoc :generating-sym-key?)
+                   (update-in [:eth.test :c] dissoc :generating-sym-key?))))))))
 
 (def sig "0x04325367620ae20dd878dbb39f69f02c567d789dd21af8a88623dc5b529827c2812571c380a2cd8236a2851b8843d6486481166c39debf60a5d30b9099c66213e4")
 


### PR DESCRIPTION
integrate the mailserver api to store custom mailservers on status-go as well as the mailserver-topics api

I modified initialize-protocol so that it waits for mailservers, mailservers-topic and mailservers-ranges to be initialized before initializing whisper. Now only mailservers-ranges is still coming from realm but it will be trivial to integrate it once the service is available

### Testing notes

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- mailservers


### Steps to test

changes are not platform dependent so it is not a big deal if iOS doesn't build

I tested the following scenario on Android emulator:

- create account
- login. select mailserver manually
- logout, login
- add mailserver manually, connect to it.
- logout, login, selected mailserver should still be selected

Note that when you select your mailserver, the fields appear empty in the details, but that is not the case, it's a bug with text input unrelated to this PR. Additionally, once you selected your own mailserver, it will have a very long id and will hide mailserver label in the settings, also known bug.

you can use this custom mailserver:

![frame](https://user-images.githubusercontent.com/1181225/64273901-8d7bc200-cf42-11e9-9775-62d471d6ef0c.png)

enode://531e252ec966b7e83f5538c19bf1cde7381cc7949026a6e499b6e998e695751aadf26d4c98d5a4eabfb7cefd31c3c88d600a775f14ed5781520a88ecd25da3c6:status-offline-inbox@35.225.227.79:30504

It is pretty hard to QA test mailserver topics. I checked in development that mailserver topics are properly retrieved after login by looking into the app-db and that there was no errors logged in adb logcat.

status: ready