### PR TITLE
Increase number on 'unread' messages indicator to +99

### DIFF
--- a/src/status_im/ui/components/badge.cljs
+++ b/src/status_im/ui/components/badge.cljs
@@ -1,6 +1,7 @@
 (ns status-im.ui.components.badge
   (:require [status-im.ui.components.react :as react]
-            [status-im.ui.components.colors :as colors]))
+            [status-im.ui.components.colors :as colors]
+            [status-im.i18n :as i18n]))
 
 (defn badge [label & [small?]]
   [react/view (merge
@@ -11,3 +12,10 @@
                 :justify-content :center
                 :align-items :center})
    [react/text {:style {:typography :caption :color colors/white}} label]])
+
+(defn message-counter [value & [small?]]
+  [badge
+   (if (> value 99)
+     (i18n/label :t/counter-99-plus)
+     value)
+   small?])

--- a/src/status_im/ui/components/tabbar/core.cljs
+++ b/src/status_im/ui/components/tabbar/core.cljs
@@ -7,6 +7,7 @@
    [status-im.utils.platform :as platform]
    [status-im.ui.components.icons.vector-icons :as vector-icons]
    [status-im.ui.components.common.common :as components.common]
+   [status-im.ui.components.badge :as badge]
    [status-im.i18n :as i18n]
    [re-frame.core :as re-frame]))
 
@@ -67,8 +68,10 @@
        {:style tabs.styles/icon-container}
        [vector-icons/icon icon (tabs.styles/icon active?)]
        (when (pos? (if count @count 0))
-         [react/view tabs.styles/counter
-          [components.common/counter @count]])]
+         [react/view {:style (if (= nav-stack :chat-stack)
+                               tabs.styles/message-counter
+                               tabs.styles/counter)}
+          [badge/message-counter @count true]])]
       (when-not platform/desktop?
         [react/view {:style tabs.styles/tab-title-container}
          [react/text {:style (tabs.styles/new-tab-title active?)}

--- a/src/status_im/ui/components/tabbar/styles.cljs
+++ b/src/status_im/ui/components/tabbar/styles.cljs
@@ -46,6 +46,11 @@
    :top      0
    :position :absolute})
 
+(def message-counter
+  {:right    -10
+   :top      0
+   :position :absolute})
+
 (def touchable-container
   {:flex   1
    :height tabs-height})

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -8,6 +8,7 @@
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.ui.components.common.common :as components.common]
             [status-im.ui.components.list-item.views :as list-item]
+            [status-im.ui.components.badge :as badge]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.home.styles :as styles]
             [status-im.utils.contenthash :as contenthash]
@@ -64,9 +65,7 @@
 (defview unviewed-indicator [chat-id]
   (letsubs [unviewed-messages-count [:chats/unviewed-messages-count chat-id]]
     (when (pos? unviewed-messages-count)
-      [components.common/counter {:size                22
-                                  :accessibility-label :unread-messages-count-text}
-       unviewed-messages-count])))
+      [badge/message-counter unviewed-messages-count])))
 
 (defn home-list-item [[_ home-item]]
   (let [{:keys

--- a/translations/en.json
+++ b/translations/en.json
@@ -172,6 +172,7 @@
 	"copy-transaction-hash": "Copy transaction ID",
 	"cost-fee": "Cost/Fee",
 	"counter-9-plus": "9+",
+	"counter-99-plus": "99+",
 	"create": "Create",
 	"create-a-pin": "Create a 6-digit passcode",
 	"create-group-chat": "Create group chat",


### PR DESCRIPTION
Completes #8676 

### Summary

Previously the unread message counter showed 9+ if the number of unread messages was greater than 9. This PR ups that limit to 99 and will show '99+' when above that limit.

*< 100 messages*

<img width="441" alt="Screen Shot 2019-10-29 at 9 50 35 PM" src="https://user-images.githubusercontent.com/108522/67825146-62bb6f00-fa96-11e9-9557-79f54c0f24ce.png">

*>= 100 messages*

<img width="439" alt="Screen Shot 2019-10-29 at 9 50 52 PM" src="https://user-images.githubusercontent.com/108522/67825162-6e0e9a80-fa96-11e9-8405-043d06b2514d.png">

### Review notes

Translations are incomplete. It only containers a '99+' string for `en` or English.

Some file changes happened on their own during the build process. I need some guidance on how whether or not to commit these.

There also seems to be some inconsistent formatting in `en.json`, my editor normalized it automatically. Let me know if you'd like me to remove these changes.

Also, please let me know if you'd like anything organized differently.

### Testing notes

No unit tests currently.

#### Platforms

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted

Tab bar.
Chat list view.

##### Functional

- 1-1 chats
- public chats
- group chats

##### Non-functional

None.

### Steps to test

1-on-1 chat: Message between 2 accounts with 100 unread messages.
Group chat: Join a popular group chat and wait until 100 unread messages.

Confirm '99+' displays in both chat list item and tab bar.

Status: WIP, looking for guidance with above items in "Review notes".
