### PR TITLE
Hide Account Export menu item in wallet for v1

### DIFF
--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -29,7 +29,7 @@
        :icon-opts {:color :black}
        :handler   #(re-frame/dispatch [:bottom-sheet/show-sheet
                                        {:content        sheets/account-settings
-                                        :content-height 130}])}]]]])
+                                        :content-height 60}])}]]]])
 
 (defn button [label icon handler]
   [react/touchable-highlight {:on-press handler :style {:flex 1}}

--- a/src/status_im/ui/screens/wallet/accounts/sheets.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/sheets.cljs
@@ -70,8 +70,9 @@
      :title     :t/account-settings
      :icon      :main-icons/info
      :disabled? true}]
-   [list-item/list-item
-    {:theme     :action
-     :title     :t/export-account
-     :icon      :main-icons/copy
-     :disabled? true}]])
+   ;; Commented out for v1
+   #_[list-item/list-item
+      {:theme     :action
+       :title     :t/export-account
+       :icon      :main-icons/copy
+       :disabled? true}]])


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Closes #9040

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR hides the `Export Account` menu item in the wallet.

### Testing notes
<!-- (Optional) -->

Tested on Android device.

![image](https://user-images.githubusercontent.com/138074/65605249-0d78d300-dfa9-11e9-9a2f-7a67d31cf52e.png)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- iOS

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->