### PR TITLE
Dont use network info but only rely on peers count for mailservers

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -472,16 +472,6 @@
   [{:keys [db]}]
   {:db (dissoc db :mailserver/request-to)})
 
-(fx/defn network-connection-status-changed
-  "when host reconnects, reset request-to and
-  reconnect to mailserver"
-  [{:keys [db] :as cofx} is-connected?]
-  (when (and (multiaccounts.model/logged-in? cofx)
-             is-connected?)
-    (fx/merge cofx
-              (reset-request-to)
-              (connect-to-mailserver))))
-
 (fx/defn remove-gaps
   [{:keys [db] :as cofx} chat-id]
   (fx/merge cofx

--- a/src/status_im/network/net_info.cljs
+++ b/src/status_im/network/net_info.cljs
@@ -16,8 +16,7 @@
             {:db (assoc db :network-status (if is-connected? :online :offline))}
             (when is-connected?
               (if-not (= (count (get-in db [:wallet :accounts])) (count (get-in db [:multiaccount :accounts])))
-                (wallet/update-balances nil)))
-            (mailserver/network-connection-status-changed is-connected?)))
+                (wallet/update-balances nil)))))
 
 (fx/defn change-network-type
   [{:keys [db] :as cofx} old-network-type network-type expensive?]

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -72,7 +72,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         chat_2.connection_status.wait_for_invisibility_of_element(60)
         message_2 = 'one more message'
         chat_2.chat_message_input.send_keys(message_2)
-        chat_2.send_message_button.click()
+        chat_2.send_message_button.click_until_absense_of_element(chat_2.send_message_button)
 
         home_1.toggle_airplane_mode()  # turning on WiFi connection on primary device
 

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -280,3 +280,14 @@ class BaseButton(BaseElement):
                 return self.navigate()
             except (NoSuchElementException, TimeoutException):
                 counter += 1
+
+    def click_until_absense_of_element(self, desired_element, attempts=3):
+        counter = 0
+        while desired_element.is_element_present(1) and counter <= attempts:
+            try:
+                self.driver.info('Tap on %s' % self.name)
+                self.find_element().click()
+                self.driver.info('Wait for %s' % desired_element.name)
+                counter += 1
+            except (NoSuchElementException, TimeoutException):
+                return self.navigate()


### PR DESCRIPTION
This code was still relaying on the OS network offline/online detection, the correct behavior is to solely rely on peers count for chat related activies.
status: ready