### PR TITLE
Ensure pod install is run if Pods directory is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,12 +127,10 @@ release-android: ##@build build release for Android
 release-ios: export TARGET_OS ?= ios
 release-ios: export BUILD_ENV ?= prod
 release-ios: watchman-clean ##@build build release for iOS release
-	# Open XCode inside the Nix context
 	@git clean -dxf -f target/ios && \
 	$(MAKE) jsbundle-ios && \
-	echo "Build in XCode, see https://status.im/build_status/ for instructions" && \
 	scripts/copy-translations.sh && \
-	open ios/StatusIm.xcworkspace
+	xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration Release -destination 'generic/platform=iOS' -UseModernBuildSystem=N clean archive
 
 release-desktop: export TARGET_OS ?= $(HOST_OS)
 release-desktop: ##@build build release for desktop release based on TARGET_OS

--- a/nix/mobile/ios/install-pods-and-status-go.sh
+++ b/nix/mobile/ios/install-pods-and-status-go.sh
@@ -11,7 +11,7 @@ RCTSTATUS_DIR="$STATUS_REACT_HOME/modules/react-native-status/ios/RCTStatus"
 targetBasename='Statusgo.framework'
 
 # Compare target folder with source to see if copying is required
-if [ -d "$RCTSTATUS_DIR/$targetBasename" ] && \
+if [ -d "$RCTSTATUS_DIR/$targetBasename" ] && [ -d $STATUS_REACT_HOME/ios/Pods/ ] && \
   diff -q --no-dereference --recursive $RCTSTATUS_DIR/$targetBasename/ $RCTSTATUS_FILEPATH/ > /dev/null; then
   echo "$RCTSTATUS_DIR/$targetBasename already in place"
 else


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR ensures `pod install` is run if you manually delete ios/Pods dir. It also makes `make release-ios` consistent with the other platforms by making it build from the command line.

<!-- (Optional, remove if no changes to documentation) -->
Documentation change PR (review please): https://github.com/status-im/status.im/pull/xxx

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

No manual testing needed, nothing in the software changed.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->