### PR TITLE
include status-go params to set version and commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ android-install: export _NIX_ATTR := targets.mobile.android.adb.shell
 android-install: export TARGET_OS ?= android
 android-install: export BUILD_TYPE ?= release
 android-install:
-	adb install result/app.apk
+	adb install result/app-$(BUILD_TYPE).apk
 
 _list: SHELL := /bin/sh
 _list:

--- a/nix/status-go/build-status-go.nix
+++ b/nix/status-go/build-status-go.nix
@@ -28,24 +28,6 @@ let
     # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
     hardeningDisable = [ "fortify" ];
 
-    # gomobile doesn't seem to be able to pass -ldflags with multiple values correctly to go build, so we just patch files here  
-    patchPhase = ''
-      date=$(date -u '+%Y-%m-%d.%H:%M:%S')
-
-      substituteInPlace cmd/statusd/main.go --replace \
-        "buildStamp = \"N/A\"" \
-        "buildStamp = \"$date\""
-      substituteInPlace params/version.go --replace \
-        "var Version string" \
-        "var Version string = \"${version}\""
-      substituteInPlace params/version.go --replace \
-        "var GitCommit string" \
-        "var GitCommit string = \"${rev}\""
-      substituteInPlace vendor/github.com/ethereum/go-ethereum/metrics/metrics.go --replace \
-        "var EnabledStr = \"false\"" \
-        "var EnabledStr = \"true\""
-    '';
-
     # Ensure XCode is present, instead of failing at the end of the build
     preConfigure = lib.optionalString isDarwin utils.enforceXCodeAvailable;
 

--- a/scripts/update-status-go.sh
+++ b/scripts/update-status-go.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -z "${IN_NIX_SHELL}" ]]; then
+    echo "Remember to call 'make shell'!"
+    exit 1
+fi
+
 set -eof pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)


### PR DESCRIPTION
While working on https://github.com/status-im/status-go/pull/1648 which implements new Prometheus metrics for `status-go` based on peer name I've stumbled upon the lack of `status-go` version in the peer name of the mobile app, which can be also found in the "About" page:
![Screenshot_20191022-144004](https://user-images.githubusercontent.com/2212681/67287042-acc2b480-f4da-11e9-925c-82f6bed39a9b.jpg)
Where the proper peer name should look like:
```
StatusIM/v0.34.0-beta.3/android-arm64/go1.12.9
```

Adam showed me that the `status-go` version comes from the `params`:
https://github.com/status-im/status-go/blob/81b0a7b2/params/config.go#L248-L252
Which used to be sed via the `-X` flag for `-ldflags` in the `Makefile`:
https://github.com/status-im/status-go/blob/81b0a7b2/Makefile#L22-L23

This doesn't work, because `NewNodeConfig` function is never called, so `config.Version` stays empty. This was fixed in https://github.com/status-im/status-go/pull/1656 and this PR implements that fix in `status-react` by adjusting how `status-go` is built by Nix, also updates its version.

Fixes #9270.