### PR TITLE
[Fixes: #9400] Fix last-group

### DIFF
--- a/src/status_im/chat/models/message_list.cljs
+++ b/src/status_im/chat/models/message_list.cljs
@@ -15,9 +15,11 @@
 (defn prepare-message [{:keys [message-id
                                clock-value
                                message-type
+                               from
                                outgoing
                                whisper-timestamp]}]
   (-> {:whisper-timestamp whisper-timestamp
+       :from from
        :one-to-one? (= :user-message message-type)
        :system-message? (= :system-message message-type)
        :clock-value clock-value
@@ -74,8 +76,7 @@
                                   outgoing)
            :first-in-group?   (or (nil? previous-message)
                                   (not (same-group? current-message previous-message)))
-           :last-in-group?    (or (nil? next-message)
-                                  (not (same-group? current-message next-message)))
+           :last-in-group?    last-in-group?
            :display-username? (and last-in-group?
                                    (not outgoing)
                                    (not one-to-one?))
@@ -154,3 +155,8 @@
   (reduce add
           message-list
           messages))
+
+(defn ->seq [message-list]
+  (if message-list
+    (array-seq (.-values message-list))
+    []))

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -9,6 +9,7 @@
             [status-im.chat.constants :as chat.constants]
             [status-im.chat.db :as chat.db]
             [status-im.chat.models :as chat.models]
+            [status-im.chat.models.message-list :as models.message-list]
             [status-im.constants :as constants]
             [status-im.contact.db :as contact.db]
             [status-im.ethereum.core :as ethereum]
@@ -760,9 +761,7 @@
  :<- [:chats/all-loaded?]
  :<- [:chats/public?]
  (fn [[message-list messages messages-gaps range all-loaded? public?]]
-   (-> (if message-list
-         (array-seq (.-values message-list))
-         [])
+   (-> (models.message-list/->seq message-list)
        (chat.db/add-datemarks)
        (hydrate-messages messages)
        (chat.db/add-gaps messages-gaps range all-loaded? public?))))

--- a/test/cljs/status_im/test/chat/models/message_list.cljs
+++ b/test/cljs/status_im/test/chat/models/message_list.cljs
@@ -26,7 +26,7 @@
           messages (shuffle [m1 m2 m3])
           [actual-m1
            actual-m2
-           actual-m3] (vals (s/build messages))]
+           actual-m3] (s/->seq (s/add-many nil messages))]
       (testing "it sorts them correclty"
         (is (= "message-3" (:message-id actual-m1)))
         (is (= "message-2" (:message-id actual-m2)))
@@ -65,7 +65,7 @@
 (def random-range (shuffle ascending-range))
 
 (defnp build-message-list [messages]
-  (s/build messages))
+  (s/add-many nil messages))
 
 (defnp append-to-message-list [l message]
   (s/add l message))
@@ -84,7 +84,7 @@
 
 (deftest ^:benchmark benchmark-list
   (let [messages (sort-by :timestamp (mapv (fn [i] (let [i (+ 100000 i 1)] {:timestamp i :clock-value i :message-id (str i) :whisper-timestamp i})) (range 100)))
-        built-list (s/build messages)]
+        built-list (s/add-many nil messages)]
     (testing "prepending to list"
       (profile {} (dotimes [_ 10] (prepend-to-message-list
                                    built-list
@@ -127,7 +127,7 @@
                            :message-id "103"
                            :timestamp 3
                            :whisper-timestamp 3}]
-        current-list (s/build current-messages)]
+        current-list (s/add-many nil current-messages)]
     (testing "inserting a newer message"
       (let [new-message {:timestamp 12
                          :clock-value 112
@@ -135,7 +135,7 @@
                          :whisper-timestamp 12}]
         (is (= 112
                (-> (s/add current-list new-message)
-                   vals
+                   (s/->seq)
                    first
                    :clock-value)))))
     (testing "inserting an older message"
@@ -145,7 +145,7 @@
                          :whisper-timestamp 0}]
         (is (= 100
                (-> (s/add current-list new-message)
-                   vals
+                   (s/->seq)
                    last
                    :clock-value)))))
     (testing "inserting in the middle of the list"
@@ -155,7 +155,7 @@
                          :whisper-timestamp 7}]
         (is (= 107
                (-> (s/add current-list new-message)
-                   vals
+                   (s/->seq)
                    (nth 1)
                    :clock-value)))))
     (testing "inserting in the middle of the list, clock-value clash"
@@ -165,6 +165,6 @@
                          :whisper-timestamp 6}]
         (is (= "106a"
                (-> (s/add current-list new-message)
-                   vals
-                   (nth 1)
+                   (s/->seq)
+                   (nth 2)
                    :message-id)))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -9,6 +9,7 @@
             [status-im.test.chat.models.input]
             [status-im.test.chat.models.message-content]
             [status-im.test.chat.models.message]
+            [status-im.test.chat.models.message-list]
             [status-im.test.chat.models]
             [status-im.test.chat.views.photos]
             [status-im.test.transport.filters.core]
@@ -85,6 +86,7 @@
  'status-im.test.chat.models
  'status-im.test.chat.models.input
  'status-im.test.chat.models.message
+ 'status-im.test.chat.models.message-list
  'status-im.test.chat.models.message-content
  'status-im.test.chat.views.photos
  'status-im.test.transport.filters.core


### PR DESCRIPTION
The from parameter was left out, tests did not pick it up as they were
not running, probably I have wrongly rebased the code and did not
include the new namespace in runner.cljs

status: ready