### PR TITLE
fix #8992 update account timestamp when login with keycard

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,6 +3,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "develop",
-    "commit-sha1": "d263be10c46aa8788bc776069225ab31c52c6c51",
-    "src-sha256": "0r7hp9a946s1sbh5dbl8s2p0z0yrzyi7pjhbwy3hqm25bbprrql0"
+    "commit-sha1": "963ea94e08ed46e20a4feee1f5d2a294e9cdf6c1",
+    "src-sha256": "19zz3ccjpk8dnrani4hccpyx6q0gvzr4s43cqr8ybk97z09w175l"
 }


### PR DESCRIPTION
fixes #8992 

### Summary

Logout from keycard account was redirecting to login screen for another user
because `b.multiaccountsDB.UpdateAccountTimestamp` was not called in
`startNodeWithKey` as it was done in `startNodeWithAccount` in status-go

The fix is therefore in status-go and this PR updates status-go version to
fix that

### Testing notes

Tested on Android, created normal account logout then keycard account logout login screen is on keycard account as expected

status: ready <!-- Can be ready or wip -->