### PR TITLE
Upgrade from hermesvm@0.1.1 to hermes-engine@0.2.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,7 @@ project.ext.react = [
     nodeExecutableAndArgs: ["node", "--max-old-space-size=16384"],
     entryFile: "index.android.js",
     enableHermes: true,     // clean and rebuild if changing. NOTE: Hermes engine is required for Android 64-bit builds running on 64 devices, to guard against a hang in the UI thread after invoking status-go
+    hermesCommand: "../../node_modules/hermes-engine/%OS-BIN%/hermes", // Can be removed once RN moves to a version which depends on hermes-engine instead of hermesvm
     bundleInPr: true,
     inputExcludes: ["android/**", "ios/**", "react-native/**", "src/**", "test/**"]
 ]
@@ -303,12 +304,10 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     if (enableHermes) {
-      def hermesPath = "../../node_modules/hermesvm/android/";
-      // Force using the release Hermes VM until the perf issues in debug VM are fixed in npm package > 0.1.1 (https://github.com/facebook/hermes/issues/73)
-      implementation files(hermesPath + "hermes-release.aar")
-    //   debugImplementation files(hermesPath + "hermes-debug.aar")
-    //   releaseImplementation files(hermesPath + "hermes-release.aar")
-    //   prImplementation files(hermesPath + "hermes-release.aar")
+      def hermesPath = "../../node_modules/hermes-engine/android/";
+      debugImplementation files(hermesPath + "hermes-debug.aar")
+      releaseImplementation files(hermesPath + "hermes-release.aar")
+      prImplementation files(hermesPath + "hermes-release.aar")
     } else {
       implementation jscFlavor
     }

--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -13,6 +13,7 @@
     "create-react-class": "15.6.2",
     "emojilib": "^2.4.0",
     "eth-phishing-detect": "^1.1.13",
+    "hermes-engine": "0.2.1",
     "hi-base32": "^0.5.0",
     "i18n-js": "^3.3.0",
     "identicon.js": "git+https://github.com/status-im/identicon.js.git#v1.2.1-status",

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -2780,6 +2780,11 @@ hasha@^3.0.0:
   dependencies:
     is-stream "^1.0.1"
 
+hermes-engine@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
+  integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
+
 hermesvm@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/hermesvm/-/hermesvm-0.1.1.tgz#bd1df92b4dc504e261c23df34864daf24b844d03"

--- a/nix/mobile/android/maven-and-npm-deps/default.nix
+++ b/nix/mobile/android/maven-and-npm-deps/default.nix
@@ -149,13 +149,9 @@ let
               'nodeExecutableAndArgs: ["${nodejs}/bin/node"'
 
           # Fix bugs in Hermes usage (https://github.com/facebook/react-native/issues/25601#issuecomment-510856047)
-          # - Make script always include release Hermes VM, as the debug version is currently way too slow in npm package <= 0.1.1 (https://github.com/facebook/hermes/issues/73)
           # - Make PR builds also count as release builds
           # - Fix issue where hermes command is being called with same input/output file
           substituteInPlace ${projectBuildDir}/node_modules/react-native/react.gradle \
-            --replace \
-              'def isRelease = targetName.toLowerCase().contains("release")' \
-              'def isRelease = true' \
             --replace \
               'targetName.toLowerCase().contains("release")' \
               '!targetName.toLowerCase().contains("debug")' \
@@ -170,6 +166,9 @@ let
               commandLine(getHermesCommand(), "-emit-binary", "-out", jsBundleFile, jsBundleFileIn, *hermesFlags)
               ' \
             || exit
+
+          # Remove legacy hermesvm folder (can be removed once we upgrade RN to a version which depends on newer hermes-engine package instead of hermesvm)
+          rm -r ${projectBuildDir}/node_modules/hermesvm
 
           # Patch dependencies which are not yet ported to AndroidX
           npx jetify


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR upgrades the Hermes engine to a version which fixes the debug performance issues. 

### Review notes

- The `hermesvm` package has been renamed to `hermes-engine`
- Removed the workaround of using release hermesvm in debug builds

status: ready <!-- Can be ready or wip -->