### PR TITLE
fix navigation reset

### DIFF
--- a/src/status_im/ui/screens/navigation.cljs
+++ b/src/status_im/ui/screens/navigation.cljs
@@ -49,9 +49,13 @@
 
 (fx/defn navigate-reset
   [{:keys [db]} {:keys [index actions] :as config}]
-  (let [view-id (:routeName (get actions index))]
-    {:db              (assoc db :view-id view-id
-                             :navigation-stack (list view-id))
+  (let [stack (into '() (map :routeName actions))
+        view-id (get stack index)]
+    {:db              (assoc db
+                             :view-id view-id
+                             ;;NOTE: stricly needs to be a list
+                             ;;because navigate-back pops it
+                             :navigation-stack stack)
      ::navigate-reset config}))
 
 (def unload-data-interceptor
@@ -158,7 +162,7 @@
  (fn []
    (reset! processing-back-event? false)))
 
-;; Below two effects are added when we need 
+;; Below two effects are added when we need
 ;; to override default react-navigation's BACK action
 ;; processing
 (re-frame/reg-fx


### PR DESCRIPTION
currently navigation-reset only works properly if you reset to a simple route

this fix allows us to use navigation reset with more complex routes, by
ensuring that the navigation stack is populated properly so that navigate
back doesn't end up emptying the stack.

this is temporary as the proper way to do navigation in general would be
to get rid of view id and navigation-stack entirely, since it is a duplication
of the state of react-navigation

status: ready