### PR TITLE
Fix strip warning on release Android builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -180,6 +180,7 @@ android {
         exclude 'META-INF/rxjava.properties'
         exclude '/lib/mips64/**'
         exclude '/lib/arm64-v8a/**'
+        exclude '/lib/armeabi/**'
         /** Fix for: Execution failed for task ':app:transformNativeLibsWithStripDebugSymbolForDebug'.
         *   with recent version of ndk (17.0.4754217)
         */

--- a/react-native/src/desktop/status_im/react_native/js_dependencies.cljs
+++ b/react-native/src/desktop/status_im/react_native/js_dependencies.cljs
@@ -36,4 +36,5 @@
 (def react-navigation       (js/require "react-navigation"))
 (def react-native-navigation-twopane  (js/require "react-native-navigation-twopane"))
 (def react-native-shake     #js {})
+(def net-info               #js {:default #js {}})
 (def react-native-mail      #js {:mail (fn [])})


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes a warning that we always get when building release Android apk:

```
[2019-09-10T16:04:16.826Z] > Task :app:transformNativeLibsWithStripDebugSymbolForPr
[2019-09-10T16:04:16.826Z] Unable to strip library '/build/project/android/app/build/intermediates/transforms/mergeJniLibs/pr/0/lib/armeabi/libucrop.so' due to missing strip tool for ABI 'ARMEABI'. Packaging it as is.
[2019-09-10T16:04:16.826Z] Unable to strip library '/build/project/android/app/build/intermediates/transforms/mergeJniLibs/pr/0/lib/armeabi/libconceal.so' due to missing strip tool for ABI 'ARMEABI'. Packaging it as is.
```

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->