### PR TITLE
Fix ENS input when starting a new chat

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -37,9 +37,10 @@
                                                   (re-frame/dispatch [:contact.ui/contact-code-submitted]))
                           :placeholder         (i18n/label :t/enter-contact-code)
                           :style               (add-new.styles/input @tw)
-                          ;; Set default-value as otherwise it will
-                          ;; be erased in global `onWillBlur` handler
-                          :default-value       new-identity
+                          ;; This input is fine to preserve inputs
+                          ;; so its contents will not be erased 
+                          ;; in onWillBlur navigation event handler
+                          :preserve-input?     true
                           :accessibility-label :enter-contact-code-input
                           :return-key-type     :go}]]
       (when-not platform/desktop?


### PR DESCRIPTION
Fixes #9046 

For some text inputs it's fine to preserve content when navigating away and back again. So the flag is introduced to text-input component implementation.

Context: when entering an ENS name, `set-new-identity` with a hex address argument is invoked every time a resolution is performed. Hence new chat name input becomes broken as it dynamically replaces a human-readable name with a hex string. In this context it is wrong to set default-value to the value of new-identity sub as it then contains a computed value, not the one entered into the input field.