### PR TITLE
Set max decimal places at 6 for signing sheet

### DIFF
--- a/src/status_im/ui/screens/signing/views.cljs
+++ b/src/status_im/ui/screens/signing/views.cljs
@@ -21,7 +21,8 @@
             [clojure.string :as string]
             [status-im.ui.screens.signing.styles :as styles]
             [status-im.react-native.resources :as resources]
-            [status-im.ui.screens.hardwallet.pin.views :as pin.views]))
+            [status-im.ui.screens.hardwallet.pin.views :as pin.views]
+            [status-im.utils.utils :as utils]))
 
 (defn hide-panel-anim
   [bottom-anim-value alpha-value window-height]
@@ -229,7 +230,7 @@
       :title :t/send-request-amount
       :error amount-error
       :accessories [[react/nested-text {:style {:color colors/gray}}
-                     [{:style {:color colors/black}} (str (or amount 0))]
+                     [{:style {:color colors/black}} (utils/format-decimals amount 6)]
                      " "
                      (or display-symbol fee-display-symbol)
                      " • "
@@ -249,7 +250,7 @@
       :title       :t/network-fee
       :error       gas-error
       :accessories [[react/nested-text {:style {:color colors/gray}}
-                     [{:style {:color colors/black}} fee]
+                     [{:style {:color colors/black}} (utils/format-decimals fee 6)]
                      " "
                      fee-display-symbol
                      " • "

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -1,5 +1,8 @@
 (ns status-im.utils.utils
-  (:require [status-im.i18n :as i18n]
+  (:require [clojure.string :as string]
+            [goog.string :as gstring]
+            [goog.string.format]
+            [status-im.i18n :as i18n]
             [status-im.react-native.js-dependencies :as rn-dependencies]
             [re-frame.core :as re-frame]
             [status-im.utils.platform :as platform]
@@ -151,3 +154,9 @@
   (if platform/desktop?
     (js/clearInterval id)
     (.clearInterval rn-dependencies/background-timer id)))
+
+(defn format-decimals [amount places]
+  (let [decimal-part (get (string/split (str amount) ".") 1)]
+    (if (> (count decimal-part) places)
+      (gstring/format (str "%." places "f") amount)
+      (or (str amount) 0))))

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -49,3 +49,9 @@
   (is (= {:a 1 :b 2} (u/deep-merge {:a 1} {:b 2})))
   (is (= {:a {:b 1 :c 2}} (u/deep-merge {:a {:b 1 :c 1}} {:a {:c 2}})))
   (is (= {:a {:b {:c 2}} :d 1} (u/deep-merge {:a {:b {:c 1}} :d 1} {:a {:b {:c 2}}}))))
+
+(deftest format-decimals-test
+  (is (= "1" (uu/format-decimals 1 5)))
+  (is (= "1.1" (uu/format-decimals 1.1 5)))
+  (is (= "1.111111" (uu/format-decimals 1.111111 7)))
+  (is (= "1.1" (uu/format-decimals 1.111 1))))


### PR DESCRIPTION
Fixes #9235 

### Summary

Amount and Network fee values overlap labels on signing sheet.  This resolves the issue by setting a maximum length and truncating any characters/digits in the value that exceed that length

### Review notes
As currently designed, it has the possibility of displaying a 0 in the last position of each value since I'm just trimming the string version of each value to fit in the field without overlapping the label.



#### Platforms
- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

* Open Status and create new account
* Navigate to Wallet -> Status account -> Send and select any Recipient
* Enter in Amount field the 0.0848969596969696969 value -> Sign transaction
* Tap Network Fee and update gas price to 1.0989898
* Verify that amount and network fee amounts are truncated to 6 digits of precision.

status: ready 
![Screenshot_20191115-113012](https://user-images.githubusercontent.com/17355484/68962204-064c9500-07a2-11ea-9e38-2d5a811e6a6b.jpg)