### PR TITLE
Fix replies, clear-history, logout bug

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -151,7 +151,7 @@
      cofx
      {:db            (update-in db [:chats chat-id] merge
                                 {:messages                  {}
-                                 :message-groups            {}
+                                 :message-list              nil
                                  :last-message-content      nil
                                  :last-message-content-type nil
                                  :last-message-timestamp    nil

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -14,8 +14,6 @@
 (s/def :chat/public-group-topic (s/nilable string?))
 (s/def :chat/public-group-topic-error (s/nilable string?))
 (s/def :chat/messages (s/nilable map?))                           ; messages indexed by message-id
-(s/def :chat/message-groups (s/nilable map?))                     ; grouped/sorted messages
-(s/def :chat/referenced-messages (s/nilable map?))                ; map of messages indexed by message-id which are not displayed directly, but referenced by other messages
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))
 (s/def :chat/bot-db (s/nilable map?))

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -121,7 +121,7 @@
                                 :deleted-at-clock-value :deletedAtClockValue
                                 :is-active :active
                                 :last-clock-value :lastClockValue})
-      (dissoc :referenced-messages :message-groups :gaps-loaded? :pagination-info
+      (dissoc :message-list :gaps-loaded? :pagination-info
               :public? :group-chat :messages
               :might-have-join-time-messages?
               :loaded-unviewed-messages-ids

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -712,12 +712,6 @@
    (or messages {})))
 
 (re-frame/reg-sub
- :chats/current-chat-message-groups
- :<- [:chats/current-chat]
- (fn [{:keys [message-groups]}]
-   (or message-groups {})))
-
-(re-frame/reg-sub
  :chats/messages-gaps
  :<- [:mailserver/gaps]
  :<- [:chats/current-chat-id]

--- a/src/status_im/transport/impl/receive.cljs
+++ b/src/status_im/transport/impl/receive.cljs
@@ -64,6 +64,6 @@
                          :identicon (get-in cofx [:metadata :author :identicon])
                          :from signature
                          :metadata (:metadata cofx))]
-      (fx/merge
-       (chat.message/receive-one cofx message)
-       (ens/verify-names-from-message this signature)))))
+      (fx/merge cofx
+                (chat.message/receive-one message)
+                (ens/verify-names-from-message this signature)))))

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -24,7 +24,7 @@
         built-message
         (protocol/Message.
          {:text (.-text content)
-          :response-to (.-response-to content)
+          :response-to (aget content "response-to")
           :name (.-name content)
           :chat-id (.-chat_id content)}
          (.-content_type parsed-message-js)

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -300,9 +300,7 @@
                                    :chat/public-group-topic
                                    :chat/public-group-topic-error
                                    :chat/messages
-                                   :chat/message-groups
                                    :chat/message-statuses
-                                   :chat/referenced-messages
                                    :chat/last-clock-value
                                    :chat/loaded-chats
                                    :chat/bot-db

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -64,7 +64,7 @@
 
 (deftest clear-history-test
   (let [chat-id "1"
-        cofx    {:db {:chats {chat-id {:message-groups          {:something "a"}
+        cofx    {:db {:chats {chat-id {:message-list            [{:something "a"}]
                                        :messages                {"1" {:clock-value 1}
                                                                  "2" {:clock-value 10}
                                                                  "3" {:clock-value 2}}
@@ -74,7 +74,7 @@
         (is (= {} (get-in actual [:db :chats chat-id :messages])))))
     (testing "it deletes all the message groups"
       (let [actual (chat/clear-history cofx chat-id)]
-        (is (= {} (get-in actual [:db :chats chat-id :message-groups])))))
+        (is (= nil (get-in actual [:db :chats chat-id :message-list])))))
     (testing "it deletes unviewed messages set"
       (let [actual (chat/clear-history cofx chat-id)]
         (is (= 0 (get-in actual [:db :chats chat-id :unviewed-messages-count])))))

--- a/test/cljs/status_im/test/data_store/chats.cljs
+++ b/test/cljs/status_im/test/data_store/chats.cljs
@@ -4,10 +4,9 @@
             [status-im.data-store.chats :as chats]))
 
 (deftest ->to-rpc
-  (let [chat {:referenced-messages []
-              :public? false
+  (let [chat {:public? false
               :group-chat true
-              :message-groups {}
+              :message-list []
               :color "color"
               :contacts #{"a" "b" "c" "d"}
               :last-clock-value 10


### PR DESCRIPTION
Fixes #9433 : this was due to the fact that `.-response-to` was
returning nil, because of the dash in the name, instead in this cases
`(aget .. "response-to")` should be used.

Fixes #9431 : This was a left-over from the move from message-groups to
message-list, and the code was not updated.

Fixes #9430 #9429 Both of these were due to the same issue, cofx were
wrongly passed to the function resulting in the db being updated but the
fxs being discarded.

There's still a separate issue that might result in messages not being
saved on logout, because of a race condition (if you logout while is
fetching messages, some of the message might not be saved). I will
address that separately as we might be able to just save messages as
they come in status-go, rather then having to pass them to status-react
and back to status-go for saving.

Might fix #9427 as well

status: ready