### PR TITLE
[#8939] hide keycard options on ios

### DIFF
--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -13,7 +13,8 @@
             [status-im.utils.security :as security]
             [status-im.utils.signing-phrase.core :as signing-phrase]
             [status-im.utils.types :as types]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.utils :as utils]
+            [status-im.utils.platform :as platform]))
 
 (defn get-signing-phrase [cofx]
   (assoc cofx :signing-phrase (signing-phrase/generate)))
@@ -29,11 +30,17 @@
 
 (defn dec-step [step]
   (let [inverted  (map-invert step-kw-to-num)]
-    (inverted (dec (step-kw-to-num step)))))
+    (if (and (= step :create-code)
+             (not platform/android?))
+      :choose-key
+      (inverted (dec (step-kw-to-num step))))))
 
 (defn inc-step [step]
   (let [inverted  (map-invert step-kw-to-num)]
-    (inverted (inc (step-kw-to-num step)))))
+    (if (and (= step :choose-key)
+             (not platform/android?))
+      :create-code
+      (inverted (inc (step-kw-to-num step))))))
 
 ;; multiaccounts create module
 (defn get-selected-multiaccount [{:keys [db]}]

--- a/src/status_im/multiaccounts/recover/core.cljs
+++ b/src/status_im/multiaccounts/recover/core.cljs
@@ -11,7 +11,8 @@
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.fx :as fx]
             [status-im.utils.security :as security]
-            [status-im.utils.types :as types]))
+            [status-im.utils.types :as types]
+            [status-im.utils.platform :as platform]))
 
 (defn check-password-errors [password]
   (cond (string/blank? password) :required-field
@@ -140,13 +141,6 @@
                      (assoc-in [:multiaccounts/recover :derived] derived-data))}
             (navigation/navigate-to-cofx :recover-multiaccount-success nil)))
 
-(fx/defn re-encrypt-pressed
-  {:events [::re-encrypt-pressed]}
-  [{:keys [db] :as cofx}]
-  (fx/merge cofx
-            {:db (assoc-in db [:intro-wizard :selected-storage-type] :default)}
-            (navigation/navigate-to-cofx :recover-multiaccount-select-storage nil)))
-
 (fx/defn enter-phrase-pressed
   {:events [::enter-phrase-pressed]}
   [{:keys [db] :as cofx}]
@@ -179,6 +173,15 @@
     (if (= storage-type :advanced)
       {:dispatch [:recovery.ui/keycard-option-pressed]})
     (navigation/navigate-to-cofx cofx :recover-multiaccount-enter-password nil)))
+
+(fx/defn re-encrypt-pressed
+  {:events [::re-encrypt-pressed]}
+  [{:keys [db] :as cofx}]
+  (fx/merge cofx
+            {:db (assoc-in db [:intro-wizard :selected-storage-type] :default)}
+            (if platform/android?
+              (navigation/navigate-to-cofx :recover-multiaccount-select-storage nil)
+              (select-storage-next-pressed))))
 
 (fx/defn proceed-to-password-confirm
   [{:keys [db] :as cofx}]

--- a/src/status_im/ui/screens/intro/views.cljs
+++ b/src/status_im/ui/screens/intro/views.cljs
@@ -20,7 +20,8 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.constants :as constants]
-            [status-im.utils.config :as config]))
+            [status-im.utils.config :as config]
+            [status-im.utils.platform :as platform]))
 
 (defn dots-selector [{:keys [on-press n selected color]}]
   [react/view {:style (styles/dot-selector n)}
@@ -139,7 +140,8 @@
       [react/text {:style (assoc styles/wizard-text :text-align :left :margin-left 16)}
        (i18n/label type)]]
      [react/touchable-highlight
-      {:on-press #(re-frame/dispatch [:intro-wizard/on-key-storage-selected (if config/hardwallet-enabled? type :default)])}
+      {:on-press #(re-frame/dispatch [:intro-wizard/on-key-storage-selected (if (and config/hardwallet-enabled?
+                                                                                     platform/android?) type :default)])}
       [react/view (assoc (styles/list-item selected?)
                          :align-items :flex-start
                          :padding-top 20

--- a/src/status_im/ui/screens/multiaccounts/recover/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/recover/views.cljs
@@ -18,7 +18,8 @@
             [status-im.ui.screens.intro.views :as intro.views]
             [status-im.utils.utils :as utils]
             [status-im.constants :as constants]
-            [status-im.ui.components.list-item.views :as list-item]))
+            [status-im.ui.components.list-item.views :as list-item]
+            [status-im.utils.platform :as platform]))
 
 (defn bottom-sheet-view []
   [react/view {:flex 1 :flex-direction :row}
@@ -29,17 +30,19 @@
       :accessibility-label :enter-seed-phrase-button
       :icon                :main-icons/text
       :on-press            #(re-frame/dispatch [::multiaccounts.recover/enter-phrase-pressed])}]
-    [list-item/list-item
-     {:theme               :action
-      :title               :t/recover-with-keycard
-      :disabled?           (not config/hardwallet-enabled?)
-      :accessibility-label :recover-with-keycard-button
-      :icon                :main-icons/keycard-logo
-      :on-press            #(re-frame/dispatch [::hardwallet/recover-with-keycard-pressed])}]]])
+    (when (and config/hardwallet-enabled?
+               platform/android?)
+      [list-item/list-item
+       {:theme               :action
+        :title               :t/recover-with-keycard
+        :disabled?           (not config/hardwallet-enabled?)
+        :accessibility-label :recover-with-keycard-button
+        :icon                :main-icons/keycard-logo
+        :on-press            #(re-frame/dispatch [::hardwallet/recover-with-keycard-pressed])}])]])
 
 (def bottom-sheet
   {:content        bottom-sheet-view
-   :content-height 130})
+   :content-height (if platform/android? 130 65)})
 
 (defview enter-phrase []
   (letsubs [{:keys [processing?


### PR DESCRIPTION
fixes #8939

### Summary

Hide keycard options on ios devices since it's only supported on android yet.

status: ready