### PR TITLE
[8957] fix - Wallet address can't be copied by tapping on it

### DIFF
--- a/src/status_im/ui/components/qr_code_viewer/styles.cljs
+++ b/src/status_im/ui/components/qr_code_viewer/styles.cljs
@@ -1,6 +1,5 @@
 (ns status-im.ui.components.qr-code-viewer.styles
-  (:require [status-im.ui.components.colors :as colors])
-  (:require-macros [status-im.utils.styles :refer [defstyle]]))
+  (:require [status-im.ui.components.colors :as colors]))
 
 (def qr-code-hint
   {:color           colors/gray
@@ -12,19 +11,15 @@
 
 (defn qr-code-container [width]
   {:align-self       :center
-   :width            (+ width qr-code-padding qr-code-padding)
+   :width            width
+   :height           width
+   :padding-horizontal 16
    :background-color colors/white
    :border-color     colors/black-transparent
    :align-items      :center
    :justify-content  :center
    :border-width     1
    :border-radius    8})
-
-(defstyle name-container
-  {:flex           0.6
-   :flex-direction :column
-   :ios            {:align-items :center}
-   :android        {:margin-left 15}})
 
 (def name-text
   {:font-size 17})

--- a/src/status_im/ui/components/qr_code_viewer/views.cljs
+++ b/src/status_im/ui/components/qr_code_viewer/views.cljs
@@ -1,21 +1,28 @@
 (ns status-im.ui.components.qr-code-viewer.views
-  (:require [reagent.core :as reagent]
+  (:require [cljs-bean.core :as bean]
+            [reagent.core :as reagent]
             [status-im.react-native.js-dependencies :as rn-dependencies]
             [status-im.ui.components.qr-code-viewer.styles :as styles]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.svg :as svg])
-  (:require-macros [status-im.utils.views :refer [defview letsubs]]))
+            [status-im.ui.components.svg :as svg]))
 
 (defn qr-code [{:keys [size value]}]
   (let [uri (reagent/atom nil)]
-    (.toString rn-dependencies/qr-code value #(reset! uri %2))
+    (.toString
+     rn-dependencies/qr-code
+     value
+     (bean/->js {:margin 0 :width size})
+     #(reset! uri %2))
     (fn []
       (when @uri
         [svg/svgxml {:xml @uri :width size :height size}]))))
 
-(defn qr-code-view [size value]
+(defn qr-code-view
+  "Qr Code view including the frame.
+  Note: `size` includes frame with `styles/qr-code-padding.`"
+  [size value]
   (when (and size value)
     [react/view {:style               (styles/qr-code-container size)
                  :accessibility-label :qr-code-image}
      [qr-code {:value value
-               :size  size}]]))
+               :size  (- size (* styles/qr-code-padding 2))}]]))

--- a/src/status_im/ui/screens/profile/user/styles.cljs
+++ b/src/status_im/ui/screens/profile/user/styles.cljs
@@ -1,8 +1,5 @@
 (ns status-im.ui.screens.profile.user.styles
-  (:require-macros [status-im.utils.styles :refer [defstyle]])
-  (:require [status-im.ui.components.colors :as colors]
-            [status-im.ui.screens.profile.components.styles :as profile.components.styles]
-            [status-im.ui.components.styles :as components.styles]))
+  (:require [status-im.ui.components.colors :as colors]))
 
 (def share-contact-code-container
   {:flex-direction  :row
@@ -20,25 +17,8 @@
    :flex-direction :column})
 
 (def share-link-button
-  {:margin-vertical   20})
-
-(defstyle my-profile-info-container {})
-
-(defstyle my-profile-settings-logout-wrapper
-  {:flex-direction  :row
-   :justify-content :space-between
-   :align-items     :center})
-
-(defstyle my-profile-settings-logout
-  {:min-width       "50%"})
-
-(defstyle my-profile-settings-send-logs-wrapper
-  {:flex-direction  :row
-   :justify-content :space-between
-   :align-items     :center})
-
-(defstyle my-profile-settings-send-logs
-  {:min-width       "50%"})
+  {:margin-top    12
+   :margin-bottom 8})
 
 (def advanced-button
   {:margin-top    16

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -1,20 +1,20 @@
 (ns status-im.ui.screens.wallet.request.views
   (:require [re-frame.core :as re-frame]
+            [reagent.core :as reagent]
             [status-im.ethereum.eip55 :as eip55]
             [status-im.ethereum.eip681 :as eip681]
             [status-im.ethereum.tokens :as tokens]
             [status-im.i18n :as i18n]
+            [status-im.ui.components.button :as button]
+            [status-im.ui.components.copyable-text :as copyable-text]
             [status-im.ui.components.qr-code-viewer.views :as qr-code-viewer]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.styles :as components.styles]
+            [status-im.ui.components.toolbar :as toolbar]
             [status-im.ui.screens.wallet.components.views :as wallet.components]
             [status-im.ui.screens.wallet.request.styles :as styles]
-            [status-im.wallet.utils :as wallet.utils]
             [status-im.utils.utils :as utils]
-            [status-im.ui.components.colors :as colors]
-            [reagent.core :as reagent]
-            [status-im.ui.components.common.common :as components.common]
-            [status-im.ui.components.toolbar :as toolbar])
+            [status-im.wallet.utils :as wallet.utils])
   (:require-macros [status-im.utils.views :as views]))
 
 ;;TODO DEPRECATED
@@ -62,28 +62,33 @@
   (views/letsubs [{:keys [address]} [:popover/popover]
                   chain-id    [:chain-id]
                   width       (reagent/atom nil)]
-    [react/view
-     [react/view {:style {:padding-top 16 :padding-left 16 :padding-right 16}}
+    [react/view {:on-layout #(reset! width (-> % .-nativeEvent .-layout .-width))}
+     [react/view {:style {:padding-top 16 :padding-horizontal 16}}
       (when @width
-        [qr-code-viewer/qr-code-view (- @width 32) (eip681/generate-uri address {:chain-id chain-id})])
-      [react/text {:style {:font-size 13 :color colors/gray :margin-top 12 :margin-bottom 4}}
-       (i18n/label :t/ens-wallet-address)]
-      [react/view {:on-layout #(reset! width (-> % .-nativeEvent .-layout .-width))}
-       [react/text {:number-of-lines 1 :ellipsize-mode :middle
+        [qr-code-viewer/qr-code-view
+         (- @width 32)
+         (eip681/generate-uri address {:chain-id chain-id})])
+      [copyable-text/copyable-text-view
+       {:label           :t/ens-wallet-address
+        :container-style {:margin-top 12 :margin-bottom 4}
+        :copied-text     (eip55/address->checksum address)}
+       [react/text {:number-of-lines     1
+                    :ellipsize-mode      :middle
                     :accessibility-label :address-text
-                    :style           {:line-height 22 :font-size 15
-                                      :font-family "monospace"}}
+                    :style               {:line-height 22 :font-size 15
+                                          :font-family "monospace"}}
         (eip55/address->checksum address)]]]
-     [react/view {:height 1 :background-color colors/gray-lighter :margin-top 8}]
-     [react/view {:padding-bottom 16}
-      [components.common/button {:on-press     #(re-frame/dispatch [:wallet.accounts/share address])
-                                 :button-style {:margin-vertical 20 :margin-horizontal 16}
-                                 :accessibility-label :share-address-button
-                                 :label        (i18n/label :t/share-address)}]
-      ;;TODO temporary hide for v1
-      #_[components.common/button {:on-press            #(do
-                                                           (re-frame/dispatch [:hide-popover])
-                                                           (re-frame/dispatch [:navigate-to :wallet-send-transaction-request address]))
-                                   :accessibility-label :sent-transaction-request-button
-                                   :label               (i18n/label :t/send-transaction-request)
-                                   :background?         false}]]]))
+     [react/view {:margin-top 12 :margin-bottom 8}
+      [button/button
+       {:on-press            #(re-frame/dispatch [:wallet.accounts/share address])
+        :label               :t/share-address
+        :accessibility-label :share-address-button}]]
+     ;;TODO temporary hide for v1
+     #_[button/button
+        {:on-press
+         #(do
+            (re-frame/dispatch [:hide-popover])
+            (re-frame/dispatch [:navigate-to :wallet-send-transaction-request address]))
+         :accessibility-label :sent-transaction-request-button
+         :label               :t/send-transaction-request
+         :type                :secondary}]]))


### PR DESCRIPTION
fixes #8957 

Having worked on `copyable-text-view` with copied cue animation component during user.profile work, had always meant to fix this as a separate PR. Couldn't help getting this done :)

- made wallet address copyable just like user.profile share popup
- fixed bottom margin of `Share address` button
- fixed(in both wallet and profile share popover) qr code size that got shrinked during move from using webview for qr image to `qrcode` in #8862

Note: In profile, button did not have link icon anymore - haven't fixed that one, as it was mentioned in code-comment as TODO in remainder work for button component.

## Testing notes
- Test wallet tab > share pop-over
   - qr width is snug
   - Share address button bottom margin is correct
   - address is copyable with `Copied` visual cue
- Test User Profile tab > share pop-over
   - similar to above

status: ready