### PR TITLE
remove wrap-first-time

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,5 +1,19 @@
+# [DEPRECATED] Undefined is not an object evaluating `register_handler_fx`
 
-Stacktrace:
+## Deprecation note
+
+This type of error should not occur anymore now that we require the namespace in the `fx.cljs` file. 
+
+It can however happen with other macros requiring a cljs namespace. 
+
+The general fix for that type of issue is to have two files for the namespace where your macros are defined, let's say for `my-project.my-macro` namespace you would have: 
+- my_macro.cljs in which you need `(:require-macros my-project.my-macro)` and `(:require my-project.the-namespace-used-in-the-macro)`
+- my_macro.clj in which you define the macro
+
+That way you don't need to use any magical call like `find-ns` or inline `require` with some kind of call only once switch (which was the root cause of another bug in ``defstyle`` macro because the compilation phase at which the evaluation of the switch is done was not properly considered).
+
+## Stacktrace
+
 ```
 13:25:22, Requiring: hi-base32
 13:25:23, Possible Unhandled Promise Rejection (id: 0):
@@ -18,9 +32,11 @@ _callTimer@http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false
 _callImmediatesPass@http://localhost:8081/index.bundle?pla<…>
 ```
 
-Cause: 
+## Cause
+
 - stacktrace mentions `register_handler_fx`, 
 - common cause is when requires have been cleaned up and a require of `status-im.utils.handlers` namespace was removed because it looked like it was unused but was actually used through a fx/defn macro
 
-Solution: 
+## Solution
+
 go through known faulty commit looking for deleted requires

--- a/src/status_im/utils/styles.clj
+++ b/src/status_im/utils/styles.clj
@@ -1,20 +1,5 @@
 (ns status-im.utils.styles)
 
-(def first-time (atom true))
-
-(defn wrap-first-time
-  "Allows to avoid
-  \"Use of undeclared Var status-im.utils.platform/os\"
-  warning. When defstyle or defnstyle is called first time status-im.utils.platform
-  namespace will be explicitly required so that clojurescript compiler will compile
-  it before using status-im.utils.platform/os in macro"
-  [body]
-  `(do
-     ~@[(when @first-time
-          (reset! first-time false)
-          `(require 'status-im.utils.platform))]
-     ~body))
-
 (defn body [style]
   `(let [style#            ~style
          common#            (dissoc style# :android :ios :desktop)
@@ -41,9 +26,8 @@
     {:width  100
      :height 20}"
   [style-name style]
-  (wrap-first-time
-   `(def ~style-name
-      ~(body style))))
+  `(def ~style-name
+     ~(body style)))
 
 (defmacro defnstyle
   "Defines style function.
@@ -62,7 +46,6 @@
     {:width  100
      :height 5}"
   [style-name params style]
-  (wrap-first-time
-   `(defn ~style-name
-      [~@params]
-      ~(body style))))
+  `(defn ~style-name
+     [~@params]
+     ~(body style)))

--- a/src/status_im/utils/styles.cljs
+++ b/src/status_im/utils/styles.cljs
@@ -1,0 +1,3 @@
+(ns status-im.utils.styles
+  (:require-macros status-im.utils.fx)
+  (:require status-im.utils.platform))


### PR DESCRIPTION
Similar to how we fixed the fx macro, in order to avoid require magic, we can simply require the needed namespaces in the cljs file and use `require-macro` to require the macros of the clj file

status: ready <!-- Can be ready or wip -->