### PR TITLE
avoid spawning too many Nix shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ HOST_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 # This can come from Jenkins
 ifndef BUILD_TAG
-export BUILD_TAG = $(shell git rev-parse --short HEAD)
+export BUILD_TAG := $(shell git rev-parse --short HEAD)
 endif
 
 # Defines which variables will be kept for Nix pure shell, use semicolon as divider
@@ -322,6 +322,7 @@ _unknown-startdev-target-%:
 	${MAKE} _list | grep "watch-" | sed s/watch-/startdev-/; \
 	exit 1
 
+_startdev-%: SHELL := /bin/sh
 _startdev-%:
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
 	$(eval DEVICE := $(word 3, $(subst -, , $@)))


### PR DESCRIPTION
This fixes `make` calling `nix/shell.sh` too many times, resulting in output like this:
```bash
 ~/status-react$ make shell TARGET_OS=android
Env is missing TARGET_OS, assuming no target platform. See nix/README.md for more details.
Configuring default Nix shell for target ''...
Env is missing TARGET_OS, assuming no target platform. See nix/README.md for more details.
Configuring default Nix shell for target ''...
Configuring default Nix shell for target 'android'...
Checking for modifications in node_modules...
```
By using the `:=` assignment I delegate that command till when `BUILD_TAG` is actually needed.
Also, setting `SHELL` for `_startdev-%` target limits the number of Nix shells opened.