### PR TITLE
[#9107] Collectibles (except CryptoKitties) are not loaded (endless s…

### DIFF
--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -14,7 +14,10 @@
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.ui.screens.wallet.account.styles :as styles]
             [status-im.ui.screens.wallet.transactions.views :as history]
-            [status-im.ethereum.core :as ethereum]))
+            [status-im.ethereum.core :as ethereum]
+            [status-im.ui.components.list-item.views :as list-item]
+            [status-im.utils.money :as money]
+            [status-im.wallet.utils :as wallet.utils]))
 
 (def state (reagent/atom {:tab :assets}))
 
@@ -66,6 +69,19 @@
       [react/view {:style styles/divider}]
       [button (i18n/label :t/receive) :main-icons/receive  #(re-frame/dispatch [:show-popover {:view :share-account :address address}])]]]))
 
+(defn render-collectible [address]
+  (fn [{:keys [name icon amount] :as collectible}]
+    (let [items-number (money/to-fixed amount)
+          details?     (pos? items-number)]
+      [list-item/list-item
+       {:title       (wallet.utils/display-symbol collectible)
+        :subtitle    name
+        :icon        [list/item-image icon]
+        :on-press    (when details?
+                       #(re-frame/dispatch
+                         [:show-collectibles-list collectible address]))
+        :accessories [items-number :chevron]}])))
+
 (views/defview transactions [address]
   (views/letsubs [{:keys [transaction-history-sections]}
                   [:wallet.transactions.history/screen address]]
@@ -97,7 +113,7 @@
                             :footer             [react/view
                                                  {:style {:height     tabs.styles/tabs-diff
                                                           :align-self :stretch}}]
-                            :render-fn          accounts/render-collectible}]
+                            :render-fn          (render-collectible address)}]
            [react/view {:align-items :center :margin-top 32}
             [react/text {:style {:color colors/gray}}
              (i18n/label :t/no-collectibles)]])

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -12,10 +12,8 @@
             [status-im.wallet.utils :as wallet.utils]
             [status-im.ui.components.tabbar.styles :as tabs.styles]
             [reagent.core :as reagent]
-            [status-im.utils.money :as money]
             [re-frame.core :as re-frame]
             [status-im.ui.screens.wallet.accounts.sheets :as sheets]
-            [status-im.ethereum.core :as ethereum]
             [status-im.ui.screens.wallet.accounts.styles :as styles]))
 
 (def state (reagent/atom {:tab :assets}))
@@ -79,45 +77,16 @@
                               [list/item-image icon]
                               [chat-icon/custom-icon-view-list (:name token) color])}]))
 
-(defn render-collectible [{:keys [name icon amount] :as collectible}]
-  (let [items-number (money/to-fixed amount)
-        details?     (pos? items-number)]
-    [list-item/list-item
-     {:title       (wallet.utils/display-symbol collectible)
-      :subtitle    name
-      :icon        [list/item-image icon]
-      :on-press    (when details?
-                     #(re-frame/dispatch
-                       [:show-collectibles-list collectible]))
-      :accessories [items-number :chevron]}]))
-
-(views/defview assets-and-collections []
+(views/defview assets []
   (views/letsubs [{:keys [tokens nfts]} [:wallet/all-visible-assets-with-values]
                   currency [:wallet/currency]]
-    (let [{:keys [tab]} @state]
-      [react/view {:flex 1}
-       [react/view {:flex-direction :row :margin-bottom 8 :margin-horizontal 4}
-        [tab-title state :assets (i18n/label :t/wallet-assets) (= tab :assets)]
-        [tab-title state :nft (i18n/label :t/wallet-collectibles) (= tab :nft)]]
-       (if (= tab :assets)
-         [list/flat-list {:data               tokens
-                          :default-separator? false
-                          :key-fn             :name
-                          :footer             [react/view
-                                               {:style {:height     tabs.styles/tabs-diff
-                                                        :align-self :stretch}}]
-                          :render-fn          (render-asset (:code currency))}]
-         (if (seq nfts)
-           [list/flat-list {:data               nfts
-                            :default-separator? false
-                            :key-fn             :name
-                            :footer             [react/view
-                                                 {:style {:height     tabs.styles/tabs-diff
-                                                          :align-self :stretch}}]
-                            :render-fn          render-collectible}]
-           [react/view {:align-items :center :margin-top 32}
-            [react/text {:style {:color colors/gray}}
-             (i18n/label :t/no-collectibles)]]))])))
+    [list/flat-list {:data               tokens
+                     :default-separator? false
+                     :key-fn             :name
+                     :footer             [react/view
+                                          {:style {:height     tabs.styles/tabs-diff
+                                                   :align-self :stretch}}]
+                     :render-fn          (render-asset (:code currency))}]))
 
 (views/defview total-value []
   (views/letsubs [currency        [:wallet/currency]
@@ -149,7 +118,7 @@
        [icons/icon :main-icons/more {:accessibility-label :accounts-more-options}]]]]))
 
 (views/defview accounts []
-  (views/letsubs [{:keys [accounts address keycard-key-uid]} [:multiaccount]]
+  (views/letsubs [{:keys [accounts keycard-key-uid]} [:multiaccount]]
     [react/scroll-view {:horizontal true}
      [react/view {:flex-direction :row :padding-top 11 :padding-bottom 12}
       (for [account accounts]
@@ -167,4 +136,4 @@
     [react/view {:margin-top 8 :padding-horizontal 16}
      [total-value]
      [accounts]]
-    [assets-and-collections]]])
+    [assets]]])


### PR DESCRIPTION


fixes #9107

tested on ios, can see all collectibles

removed collectibles from overview screen
