### PR TITLE
Preserve text-input's default value

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -37,6 +37,9 @@
                                                   (re-frame/dispatch [:contact.ui/contact-code-submitted]))
                           :placeholder         (i18n/label :t/enter-contact-code)
                           :style               (add-new.styles/input @tw)
+                          ;; Set default-value as otherwise it will
+                          ;; be erased in global `onWillBlur` handler
+                          :default-value       new-identity
                           :accessibility-label :enter-contact-code-input
                           :return-key-type     :go}]]
       (when-not platform/desktop?

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -34,6 +34,9 @@
        :auto-capitalize     :none
        :auto-focus          false
        :accessibility-label :chat-name-input
+       ;; Set default-value as otherwise it will
+       ;; be erased in global `onWillBlur` handler
+       :default-value       topic
        :placeholder         nil
        :return-key-type     :go
        :auto-correct        false}]]]

--- a/src/status_im/ui/screens/routing/core.cljs
+++ b/src/status_im/ui/screens/routing/core.cljs
@@ -40,8 +40,10 @@
     :on-will-blur
     (fn []
       (reset! screen-focused? false)
-      (doseq [text-input @react/text-input-refs]
-        (.clear text-input)))}])
+      ;; Reset currently mounted text inputs to their default values
+      ;; on navigating away; this is a privacy measure
+      (doseq [[text-input default-value] @react/text-input-refs]
+        (.setNativeProps text-input (clj->js {:text default-value}))))}])
 
 (defn wrap
   "Wraps screen with main view and adds navigation-events component"


### PR DESCRIPTION
Fixes #8910 

This issue was introduced in https://github.com/status-im/status-react/pull/8625. Consider this scenario:
  1. User navigates from Home view to Chat view
  2. Inputs some text into message box, but does not send it
  3. Goes back to Home and then again to Chat
  4. The text entered at step 2 is missing, because it's being set via `default-value` prop, and it is erased in `on-will-blur` navigation events handler.

After adding logging it turns out that text-input's `onRef` handler is invoked before the `onWillBlur` for Home view in step 3. So the default-value gets cleared, as we are not tracking which inputs belong to which views. Restoring `default-value` via `setNativeProps` seems to resolve this issue.