### PR TITLE
Suppress back-up-seed prompt when already done (fixes #8938)

### DIFF
--- a/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
@@ -19,14 +19,15 @@
    {:type                    :small
     :title                   :t/back-up-seed-phrase
     :accessibility-label     :back-up-recovery-phrase-button
+    :disabled?               (not show-backup-seed?)
     ;; TODO - remove container bottom margin
     ;; when items below are implemented
     :container-margin-bottom 8
     :on-press
     #(re-frame/dispatch [:navigate-to :backup-seed])
     :accessories
-    [(when show-backup-seed? [components.common/counter {:size 22} 1])
-     :chevron]}
+    (when show-backup-seed? [[components.common/counter {:size 22} 1]
+                             :chevron])}
    {:type                    :small
     :title                   (str (i18n/label :t/lock-app-with) " " (biometric/get-label supported-biometric-auth))
     :container-margin-bottom 8


### PR DESCRIPTION
fixes #8938 

### Summary

Suppresses backup-seed-phrase option on Pirvacy & Security screen when already backed up

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Privacy & Security Settings

##### Functional

- Privacy & Security Settings

### Steps to test
1. Open Status
2.  Open Profile
3. Open Privacy & Security Settings
4. Back up seed phrase 
5. Navigate back to Privacy & Security Settings
6.  Security section will be suppressed

status: ready 

Visual representation on Android
![Back-up-seed-suppresed](https://user-images.githubusercontent.com/17355484/66163449-5dd1df80-e5fe-11e9-964c-e607ea2573a5.png)

