### PR TITLE
throw errors on dangerous behaviours

### DIFF
--- a/src/status_im/utils/fx.cljs
+++ b/src/status_im/utils/fx.cljs
@@ -33,7 +33,7 @@
                              (if (get merged-fx k)
                                (if (mergeable-keys k)
                                  (update merged-fx k into v)
-                                 (do (log/error "Merging fx with common-key: " k v)
+                                 (do (log/error "Merging fx with common-key: " k v (get merged-fx k))
                                      (reduced {:merging-fx-with-common-keys k})))
                                (assoc merged-fx k v))))
                          fx

--- a/test/cljs/status_im/test/models/bootnode.cljs
+++ b/test/cljs/status_im/test/models/bootnode.cljs
@@ -19,7 +19,7 @@
                         {:random-id-generator   (constantly "some-id")
                          :db {:bootnodes/manage new-bootnode
                               :network          "mainnet_rpc"
-                              :multiaccount  {}}})]
+                              :multiaccount {:not-empty "would throw an error if was empty"}}})]
       (is (= expected (get-in actual [:db :multiaccount :bootnodes])))))
   (testing "adding an existing bootnode"
     (let [new-bootnode {:id   {:value "a"}

--- a/test/cljs/status_im/test/multiaccounts/update/core.cljs
+++ b/test/cljs/status_im/test/multiaccounts/update/core.cljs
@@ -4,10 +4,14 @@
             [status-im.multiaccounts.update.core :as multiaccounts.update]))
 
 (deftest test-multiaccount-update
-  (let [efx (multiaccounts.update/multiaccount-update {:db {:multiaccount {}}} nil {})
+  ;;TODO this test case actually shows that we are doing a needless rpc call when
+  ;;there is no changes, but it is an edge case that shouldn't really happen
+  (let [efx (multiaccounts.update/multiaccount-update
+             {:db {:multiaccount {:not-empty "would throw an error if was empty"}}}
+             nil {})
         json-rpc (into #{} (map :method (::json-rpc/call efx)))]
     (is (json-rpc "settings_saveConfig"))
-    (is (= (get-in efx [:db :multiaccount]) {}))))
+    (is (= (get-in efx [:db :multiaccount]) {:not-empty "would throw an error if was empty"}))))
 
 (deftest test-clean-seed-phrase
   (let [efx (multiaccounts.update/clean-seed-phrase {:db {:multiaccount {:mnemonic "lalalala"}}})


### PR DESCRIPTION
This PR doesn't fix anything but instead will help solve a few pending bugs. (it will change the way these bugs manifest and decrease their severity, accounts shouldn't be toasted anymore and instead the app crashes and the issue is logged)

- if multiaccount settings are saved on top of an empty map or nil,
this means something went wrong, the state of the app is unstable,
and actually saving will result in loss of data. It should never
happen, but if it does, throw and error and abort.
- sometimes two fxs are merged when they shouldn't, this is caused by
bugs and should never happen, but if it does, throw an error with arguments
for both effects to help localize the error

status: ready <!-- Can be ready or wip -->