### PR TITLE
[#8934] Only one sticker is shown in "Recently used"

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -652,7 +652,7 @@
    (fx/merge
     cofx
     (multiaccounts.update/multiaccount-update
-     {:stickers/recent-stickers (conj (remove #(= hash %) (:recent-stickers multiaccount)) hash)}
+     {:stickers/recent-stickers (conj (remove #(= hash %) (:stickers/recent-stickers multiaccount)) hash)}
      {})
     (chat.input/send-sticker-fx sticker current-chat-id))))
 


### PR DESCRIPTION

fixes #8934

![image](https://user-images.githubusercontent.com/11790366/65872627-3fab7b80-e381-11e9-9c76-5c6c480b35fb.png)

tested in ios simulator