### PR TITLE
[#8657] Keyboard overlaps sign button if you tap on sign after changing "Recipient" or "Asset" field on Send Transaction screen

### DIFF
--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -27,7 +27,8 @@
      [topbar/simple-toolbar (i18n/label :t/send-transaction)]
      [react/view components.styles/flex
       [wallet.components/network-info]
-      [react/scroll-view {:keyboard-should-persist-taps :always
+      [react/scroll-view {:keyboard-should-persist-taps :never
+                          :keyboard-dismiss-mode        :on-drag
                           :ref                          #(reset! scroll %)
                           :on-content-size-change       #(when (and scroll @scroll)
                                                            (.scrollToEnd @scroll))}


### PR DESCRIPTION
fixes #8657

I did several tests and the only way I found so far is to set `:keyboard-should-persist-taps` to `:never`.

btw the root cause seems to be that, if you navigate to asset or recipient when the amount input text has focus, when you navigate back the amount input automatically receives the focus again and keyboard pop-ups. This "focus restoration" generates a state where keyboard remains on top.

I don't know yet why\how the focus is auto restored when navigating back, but `:keyboard-should-persist-taps` to `:never` force input to always loose focus before navigating away.

can you check if this is an acceptable solution? The side-effect is that user, when amount text input has focus, has to tap twice to navigate to recipient or asset. To mitigate I added `:keyboard-dismiss-mode  :on-drag`.