### PR TITLE
[#8945] "null is not an object" error when tap on sticker sent in chat

### DIFF
--- a/src/status_im/stickers/core.cljs
+++ b/src/status_im/stickers/core.cljs
@@ -120,8 +120,8 @@
                  (navigation/navigate-to-cofx % :stickers-pack-modal pack)))))
 
 (fx/defn open-sticker-pack
-  [{{:stickers/keys [packs packs-installed] :keys [network] :as db} :db :as cofx} id]
-  (when (and id (string/starts-with? network "mainnet"))
+  [{{:stickers/keys [packs packs-installed] :networks/keys [current-network] :as db} :db :as cofx} id]
+  (when (and id (string/starts-with? current-network "mainnet"))
     (let [pack    (or (get packs-installed id)
                       (get packs id))
           contract-address (contracts/get-address db :status/stickers)]


### PR DESCRIPTION

fixes #8945

tested on ios simulator