### PR TITLE
Fix #9180

### DIFF
--- a/src/status_im/wallet/choose_recipient/core.cljs
+++ b/src/status_im/wallet/choose_recipient/core.cljs
@@ -83,7 +83,9 @@
       (if (ethereum/address? recipient)
         (let [checksum (eip55/address->checksum recipient)]
           (if (eip55/valid-address-checksum? checksum)
-            {:db       (assoc-in db [:wallet :send-transaction :to] checksum)
+            {:db       (-> db
+                           (assoc-in [:wallet :send-transaction :to] checksum)
+                           (assoc-in [:wallet :send-transaction :to-name] nil))
              :dispatch [:navigate-back]}
             {:ui/show-error (i18n/label :t/wallet-invalid-address-checksum {:data recipient})}))
         {:ui/show-error (i18n/label :t/wallet-invalid-address {:data recipient})}))))


### PR DESCRIPTION
fixes #9180 

### Summary

When you start a send-transaction and select an address from contacts, then switch the recipient to a pasted address, the "To" name remains corresponding to the previous address imported from contacts.
This PR resolves the above issue.

#### Review Notes
This only impacts the process when entering a recipient address manually.  Scanning with a QR code already works as expected.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Wallet

##### Functional

- wallet / send-transactions

##### Non-functional

N/A

### Steps to test

- Open Status
- Go to Wallet > Send
- Select account in "Recipient" field and then select an account
- Note "To" name that appears above recipient address
- Tap on "Recipient" field again and > Enter recipient address > paste valid address > Done
- Verify that "To" name no longer appears

status: ready 

Video demo of working code
![suppress-stale-name](https://user-images.githubusercontent.com/17355484/67596047-dc212d80-f735-11e9-9958-aae7020d6758.gif)
