### PR TITLE
Fix #8960

### DIFF
--- a/src/status_im/wallet/choose_recipient/core.cljs
+++ b/src/status_im/wallet/choose_recipient/core.cljs
@@ -90,8 +90,8 @@
 
 (fx/defn fill-request-from-url
   {:events [:wallet/fill-request-from-url]}
-  [{{:keys [network] :wallet/keys [all-tokens] :as db} :db} data origin]
-  (let [current-chain-id                       (get-in constants/default-networks [network :config :NetworkId])
+  [{{:networks/keys [current-network] :wallet/keys [all-tokens] :as db} :db} data origin]
+  (let [current-chain-id                       (get-in constants/default-networks [current-network :config :NetworkId])
         {:keys [address chain-id] :as details} (extract-details data current-chain-id all-tokens)
         valid-network?                         (boolean (= current-chain-id chain-id))
         previous-state                         (get-in db [:wallet :send-transaction])


### PR DESCRIPTION
fixes #8960 

### Summary

Issue as described in #8960 where using the camera to scan a QR code with a URL link throws an error.  

Solution fixes bug by pointing network to the correct key in the database.  

### Testing/Review notes
Metamask QR codes only work if your network is set to mainnet.  [Metamask doesn't really support EIP681](https://github.com/MetaMask/metamask-extension/issues/5125).  I don't know if it's possible to tell if you're scanning a Metamask QR code specifically but all they do is tack "ethereum" onto the front of the address so Status will throw the error message since it thinks you're reading an EIP681 compliant URI.

I tested using [this link generator](https://brunobar79.github.io/eip681-link-generator/#) and it processed the URI just fine and throws the appropriate error if the app is set to a different network than the URI calls for.

#### Platforms
Only tested on Android.  May be blocked by #8997 for iOS devices.  I can't verify as I don't have a Mac or iOS devices.

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet/transfers

### Steps to test

- Open Status
- Go to Wallet -> Account -> Send
- Tap "Choose Recipient" and then "Scan QR Code"
- Scan QR code

status: ready
