### PR TITLE
[#8973] Mobile data syncing pop-up missing text

### DIFF
--- a/src/status_im/ui/screens/mobile_network_settings/sheets.cljs
+++ b/src/status_im/ui/screens/mobile_network_settings/sheets.cljs
@@ -55,9 +55,10 @@
      (str " " (i18n/label :mobile-network-sheet-settings))]]])
 
 (views/defview settings-sheet []
-  [react/view {:style styles/container}
-   [title :mobile-syncing-sheet-title]
-   [details :mobile-syncing-sheet-details]
+  [react/view {:flex 1}
+   [react/view {:align-items :center}
+    [title :mobile-syncing-sheet-title]
+    [details :mobile-syncing-sheet-details]]
    [list-item/list-item
     {:theme    :action
      :title    :t/mobile-network-continue-syncing
@@ -77,9 +78,10 @@
     [settings]]])
 
 (views/defview offline-sheet []
-  [react/view {:style styles/container}
-   [title :t/mobile-network-sheet-offline]
-   [details :t/mobile-network-sheet-offline-details]
+  [react/view {:flex 1}
+   [react/view {:align-items :center}
+    [title :t/mobile-network-sheet-offline]
+    [details :t/mobile-network-sheet-offline-details]]
    [list-item/list-item
     {:theme    :action
      :title    :t/mobile-network-start-syncing

--- a/src/status_im/ui/screens/mobile_network_settings/sheets_styles.cljs
+++ b/src/status_im/ui/screens/mobile_network_settings/sheets_styles.cljs
@@ -1,10 +1,5 @@
 (ns status-im.ui.screens.mobile-network-settings.sheets-styles
-  (:require [status-im.ui.components.colors :as colors]
-            [status-im.ui.components.styles :as common-styles]))
-
-(def container
-  {:flex        1
-   :align-items :center})
+  (:require [status-im.ui.components.colors :as colors]))
 
 (def title
   {:height     21


### PR DESCRIPTION

fixes #8973

![image](https://user-images.githubusercontent.com/11790366/65870685-14269200-e37d-11e9-8ddd-a4b9d963725f.png)


tested in ios simulator