### PR TITLE
[#8650] Tappable "backup seed" notification in wallet

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1050,6 +1050,18 @@
    (map :balance (vals (:accounts wallet)))))
 
 (re-frame/reg-sub
+ :empty-balances?
+ :<- [:balances]
+ (fn [balances]
+   (every?
+    (fn [balance]
+      (every?
+       (fn [asset]
+         (or (nil? asset) (.isZero asset)))
+       (vals balance)))
+    balances)))
+
+(re-frame/reg-sub
  :price
  :<- [:prices]
  (fn [prices [_ fsym tsym]]

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -100,16 +100,24 @@
      [react/text {:style {:color colors/gray}} (i18n/label :t/wallet-total-value)]]))
 
 (views/defview accounts-options []
-  (views/letsubs [{:keys [seed-backed-up?]} [:multiaccount]]
+  (views/letsubs [{:keys [seed-backed-up?]} [:multiaccount]
+                  empty-balances?           [:empty-balances?]]
     [react/view {:flex-direction :row :align-items :center}
      [react/view {:flex 1 :padding-left 16}
-      (when-not seed-backed-up?
-        [react/view {:flex-direction :row :align-items :center}
-         [react/view {:width           14 :height 14 :background-color colors/gray :border-radius 7 :align-items :center
-                      :justify-content :center :margin-right 9}
-          [react/text {:style {:color colors/white :font-size 13 :font-weight "700"}} "!"]]
-         [react/text {:style {:color colors/gray}
-                      :accessibility-label :back-up-your-seed-phrase-warning} (i18n/label :t/back-up-your-seed-phrase)]])]
+      (when (and (not seed-backed-up?)
+                 (not empty-balances?))
+        [react/touchable-highlight
+         {:on-press #(re-frame/dispatch [:navigate-to :backup-seed])}
+         [react/view {:flex-direction :row :align-items :center}
+          [react/view {:width           14 :height 14 :background-color colors/gray :border-radius 7 :align-items :center
+                       :justify-content :center :margin-right 9}
+           [react/text {:style {:color       colors/white
+                                :font-size   13
+                                :font-weight "700"}}
+            "!"]]
+          [react/text {:style               {:color colors/gray}
+                       :accessibility-label :back-up-your-seed-phrase-warning}
+           (i18n/label :t/back-up-your-seed-phrase)]]])]
      [react/touchable-highlight {:on-press #(re-frame/dispatch [:bottom-sheet/show-sheet
                                                                 {:content        (sheets/accounts-options seed-backed-up?)
                                                                  :content-height (if seed-backed-up? 190 250)}])}

--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -109,16 +109,20 @@ class TestWalletManagement(SingleDeviceTestCase):
         self.verify_no_errors()
 
     @marks.testrail_id(5358)
-    @marks.critical
+    @marks.medium
     def test_backup_recovery_phrase_warning_from_wallet(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
         wallet = sign_in.wallet_button.click()
         wallet.set_up_wallet()
-        if not wallet.backup_recovery_phrase_warning_text.is_element_present():
-            self.driver.fail("'Back up your seed phrase' warning is not shown on Wallet")
-        wallet.multiaccount_more_options.click_until_presence_of_element(wallet.backup_recovery_phrase)
-        wallet.backup_recovery_phrase.click()
+        if wallet.backup_recovery_phrase_warning_text.is_element_present():
+            self.driver.fail("'Back up your seed phrase' warning is shown on Wallet while no funds are present")
+        address = wallet.get_wallet_address()
+        self.network_api.get_donate(address[2:])
+        wallet.back_button.click()
+        if not wallet.backup_recovery_phrase_warning_text.is_element_present(30):
+            self.driver.fail("'Back up your seed phrase' warning is not shown on Wallet with funds")
+        wallet.backup_recovery_phrase_warning_text.click()
         profile = wallet.get_profile_view()
         profile.backup_recovery_phrase()
 

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -1,5 +1,4 @@
 import random
-import pytest
 
 from support.utilities import get_merged_txs_list
 from tests import marks, unique_password, common_password

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -157,6 +157,14 @@ class UpdateFeeButton(BaseButton):
         super(UpdateFeeButton, self).__init__(driver)
         self.locator = self.Locator.xpath_selector("//*[@text='Update']")
 
+    def click(self):
+        for _ in range(3):
+            self.driver.info('Tap on %s' % self.name)
+            self.find_element().click()
+            self.driver.info('Wait for no %s' % self.name)
+            if not self.is_element_displayed(1):
+                return self.navigate()
+
 
 class ShareButton(BaseButton):
 


### PR DESCRIPTION
fix #8650 

- notification is tappable
- appears only if user has nonzero balance and hasn't backed up seed yet