### PR TITLE
fix log level config

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,24 @@
+This document MUST be updated everytime a PR has been identified has the source of a bug in develop. The post mortem analysis MUST include: the CAUSE of the bug, the RESOLUTION PROCESS and PREVENTION MEASURES.
+
+
+# "sql: no rows in result set" error on iOS login
+
+## Cause
+
+There was errors in the iOS native code:
+- "loginWithKeycard" method was not implemented
+- "createAndLoginWithKeycard" method was actually used instead of "createAndLogin** which is used for regular account creation without keycard and doesn't have the same final argument
+
+QA process was focused on account creation and login with keycard, and this bug would only appear specifically on iOS when creating an account without keycard and only during the next login. It was therefore a more complex path to reach that what could have been expected from this PR, and it was caused in develop by a developer working on iOS simulator because that is a common path during development.
+
+## Resolution process
+
+- the commit was reverted locally by the developer which fixed the issue localy and confirmed the faulty commit
+- the bug was only reproducible on iOS which strongly hinted at a potential issue with native code
+- the missing method was not the origin of the problem but was found at this point and further analysis lead to the shadowing error
+
+## Prevention measures
+
+- PRs that change native code should be checked for plateform parity:
+  - same methods are created/modified for each platform
+  - test cases in the PR should take these methods in consideration

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -404,7 +404,7 @@ RCT_EXPORT_METHOD(saveAccountAndLogin:(NSString *)accountData
 }
 
 //////////////////////////////////////////////////////////////////// saveAccountAndLoginWithKeycard
-RCT_EXPORT_METHOD(saveAccountAndLogin:(NSString *)accountData
+RCT_EXPORT_METHOD(saveAccountAndLoginWithKeycard:(NSString *)accountData
                   password:(NSString *)password
                   config:(NSString *)config
                   chatKey:(NSString *)chatKey) {
@@ -423,7 +423,18 @@ RCT_EXPORT_METHOD(login:(NSString *)accountData
     NSLog(@"Login() method called");
 #endif
     NSString *result = StatusgoLogin(accountData, password);
-    
+    NSLog(@"%@", result);
+}
+
+//////////////////////////////////////////////////////////////////// loginWithKeycard
+RCT_EXPORT_METHOD(loginWithKeycard:(NSString *)accountData
+                  password:(NSString *)password
+                  chatKey:(NSString *)chatKey) {
+#if DEBUG
+    NSLog(@"LoginWithKeycard() method called");
+#endif
+    NSString *result = StatusgoLoginWithKeycard(accountData, password, chatKey);
+
     NSLog(@"%@", result);
 }
 

--- a/src/status_im/log_level/core.cljs
+++ b/src/status_im/log_level/core.cljs
@@ -12,10 +12,11 @@
         new-settings  (if log-level
                         (assoc settings :log-level log-level)
                         (dissoc settings :log-level))]
-    (multiaccounts.update/update-settings cofx
-                                          new-settings
-                                          (when (not= (node/get-log-level settings) (node/get-log-level new-settings))
-                                            {:success-event [:multiaccounts.update.callback/save-settings-success]}))))
+    (fx/merge cofx
+              (multiaccounts.update/update-settings new-settings
+                                                    {})
+              (node/prepare-new-config {:on-success #(when (not= (node/get-log-level settings) (node/get-log-level new-settings))
+                                                       (re-frame/dispatch [:logout]))}))))
 
 (fx/defn show-change-log-level-confirmation
   [{:keys [db]} {:keys [name value] :as log-level}]

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -169,6 +169,10 @@
   (types/clj->json (get-multiaccount-node-config db)))
 
 (fx/defn save-new-config
+  "Saves a new status-go config for the current account
+   This RPC method is the only way to change the node config of an account.
+   NOTE: it is better used indirectly through `prepare-new-config`, which will take
+   care of building up the proper config based on settings in app-db"
   {:events [::save-new-config]}
   [{:keys [db]} config {:keys [on-success]}]
   {::json-rpc/call [{:method "settings_saveNodeConfig"
@@ -176,6 +180,7 @@
                      :on-success on-success}]})
 
 (fx/defn prepare-new-config
+  "Use this function to apply settings to the current account node config"
   [{:keys [db]} {:keys [on-success]}]
   {::prepare-new-config [(get-new-config db)
                          #(re-frame/dispatch [::save-new-config % {:on-success on-success}])]})


### PR DESCRIPTION
@cammellos related to bootnodes, I added some docstrings to the important functions

the log level config for status-go wasn't saved in the node-config
as a result even though the setting looked applied in the UI it wasn't
in the node

Waiting for build to test

status: ready