### PR TITLE
Fix profile pic bugs (#9234)

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -28,7 +28,8 @@
             [status-im.wallet.core :as wallet]
             [taoensso.timbre :as log]
             [status-im.ui.screens.db :refer [app-db]]
-            [status-im.multiaccounts.biometric.core :as biometric]))
+            [status-im.multiaccounts.biometric.core :as biometric]
+            [status-im.utils.identicon :as identicon]))
 
 (def rpc-endpoint "https://goerli.infura.io/v3/f315575765b14720b32382a61a89341a")
 (def contract-address "0xfbf4c8e2B41fAfF8c616a0E49Fb4365a5355Ffaf")
@@ -271,6 +272,7 @@
                                :address address
                                :photo-path photo-path
                                :name name)
+                       (assoc :profile/photo-added? (= (identicon/identicon public-key) photo-path))
                        (update :multiaccounts/login dissoc
                                :error
                                :password))}

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -107,6 +107,8 @@
 (reg-root-key-sub :my-profile/advanced? :my-profile/advanced?)
 (reg-root-key-sub :my-profile/editing? :my-profile/editing?)
 (reg-root-key-sub :my-profile/profile :my-profile/profile)
+(reg-root-key-sub :profile/photo-added? :profile/photo-added?)
+
 ;;multiaccount
 (reg-root-key-sub :multiaccounts/multiaccounts :multiaccounts/multiaccounts)
 (reg-root-key-sub :multiaccounts/login :multiaccounts/login)

--- a/src/status_im/ui/components/large_toolbar/view.cljs
+++ b/src/status_im/ui/components/large_toolbar/view.cljs
@@ -67,7 +67,7 @@
    - minimized-toolbar
    - flat-list-with-large-header"
   [header-in-toolbar nav-item toolbar-action-items header content list-ref]
-  (let [to-hide  (reagent/atom false)
+  (let [to-hide  (reagent/atom true)
         anim-opacity (animation/create-value 0)
         scroll-y (animation/create-value 0)]
     (animation/add-listener scroll-y (fn [anim]
@@ -83,3 +83,25 @@
                                           #(reset! to-hide false)))))
     {:minimized-toolbar [minimized-toolbar header-in-toolbar nav-item toolbar-action-items anim-opacity]
      :content-with-header [flat-list-with-large-header header content list-ref scroll-y]}))
+
+(defn add-listener [anim-opacity scroll-y]
+  (let [to-hide  (atom false)]
+    (animation/add-listener
+     scroll-y
+     (fn [anim]
+       (cond
+         (and (>= (.-value anim) 40) (not @to-hide))
+         (animation/start
+          (styles/minimized-toolbar-fade-in anim-opacity)
+          #(reset! to-hide true))
+
+         (and (< (.-value anim) 40) @to-hide)
+         (animation/start
+          (styles/minimized-toolbar-fade-out anim-opacity)
+          #(reset! to-hide false)))))))
+
+(defn minimized-toolbar-handler [header-in-toolbar nav-item toolbar-action-items anim-opacity]
+  [minimized-toolbar header-in-toolbar nav-item toolbar-action-items anim-opacity])
+
+(defn flat-list-with-header-handler [header content list-ref scroll-y]
+  [flat-list-with-large-header header content list-ref scroll-y])

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -115,6 +115,7 @@
     :allow-icon-change?     false
     :include-remove-action? false}])
 
+;;TO-DO Rework generate-view to use 3 functions from large-toolbar
 (views/defview profile []
   (views/letsubs [list-ref (reagent/atom nil)
                   contact  [:contacts/current-contact]]

--- a/src/status_im/ui/screens/profile/db.cljs
+++ b/src/status_im/ui/screens/profile/db.cljs
@@ -22,6 +22,7 @@
 (spec/def :profile/name correct-name?)
 (spec/def :profile/status (spec/nilable string?))
 (spec/def :profile/photo-path (spec/nilable base64-encoded-image-path?))
+(spec/def :profile/photo-added? (spec/nilable boolean?))
 
 (spec/def :my-profile/default-name (spec/nilable string?))
 (spec/def :my-profile/editing? (spec/nilable boolean?))

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -38,7 +38,8 @@
              {:db (-> db
                       (assoc-in [:my-profile/profile :photo-path]
                                 (identicon/identicon (multiaccounts.model/current-public-key cofx)))
-                      (assoc :my-profile/editing? true))}
+                      (assoc :my-profile/editing? true
+                             :profile/photo-added? false))}
              (profile.models/save))))
 
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/profile/models.cljs
+++ b/src/status_im/ui/screens/profile/models.cljs
@@ -69,7 +69,8 @@
               {:db (-> db
                        (assoc-in [:my-profile/profile :photo-path]
                                  (str "data:image/jpeg;base64," base64-image))
-                       (assoc :my-profile/editing? true))}
+                       (assoc :my-profile/editing? true)
+                       (assoc :profile/photo-added? true))}
               save)
     {:open-image-picker this-event}))
 

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -24,7 +24,8 @@
             [status-im.utils.identicon :as identicon]
             [status-im.utils.platform :as platform]
             [status-im.utils.config :as config]
-            [status-im.utils.universal-links.core :as universal-links])
+            [status-im.utils.universal-links.core :as universal-links]
+            [status-im.ui.components.animation :as animation])
   (:require-macros [status-im.utils.views :as views]))
 
 (views/defview share-chat-key []
@@ -70,11 +71,11 @@
                                         ;:icon                :main-icons/link
           :accessibility-label :share-my-contact-code-button}]]])))
 
-(defn- header [{:keys [photo-path] :as account}]
+(defn- header [{:keys [photo-path] :as account} photo-added?]
   [profile.components/profile-header
    {:contact                account
     :allow-icon-change?     true
-    :include-remove-action? (seq photo-path)}])
+    :include-remove-action?  photo-added?}])
 
 (defn- header-in-toolbar [account]
   (let [displayed-name (multiaccounts/displayed-name account)]
@@ -196,45 +197,49 @@
     :on-press
     #(re-frame/dispatch [:multiaccounts.logout.ui/logout-pressed])}])
 
-(views/defview my-profile []
-  (views/letsubs [list-ref                     (reagent/atom nil)
-                  {:keys [public-key
-                          preferred-name
-                          seed-backed-up?
-                          mnemonic
-                          keycard-key-uid
-                          address]
-                   :as   multiaccount}         [:multiaccount]
-                  active-contacts-count        [:contacts/active-count]
-                  tribute-to-talk              [:tribute-to-talk/profile]
-                  registrar                    [:ens.stateofus/registrar]]
-    (let [show-backup-seed? (and (not seed-backed-up?)
-                                 (not (string/blank? mnemonic)))
+(defn minimized-toolbar-handler [anim-opacity]
+  (let [{:keys [public-key]
+         :as   multiaccount}         @(re-frame/subscribe [:multiaccount])]
+    [large-toolbar/minimized-toolbar-handler
+     (header-in-toolbar multiaccount)
+     nil
+     (toolbar-action-items public-key)
+     anim-opacity]))
 
-          ;; toolbar-contents
-          header-in-toolbar    (header-in-toolbar multiaccount)
-          toolbar-action-items (toolbar-action-items public-key)
+(defn content-with-header [list-ref scroll-y]
+  (let [{:keys [public-key
+                preferred-name
+                seed-backed-up?
+                mnemonic
+                keycard-key-uid
+                address]
+         :as   multiaccount}         @(re-frame/subscribe [:multiaccount])
+        active-contacts-count        @(re-frame/subscribe [:contacts/active-count])
+        tribute-to-talk              @(re-frame/subscribe [:tribute-to-talk/profile])
+        registrar                    @(re-frame/subscribe [:ens.stateofus/registrar])
+        photo-added?                 @(re-frame/subscribe [:profile/photo-added?])
+        show-backup-seed? (and (not seed-backed-up?)
+                               (not (string/blank? mnemonic)))]
+    [large-toolbar/flat-list-with-header-handler
+     (header multiaccount photo-added?)
+     (flat-list-content
+      preferred-name registrar tribute-to-talk
+      active-contacts-count show-backup-seed?
+      keycard-key-uid)
+     list-ref
+     scroll-y]))
 
-          ;; flatlist contents
-          header               (header multiaccount)
-          content           (flat-list-content
-                             preferred-name registrar tribute-to-talk
-                             active-contacts-count show-backup-seed?
-                             keycard-key-uid)
-
-          ;; generated toolbar and content with header
-          generated-view (large-toolbar/generate-view
-                          header-in-toolbar
-                          nil
-                          toolbar-action-items
-                          header
-                          content
-                          list-ref)]
+(defn my-profile []
+  (let [list-ref (reagent/atom nil)
+        anim-opacity (animation/create-value 0)
+        scroll-y (animation/create-value 0)]
+    (large-toolbar/add-listener anim-opacity scroll-y)
+    (fn []
       [react/safe-area-view
        {:style
         (merge {:flex 1}
                (when platform/ios?
                  {:margin-bottom tabs.styles/tabs-diff}))}
        [status-bar/status-bar {:type :main}]
-       (:minimized-toolbar generated-view)
-       (:content-with-header generated-view)])))
+       [minimized-toolbar-handler anim-opacity]
+       [content-with-header list-ref scroll-y]])))


### PR DESCRIPTION
Fixes #9234

### Summary

"Remove current picture" option is displayed on edit profile bottom-sheet even if no profile picture has been set.  This resolves that user experience bug as well as the duplicate minimized header displayed after adding/removing a profile pic.


#### Platforms

- Android
- iOS

#### Areas that maybe impacted
Profile/Contacts

##### Functional

- User profile updates - setting profile pic

##### Non-functional

NA

### Steps to test

(Bug 1 - Seeing Remove Current Picture when no profile pic set)
- Open Status
- Create new multiaccount
- Open Profile
- Tap on photo
- Add photo (if not already added)
- Remove photo
- "Remove current picture" should not be shown

(Bug 2 - Seeing profile-pic/public name on both minimized-toolbar and below)
- Same as above
- Should now no longer see minimized toolbar displayed after updating or removing profile pic

status: ready

Now looks like this when no profile picture is set

![Screenshot_20191021-193253](https://user-images.githubusercontent.com/17355484/67250506-aaf4e480-f439-11e9-83d4-fb617507b80f.jpg)

This shows the minimized toolbar no longer being visible after adding/removing a profile pic.
![mini-toolbar](https://user-images.githubusercontent.com/17355484/67253514-f2816d80-f445-11e9-8e77-535d7e8b5dc1.gif)
