### PR TITLE
typos in REVIEW.md

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -5,11 +5,11 @@ This document MUST be updated everytime a PR has been identified has the source 
 
 ## Cause
 
-There was errors in the iOS native code:
+There were errors in the iOS native code:
 - "loginWithKeycard" method was not implemented
 - "createAndLoginWithKeycard" method was actually used instead of "createAndLogin** which is used for regular account creation without keycard and doesn't have the same final argument
 
-QA process was focused on account creation and login with keycard, and this bug would only appear specifically on iOS when creating an account without keycard and only during the next login. It was therefore a more complex path to reach that what could have been expected from this PR, and it was caused in develop by a developer working on iOS simulator because that is a common path during development.
+QA process was focused on account creation and login with keycard, and this bug would only appear specifically on iOS when creating an account without keycard and only during the next login. It was therefore a more complex path to reach than what could have been expected from this PR, and it was caused in develop by a developer working on iOS simulator because that is a common path during development.
 
 ## Resolution process
 
@@ -19,7 +19,7 @@ QA process was focused on account creation and login with keycard, and this bug 
 
 ## Prevention measures
 
-- PRs that change native code should be checked for plateform parity:
+- PRs that change native code should be checked for platform parity:
   - same methods are created/modified for each platform
   - test cases in the PR should take these methods in consideration
 


### PR DESCRIPTION
@PombeirP not sure how it happened but in this PR https://github.com/status-im/status-react/pull/9015 you reviewed typo from a previous commit so here is the patch

status: ready