### PR TITLE
[Fixes #9088] Store eip1581 path

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -237,12 +237,19 @@
 
 (def ^:const status-create-address "status_createaddress")
 
-(def ^:const path-root "m/44'/60'/0'/0")
-(def ^:const path-default-wallet "m/44'/60'/0'/0/0")
-(def ^:const path-whisper "m/43'/60'/1581'/0'/0")
+; BIP44 Wallet Root Key, the extended key from which any wallet can be derived
+(def ^:const path-wallet-root "m/44'/60'/0'/0")
+; EIP1581 Root Key, the extended key from which any whisper key/encryption key can be derived
+(def ^:const path-eip1581 "m/43'/60'/1581'")
+; BIP44-0 Wallet key, the default wallet key
+(def ^:const path-default-wallet (str path-wallet-root "/0"))
+; EIP1581 Chat Key 0, the default whisper key
+(def ^:const path-whisper (str path-eip1581 "/0'/0"))
 
 (def ^:const path-default-wallet-keyword (keyword path-default-wallet))
 (def ^:const path-whisper-keyword (keyword path-whisper))
+(def ^:const path-wallet-root-keyword (keyword path-wallet-root))
+(def ^:const path-eip1581-keyword (keyword path-eip1581))
 
 ;; (ethereum/sha3 "Transfer(address,address,uint256)")
 (def ^:const event-transfer-hash "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")

--- a/src/status_im/multiaccounts/recover/core.cljs
+++ b/src/status_im/multiaccounts/recover/core.cljs
@@ -127,7 +127,10 @@
       (let [{:keys [id] :as root-data} (types/json->clj result)]
         (status-im.native-module.core/multiaccount-derive-addresses
          id
-         [constants/path-default-wallet constants/path-whisper]
+         [constants/path-wallet-root
+          constants/path-eip1581
+          constants/path-whisper
+          constants/path-default-wallet]
          (fn [result]
            (let [derived-data (types/json->clj result)]
              (re-frame/dispatch [::import-multiaccount-success


### PR DESCRIPTION
When creating the account we store as well the path specified in eip1581
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1581.md ,
`m / 43' / 60' / 1581'`.

The reason for doing so is that eventually we might want to derive an
encryption key from it, which would require the user to re-enter their
seed phrase if we would not store this.

This commit changes also the behavior **not to** store the master key, and instead store the key at 
`m /44'/60' /0'/0` from which wallets can be derived.

I could not test on keycard as I do not own one.

status: ready