### PR TITLE
Clean /tmp and $TMPDIR in make clean

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -61,7 +61,7 @@ pipeline {
         script { cmn.nix.shell('lein deps :tree', attr: 'targets.leiningen.shell') }
       }
     }
-    stage('Parallel') {
+    stage('Parallel Assemble') {
       parallel {
         stage('Checks') { stages {
           stage('Lint') {
@@ -74,11 +74,6 @@ pipeline {
               script { cmn.nix.shell('lein test-cljs', attr: 'targets.leiningen.shell') }
             }
           }
-          /* stage('Coverage') {
-            steps {
-              script { android.coverage() }
-            }
-          } */
         } }
         stage('Build') { stages {
           stage('JSBundle') {
@@ -96,35 +91,41 @@ pipeline {
         } }
       }
     }
-    stage('Archive') {
-      steps { script {
-        apks.each { archiveArtifacts it }
-      } }
-    }
-    stage('Upload') {
-      steps {
-        script {
-          def urls = apks.collect { cmn.uploadArtifact(it) }
-          /* return only the universal APK */
-          if (urls.size() > 1) { 
-            env.PKG_URL = urls.find { it.contains('universal') }
-          } else { /* if no universal is available pick first */
-            env.PKG_URL = urls.first()
-          }
-          /* build type specific */
-          switch (btype) {
-            case 'release':
-              android.uploadToPlayStore(); break;
-            case 'nightly':
-              env.DIAWI_URL = android.uploadToDiawi(); break;
-            case 'e2e':
-              env.SAUCE_URL = android.uploadToSauceLabs(); break;
+    stage('Parallel Upload') {
+      parallel {
+        stage('Archive') {
+          steps { script {
+            apks.each { archiveArtifacts it }
+          } }
+        }
+        stage('Upload') {
+          steps {
+            script {
+              def urls = apks.collect { cmn.uploadArtifact(it) }
+              /* return only the universal APK */
+              if (urls.size() > 1) { 
+                env.PKG_URL = urls.find { it.contains('universal') }
+              } else { /* if no universal is available pick first */
+                env.PKG_URL = urls.first()
+              }
+              /* build type specific */
+              switch (btype) {
+                case 'release':
+                  android.uploadToPlayStore(); break;
+                case 'nightly':
+                  env.DIAWI_URL = android.uploadToDiawi(); break;
+                case 'e2e':
+                  env.SAUCE_URL = android.uploadToSauceLabs(); break;
+              }
+            }
           }
         }
       }
     }
     stage('Cleanup') {
-      steps { sh 'make clean' }
+      steps {
+        sh 'make clean'
+      }
     }
   }
   post {

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -31,7 +31,7 @@ pipeline {
           osx    = cmn.ci.Build('status-react/combined/desktop-macos')
         } } }
         stage('Linux') { steps { script {
-          nix    = cmn.ci.Build('status-react/combined/desktop-linux')
+          tux    = cmn.ci.Build('status-react/combined/desktop-linux')
         } } }
         stage('Windows') { steps { script {
           win    = cmn.ci.Build('status-react/combined/desktop-windows')
@@ -55,7 +55,7 @@ pipeline {
         sh('rm -f pkg/*')
         if (btype != 'release') {
           cmn.ci.copyArts(osx)
-          cmn.ci.copyArts(nix)
+          cmn.ci.copyArts(tux)
           cmn.ci.copyArts(win)
         }
         cmn.ci.copyArts(ios)
@@ -78,7 +78,7 @@ pipeline {
           iOS: cmn.pkgUrl(ios), /*iOSe2e: cmn.pkgUrl(iose2e),*/
           Diawi: cmn.utils.getEnv(ios, 'DIAWI_URL'),
           /* desktop */
-          App: cmn.pkgUrl(nix), Mac: cmn.pkgUrl(osx), Win: cmn.pkgUrl(win),
+          App: cmn.pkgUrl(tux), Mac: cmn.pkgUrl(osx), Win: cmn.pkgUrl(win),
           /* upload the sha256 checksums file too */
           SHA: cmn.uploadArtifact(cmn.utils.pkgFind('sha256')),
         ]
@@ -95,7 +95,7 @@ pipeline {
     stage('Publish') {
       steps { script {
         switch (btype) {
-          case 'nightly': build('misc/status.im'); break
+          //case 'nightly': build('misc/status.im'); break
           case 'release': gh.publishReleaseMobile(); break
         }
       } }

--- a/ci/Jenkinsfile.fastlane.clean
+++ b/ci/Jenkinsfile.fastlane.clean
@@ -7,6 +7,10 @@ pipeline {
     LC_ALL    = 'en_US.UTF-8'
     TARGET_OS = 'ios'
     FASTLANE_DISABLE_COLORS = 1
+    /* See nix/README.md */
+    NIX_IGNORE_SYMLINK_STORE = 1
+    /* avoid writing to r/o /nix */
+    GEM_HOME  = '~/.rubygems'
   }
 
   options {
@@ -25,7 +29,8 @@ pipeline {
         nix = load('ci/nix.groovy')
         nix.shell(
           'bundle install --gemfile=fastlane/Gemfile',
-          attr: 'targets.mobile.fastlane.shell')
+          attr: 'targets.mobile.fastlane.shell'
+        )
       } }
     }
     stage('Clean Users'){

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -27,7 +27,8 @@ pipeline {
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'ios'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
-    NIX_IGNORE_SYMLINK_STORE = 1 // https://github.com/NixOS/nix/issues/2925#issuecomment-499544039
+    /* See nix/README.md */
+    NIX_IGNORE_SYMLINK_STORE = 1
     FASTLANE_DISABLE_COLORS = 1
     BUNDLE_PATH = "${HOME}/.bundle"
     /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
@@ -49,7 +50,7 @@ pipeline {
         }
       }
     }
-    stage('Parallel') {
+    stage('Parallel Assemble') {
       parallel {
         stage('Checks') { stages {
           stage('Lint') {
@@ -77,20 +78,24 @@ pipeline {
         } }
       }
     }
-    stage('Archive') {
-      steps {
-        archiveArtifacts api
-      }
-    }
-    stage('Upload') {
-      steps {
-        script {
-          env.PKG_URL = cmn.uploadArtifact(api)
-          /* e2e builds get tested in SauceLabs */
-          if (btype == 'e2e') {
-            env.SAUCE_URL = ios.uploadToSauceLabs()
-          } else {
-            env.DIAWI_URL = ios.uploadToDiawi()
+    stage('Parallel Upload') {
+      parallel {
+        stage('Archive') {
+          steps {
+            archiveArtifacts api
+          }
+        }
+        stage('Upload') {
+          steps {
+            script {
+              env.PKG_URL = cmn.uploadArtifact(api)
+              /* e2e builds get tested in SauceLabs */
+              if (btype == 'e2e') {
+                env.SAUCE_URL = ios.uploadToSauceLabs()
+              } else {
+                env.DIAWI_URL = ios.uploadToDiawi()
+              }
+            }
           }
         }
       }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -53,7 +53,7 @@ pipeline {
         }
       }
     }
-    stage('Parallel') {
+    stage('Parallel Assemble') {
       parallel {
         stage('Checks') { stages {
           stage('Lint') {
@@ -86,14 +86,18 @@ pipeline {
         } }
       }
     }
-    stage('Archive') {
-      steps {
-        archiveArtifacts app
-      }
-    }
-    stage('Upload') {
-      steps {
-        script { env.PKG_URL = cmn.uploadArtifact(app) }
+    stage('Parallel Upload') {
+      parallel {
+        stage('Archive') {
+          steps {
+            archiveArtifacts app
+          }
+        }
+        stage('Upload') {
+          steps {
+            script { env.PKG_URL = cmn.uploadArtifact(app) }
+          }
+        }
       }
     }
     stage('Cleanup') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -27,7 +27,8 @@ pipeline {
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'macos'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
-    NIX_IGNORE_SYMLINK_STORE = 1 // https://github.com/NixOS/nix/issues/2925#issuecomment-499544039
+    /* See nix/README.md */
+    NIX_IGNORE_SYMLINK_STORE = 1
     VERBOSE_LEVEL = '3'
     /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
     LEIN_HOME         = "/var/tmp/lein-${EXECUTOR_NUMBER}"
@@ -50,7 +51,7 @@ pipeline {
         }
       }
     }
-    stage('Parallel') {
+    stage('Parallel Assemble') {
       parallel {
         stage('Checks') { stages {
           stage('Lint') {
@@ -83,14 +84,18 @@ pipeline {
         } }
       }
     }
-    stage('Archive') {
-      steps {
-        archiveArtifacts dmg
-      }
-    }
-    stage('Upload') {
-      steps {
-        script { env.PKG_URL = cmn.uploadArtifact(dmg) }
+    stage('Parallel Upload') {
+      parallel {
+        stage('Archive') {
+          steps {
+            archiveArtifacts dmg
+          }
+        }
+        stage('Upload') {
+          steps {
+            script { env.PKG_URL = cmn.uploadArtifact(dmg) }
+          }
+        }
       }
     }
     stage('Cleanup') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -56,7 +56,7 @@ pipeline {
         }
       }
     }
-    stage('Parallel') {
+    stage('Parallel Assemble') {
       parallel {
         stage('Checks') { stages {
           stage('Lint') {
@@ -89,14 +89,18 @@ pipeline {
         } }
       }
     }
-    stage('Archive') {
-      steps {
-        archiveArtifacts app
-      }
-    }
-    stage('Upload') {
-      steps {
-        script { env.PKG_URL = cmn.uploadArtifact(app) }
+    stage('Parallel Upload') {
+      parallel {
+        stage('Archive') {
+          steps {
+            archiveArtifacts app
+          }
+        }
+        stage('Upload') {
+          steps {
+            script { env.PKG_URL = cmn.uploadArtifact(app) }
+          }
+        }
       }
     }
     stage('Cleanup') {

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -59,11 +59,11 @@ def prep(type = 'nightly') {
 
   if (env.TARGET_OS == 'macos' || env.TARGET_OS == 'linux' || env.TARGET_OS == 'windows') {
     /* node deps, pods, and status-go download */
-    utils.nix.shell('scripts/prepare-for-desktop-platform.sh', pure: false)
+    nix.shell('scripts/prepare-for-desktop-platform.sh', pure: false)
     sh('scripts/copy-translations.sh')
   } else if (env.TARGET_OS != 'android') {
     // run script in the nix shell so that node_modules gets instantiated before attempting the copies
-    utils.nix.shell('scripts/copy-translations.sh chmod')
+    nix.shell('scripts/copy-translations.sh chmod')
   }
 }
 
@@ -86,15 +86,15 @@ def uploadArtifact(path) {
     usernameVariable: 'DO_ACCESS_KEY',
     passwordVariable: 'DO_SECRET_KEY'
   )]) {
-    nix.shell("""
-      s3cmd \\
-        --acl-public ${customOpts} \\
+    shell("""
+      s3cmd ${customOpts} \\
+        --acl-public \\
         --host="${domain}" \\
         --host-bucket="%(bucket)s.${domain}" \\
         --access_key=${DO_ACCESS_KEY} \\
         --secret_key=${DO_SECRET_KEY} \\
         put ${path} s3://${bucket}/
-    """, pure: false)
+    """)
   }
   return "https://${bucket}.${domain}/${utils.getFilename(path)}"
 }

--- a/nix/build.sh
+++ b/nix/build.sh
@@ -55,6 +55,12 @@ nixOpts=(
   "default.nix"
 )
 
+# This variable allows specifying which env vars to keep for Nix pure shell
+# The separator is a semicolon
+if [[ -n "${_NIX_KEEP}" ]]; then
+  nixOpts+=("--keep ${_NIX_KEEP//;/ --keep }")
+fi
+
 # Run the actual build
 echo "Running: nix-build ${nixOpts[@]}"
 nixResultPath=$(nix-build ${nixOpts[@]})

--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,6 @@ let
     gnumake
     jq
     wget
-    s3cmd
   ];
 
 in mkShell {


### PR DESCRIPTION
Sometimes Metro bundler cache/Yarn cache get broken and this issue manifests itself in weird errors during app startup, e.g. `ReactClassInterface: You are attempting to define 'UNSAFE_componentWillReceiveProps' on your component more than once. This conflict may be due to a mixin`.

The solution is to clean temp directories, on macOS at least Yarn and Metro bundler put their cache files into `/tmp` and `$TMPDIR` folders.

---
Changes:
* Define `TMPDIR` to be `/tmp/tmp-status-react-$(BUILD_TAG)` where `BUILD_TAG` is the commit
  - In case of Jenkins `BUILD_TAG` is a unique build identifier
* Add `TMPDIR` to `_NIX_KEEP` so it's passed to Nix shell and builds
* Add `_tmpdir-mk` target to `Makefile` to be called every time `make` is called
* Add `_tmpdir-rm` target to `Makefile` to be called with `make clean`
* Parallelize the 2 `Archive` and `Upload` stages to shorten the builds a bit
* Undo the use of Nix shell for `s3cmd` upload, since Nix isn't available on master
* Fixed `fastlane ios clean` job by adding missing `NIX_IGNORE_SYMLINK_STORE=1` (#9232)