### PR TITLE
Copy update multiaccount: watch account > address

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -13,7 +13,7 @@
 	"active-online": "Online",
 	"active-unknown": "Unknown",
 	"add": "Add",
-	"add-a-watch-account": "Add a watch-only account",
+	"add-a-watch-account": "Add a watch-only address",
 	"add-account": "Add account",
 	"add-account-description": "You can import any type of Ethereum account to add it to your Status wallet",
 	"add-account-incorrect-password": "Password seems to be incorrect. Enter the password you use to unlock the app.",


### PR DESCRIPTION
Fixes copy update in [8447](https://github.com/status-im/status-react/issues/8447) (issue has more open items and remains open)

### Summary
In the UI we want to refer to a watch only address as `address` instead of `account`. Interactions with an address are limited compared to an account in wallet. e.g. there is no option to send assets from this account as Status wallet does not have the key to sign for transactions.

#### Areas that maybe impacted
Should only impact bottom sheet on Add account

### Steps to test
- Open Status
- Tap on wallet
- Tap on add account
- check copy on bottom sheet

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
