### PR TITLE
build multiple APKs for different architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,9 @@ release-android: export TARGET_OS ?= android
 release-android: export BUILD_ENV ?= prod
 release-android: export BUILD_TYPE ?= nightly
 release-android: export BUILD_NUMBER ?= 9999
-release-android: export NDK_ABI_FILTERS ?= armeabi-v7a;arm64-v8a;x86
 release-android: export STORE_FILE ?= $(HOME)/.gradle/status-im.keystore
+release-android: export ANDROID_ABI_SPLIT ?= false
+release-android: export ANDROID_ABI_INCLUDE ?= armeabi-v7a;arm64-v8a;x86
 release-android: ##@build build release for Android
 	scripts/release-android.sh
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,16 +93,6 @@ project.ext.react = [
 apply from: "../../node_modules/react-native/react.gradle"
 
 /**
- * Set this to true to create two separate APKs instead of one:
- *   - An APK that only works on ARM devices
- *   - An APK that only works on x86 devices
- * The advantage is the size of the APK is reduced by about 4MB.
- * Upload all the APKs to the Play Store and people will download
- * the correct one based on the CPU architecture of their device.
- */
-def enableSeparateBuildPerCPUArchitecture = false
-
-/**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
 def enableProguardInReleaseBuilds = false
@@ -184,10 +174,13 @@ android {
         multiDexEnabled true
         versionCode getVersionCode()
         versionName getVersionName()
-        ndk {
-            abiFilters getEnvOrConfig('NDK_ABI_FILTERS').split(';')
-        }
         missingDimensionStrategy 'react-native-camera', 'general'
+        /* this needs to be empty if we want APKs split by ABIs */
+        if (!getEnvOrConfig('ANDROID_ABI_SPLIT').toBoolean()) {
+            ndk {
+                abiFilters getEnvOrConfig('ANDROID_ABI_INCLUDE').split(";")
+            }
+        }
     }
     /**
      * Arbitrary project metadata
@@ -242,9 +235,9 @@ android {
     splits {
         abi {
             reset()
-            enable enableSeparateBuildPerCPUArchitecture
-            universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "arm64-v8a", "x86"
+            enable getEnvOrConfig('ANDROID_ABI_SPLIT').toBoolean()
+            include getEnvOrConfig('ANDROID_ABI_INCLUDE').split(";")
+            universalApk true
         }
     }
     buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -38,8 +38,10 @@ STATUS_RELEASE_STORE_PASSWORD=password
 STATUS_RELEASE_KEY_ALIAS=status
 STATUS_RELEASE_KEY_PASSWORD=password
 
-# platforms for which to build the Android bundle
-NDK_ABI_FILTERS=armeabi-v7a;arm64-v8a;x86
+# By default we build a mostly universal APK
+ANDROID_ABI_SPLIT=false
+# Some platforms are excluded though
+ANDROID_ABI_INCLUDE=armeabi-v7a;arm64-v8a;x86
 
 org.gradle.jvmargs=-Xmx8704M
 

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -90,21 +90,23 @@ pipeline {
           }
           stage('Bundle') {
             steps {
-              script { apk = android.bundle() }
+              script { apks = android.bundle() }
             }
           }
         } }
       }
     }
     stage('Archive') {
-      steps {
-        archiveArtifacts apk
-      }
+      steps { script {
+        apks.each { archiveArtifacts it }
+      } }
     }
     stage('Upload') {
       steps {
         script {
-          env.PKG_URL = cmn.utils.uploadArtifact(apk)
+          def urls = apks.collect { cmn.utils.uploadArtifact(it) }
+          /* return only the universal APK */
+          env.PKG_URL = urls.find { it.contains('universal') }
           /* build type specific */
           switch (btype) {
             case 'release':

--- a/ci/ghcmgr.groovy
+++ b/ci/ghcmgr.groovy
@@ -54,8 +54,8 @@ def postBuild(success) {
   }
   /* We're not using --fail because it suppresses server response */
   if (!stdout.contains('HTTP_CODE:201')) {
-    error("Notifying GHCMGR failed with: ${httpCode}")
     println("STDOUT:\n${stdout}")
+    error("Notifying GHCMGR failed with: TODO")
   }
 }
 

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -31,8 +31,10 @@ def gitCommit() {
   return GIT_COMMIT.take(6)
 }
 
-def pkgFilename(type, ext) {
-  return "StatusIm-${timestamp()}-${gitCommit()}-${type}.${ext}"
+def pkgFilename(type, ext, arch="universal") {
+  return [
+    "StatusIm", timestamp(), gitCommit(), type, arch,
+  ].join('-') + ".${ext}"
 }
 
 def doGitRebase() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -258,14 +258,14 @@ end
 
 platform :android do
   # Optional env variables
-  APK_PATH = ENV['APK_PATH'] || 'result/app.apk'
+  APK_PATHS = ENV["APK_PATHS"]&.split(";") or ["result/app.apk"]
 
   desc 'Deploy a new internal build to Google Play'
   desc 'expects GOOGLE_PLAY_JSON_KEY environment variable'
   lane :nightly do
     upload_to_play_store(
       track: 'internal',
-      apk: APK_PATH,
+      apk_paths: APK_PATHS,
       json_key_data: ENV['GOOGLE_PLAY_JSON_KEY']
     )
   end
@@ -275,7 +275,7 @@ platform :android do
   lane :release do
     upload_to_play_store(
       track: 'alpha',
-      apk: APK_PATH,
+      apk_paths: APK_PATHS,
       json_key_data: ENV['GOOGLE_PLAY_JSON_KEY']
     )
   end
@@ -299,7 +299,8 @@ platform :android do
   desc '---'
   desc 'Output: writes `fastlane/diawi.out` file url of the uploded file'
   lane :upload_diawi do
-    upload_to_diawi(APK_PATH)
+    uniApk = APK_PATHS.detect { |a| a.include? 'universal' }
+    upload_to_diawi(uniApk)
   end
 
   desc '`fastlane android saucelabs` - upload .apk to sauce labs'
@@ -309,6 +310,7 @@ platform :android do
   desc 'expects to have a saucelabs destination name as SAUCE_LABS_NAME env variable'
   desc "will fails if file isn't there"
   lane :saucelabs do
-    upload_to_saucelabs(APK_PATH)
+    e2eApk = APK_PATHS.detect { |a| a.include? 'x86' }
+    upload_to_saucelabs(e2eApk)
   end
 end

--- a/nix/build.sh
+++ b/nix/build.sh
@@ -26,7 +26,6 @@ trap cleanup EXIT ERR INT QUIT
 # build output will end up under /nix, we have to extract it
 function extractResults() {
   local nixResultPath="$1"
-  echo "Saving build result: ${nixResultPath}"
   mkdir -p "${resultPath}"
   cp -vfr ${nixResultPath}/* "${resultPath}"
   chmod -R u+w "${resultPath}"
@@ -43,7 +42,8 @@ if [[ -z "${targetAttr}" ]]; then
   exit 1
 fi
 
-# Some defaults flags, --pure could be optional in the future
+# Some defaults flags, --pure could be optional in the future.
+# NOTE: The --keep-failed flag can be used for debugging issues.
 nixOpts=(
   "--pure"
   "--fallback"
@@ -59,6 +59,7 @@ nixOpts=(
 echo "Running: nix-build ${nixOpts[@]}"
 nixResultPath=$(nix-build ${nixOpts[@]})
 
+echo "Extracting result: ${nixResultPath}"
 extractResults "${nixResultPath}"
 
 echo "SUCCESS"

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -7,7 +7,9 @@ source "$_current_dir/lib/setup/path-support.sh"
 source_lib "platform.sh"
 
 nixOpts=(
-  "--arg env {NDK_ABI_FILTERS=\"${NDK_ABI_FILTERS}\";}"
+  "--arg env {BUILD_ENV=\"${BUILD_ENV}\";}"
+  "--arg env {ANDROID_ABI_SPLIT=\"${ANDROID_ABI_SPLIT}\";}"
+  "--arg env {ANDROID_ABI_INCLUDE=\"${ANDROID_ABI_INCLUDE}\";}"
   "--argstr build-type ${BUILD_TYPE}"
   "--argstr build-number ${BUILD_NUMBER}"
   "--argstr keystore-file ${STORE_FILE}"


### PR DESCRIPTION
In order to reduce size of APKs people will be downloading from PlayStore this PR changes `release` build to produce multiple APKs for different architectures(`armeabi-v7a` and `arm64-v8a`) as well as one universal APK which includes all of them.

Builds for PRs and nightlies remain unchanged and produce one APK for `armeabi-v7a`, `arm64-v8a`, and `x86`.

Changes:
* Replace `NDK_ABI_FILTERS` env variable with:
  - `ANDROID_ABI_SPLIT` to control if one or multiple APKs are produced
  - `ANDROID_ABI_INCLUDE` to control for which architectures APKs are built
* Replaces `APK_PATH` env variable with `APK_PATHS` in `Fastlfile` to upload multiple APKs
* Adjusts `ci/Jenkinsfile.android` to archive and upload multiple APKs
* Adds `renameAPKs` method in `ci/android.groovy` for dynamically renaming multiple APKs
* Adjusts `nix/mobile/android/targets/release-android.nix` to copy multiple APKs to `$out`

Successful manual `release` build: https://ci.status.im/job/tests/job/android-build-branch-test/325

![split_apks](https://user-images.githubusercontent.com/2212681/65599406-11532800-df9e-11e9-926c-314d33fd2c6c.png)

__Note:__ The `universal` APK is bigger(`~73MB`) than our normal ones(`~43MB`) because it includes `x86` and `x86_64` and that cannot be changed.