### PR TITLE
[#9446] Resume logging when connection to card is restored

### DIFF
--- a/src/status_im/hardwallet/card.cljs
+++ b/src/status_im/hardwallet/card.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as re-frame]
             [status-im.react-native.js-dependencies :as js-dependencies]
             [status-im.utils.config :as config]
-            [status-im.utils.platform :as platform]))
+            [status-im.utils.platform :as platform]
+            [taoensso.timbre :as log]))
 
 (defonce keycard (.-default js-dependencies/status-keycard))
 (defonce event-emitter (.-DeviceEventEmitter js-dependencies/react-native))
@@ -12,6 +13,7 @@
    :error (.-message object)})
 
 (defn check-nfc-support []
+  (log/debug "[keycard] check-nfc-support")
   (when (and config/hardwallet-enabled?
              platform/android?)
     (.. keycard
@@ -19,6 +21,7 @@
         (then #(re-frame/dispatch [:hardwallet.callback/check-nfc-support-success %])))))
 
 (defn check-nfc-enabled []
+  (log/debug "[keycard] check-nfc-enabled")
   (when (and config/hardwallet-enabled?
              platform/android?)
     (.. keycard
@@ -26,6 +29,7 @@
         (then #(re-frame/dispatch [:hardwallet.callback/check-nfc-enabled-success %])))))
 
 (defn open-nfc-settings []
+  (log/debug "[keycard] open-nfc-settings")
   (when platform/android?
     (.openNfcSettings keycard)))
 
@@ -34,6 +38,7 @@
     (.removeAllListeners event-emitter event)))
 
 (defn register-card-events []
+  (log/debug "[keycard] register-card-events")
   (when (and config/hardwallet-enabled?
              platform/android?)
 
@@ -51,12 +56,14 @@
                                        #(re-frame/dispatch [:hardwallet.callback/on-card-disconnected %]))}])))
 
 (defn get-application-info [{:keys [pairing on-success]}]
+  (log/debug "[keycard] get-application-info")
   (.. keycard
       (getApplicationInfo (str pairing))
       (then #(re-frame/dispatch [:hardwallet.callback/on-get-application-info-success % on-success]))
       (catch #(re-frame/dispatch [:hardwallet.callback/on-get-application-info-error (error-object->map %)]))))
 
 (defn install-applet []
+  (log/debug "[keycard] install-applet")
   (when config/hardwallet-enabled?
     (.. keycard
         installApplet
@@ -64,6 +71,7 @@
         (catch #(re-frame/dispatch [:hardwallet.callback/on-install-applet-error (error-object->map %)])))))
 
 (defn init-card [pin]
+  (log/debug "[keycard] init-card")
   (when config/hardwallet-enabled?
     (.. keycard
         (init pin)
@@ -71,6 +79,7 @@
         (catch #(re-frame/dispatch [:hardwallet.callback/on-init-card-error (error-object->map %)])))))
 
 (defn install-applet-and-init-card [pin]
+  (log/debug "[keycard] install-applet-and-init-card")
   (when config/hardwallet-enabled?
     (.. keycard
         (installAppletAndInitCard pin)
@@ -79,6 +88,7 @@
 
 (defn pair
   [{:keys [password]}]
+  (log/debug "[keycard] pair")
   (when password
     (.. keycard
         (pair password)
@@ -87,6 +97,7 @@
 
 (defn generate-mnemonic
   [{:keys [pairing words]}]
+  (log/debug "[keycard] generate-mnemonic")
   (when pairing
     (.. keycard
         (generateMnemonic pairing words)
@@ -95,6 +106,7 @@
 
 (defn generate-and-load-key
   [{:keys [mnemonic pairing pin]}]
+  (log/debug "[keycard] generate-and-load-key")
   (when pairing
     (.. keycard
         (generateAndLoadKey mnemonic pairing pin)
@@ -103,6 +115,7 @@
 
 (defn unblock-pin
   [{:keys [puk new-pin pairing]}]
+  (log/debug "[keycard] unblock-pin")
   (when (and pairing new-pin puk)
     (.. keycard
         (unblockPin pairing puk new-pin)
@@ -111,6 +124,7 @@
 
 (defn verify-pin
   [{:keys [pin pairing]}]
+  (log/debug "[keycard] verify-pin")
   (when (and pairing (not-empty pin))
     (.. keycard
         (verifyPin pairing pin)
@@ -119,6 +133,7 @@
 
 (defn change-pin
   [{:keys [current-pin new-pin pairing]}]
+  (log/debug "[keycard] change-pin")
   (when (and pairing current-pin new-pin)
     (.. keycard
         (changePin pairing current-pin new-pin)
@@ -127,6 +142,7 @@
 
 (defn unpair
   [{:keys [pin pairing]}]
+  (log/debug "[keycard] unpair")
   (when (and pairing pin)
     (.. keycard
         (unpair pairing pin)
@@ -135,6 +151,7 @@
 
 (defn delete
   []
+  (log/debug "[keycard] delete")
   (.. keycard
       (delete)
       (then #(re-frame/dispatch [:hardwallet.callback/on-delete-success %]))
@@ -142,6 +159,7 @@
 
 (defn remove-key
   [{:keys [pin pairing]}]
+  (log/debug "[keycard] remove-key")
   (.. keycard
       (removeKey pairing pin)
       (then #(re-frame/dispatch [:hardwallet.callback/on-remove-key-success %]))
@@ -149,6 +167,7 @@
 
 (defn remove-key-with-unpair
   [{:keys [pin pairing]}]
+  (log/debug "[keycard] remove-key-with-unpair")
   (.. keycard
       (removeKeyWithUnpair pairing pin)
       (then #(re-frame/dispatch [:hardwallet.callback/on-remove-key-success %]))
@@ -156,6 +175,7 @@
 
 (defn unpair-and-delete
   [{:keys [pin pairing]}]
+  (log/debug "[keycard] unpair-and-delete")
   (when (and pairing pin)
     (.. keycard
         (unpairAndDelete pairing pin)
@@ -164,6 +184,7 @@
 
 (defn get-keys
   [{:keys [pairing pin on-success]}]
+  (log/debug "[keycard] get-keys")
   (when (and pairing (not-empty pin))
     (.. keycard
         (getKeys pairing pin)
@@ -172,6 +193,7 @@
 
 (defn sign
   [{:keys [pairing pin hash]}]
+  (log/debug "[keycard] sign")
   (when (and pairing pin hash)
     (.. keycard
         (sign pairing pin hash)

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -5,7 +5,8 @@
             [status-im.react-native.js-dependencies :as rn-dependencies]
             [status-im.ui.components.react :as react]
             [status-im.utils.platform :as platform]
-            [status-im.utils.types :as types]))
+            [status-im.utils.types :as types]
+            [taoensso.timbre :as log]))
 
 (defn status []
   (when (exists? (.-NativeModules rn-dependencies/react-native))
@@ -14,46 +15,56 @@
 (def adjust-resize 16)
 
 (defn clear-web-data []
+  (log/debug "[native-module] clear-web-data")
   (when (status)
     (.clearCookies (status))
     (.clearStorageAPIs (status))))
 
 (defn init-keystore []
+  (log/debug "[native-module] init-keystore")
   (.initKeystore (status)))
 
 (defn open-accounts [callback]
+  (log/debug "[native-module] open-accounts")
   (.openAccounts (status) #(callback (types/json->clj %))))
 
 (defn prepare-dir-and-update-config
   [config callback]
+  (log/debug "[native-module] prepare-dir-and-update-config")
   (.prepareDirAndUpdateConfig (status)
                               config
                               #(callback (types/json->clj %))))
 
 (defn enable-notifications []
+  (log/debug "[native-module] enable-notifications")
   (.enableNotifications (status)))
 
 (defn disable-notifications []
+  (log/debug "[native-module] disable-notifications")
   (.disableNotifications (status)))
 
 (defn save-account-and-login
   "NOTE: beware, the password has to be sha3 hashed"
   [multiaccount-data hashed-password config accounts-data]
+  (log/debug "[native-module] save-account-and-login")
   (clear-web-data)
   (.saveAccountAndLogin (status) multiaccount-data hashed-password config accounts-data))
 
 (defn save-account-and-login-with-keycard
   "NOTE: chat-key is a whisper private key sent from keycard"
   [multiaccount-data password config chat-key]
+  (log/debug "[native-module] save-account-and-login-with-keycard")
   (.saveAccountAndLoginWithKeycard (status) multiaccount-data password config chat-key))
 
 (defn login
   "NOTE: beware, the password has to be sha3 hashed"
   [account-data hashed-password]
+  (log/debug "[native-module] login")
   (clear-web-data)
   (.login (status) account-data hashed-password))
 
 (defn logout []
+  (log/debug "[native-module] logout")
   (clear-web-data)
   (.logout (status)))
 
@@ -68,6 +79,7 @@
    derive accounts from it, because saving an account flushes the loaded keys
    from memory"
   [address hashed-password callback]
+  (log/debug "[native-module] multiaccount-load-account")
   (.multiAccountLoadAccount (status)
                             (types/clj->json {:address address
                                               :password hashed-password})
@@ -77,6 +89,7 @@
   "TODO: this function is not used anywhere
    if usage isn't planned, remove"
   [callback]
+  (log/debug "[native-module]  multiaccount-reset")
   (.multiAccountReset (status)
                       callback))
 
@@ -86,6 +99,7 @@
    with `multiaccount-store-derived` if you want to be able to
    reuse the derived addresses later"
   [account-id paths callback]
+  (log/debug "[native-module]  multiaccount-derive-addresses")
   (when (status)
     (.multiAccountDeriveAddresses (status)
                                   (types/clj->json {:accountID account-id
@@ -101,6 +115,7 @@
    `multiaccount-load-account` before using `multiaccount-store-derived`
    and the id of the account stored will have changed"
   [account-id hashed-password callback]
+  (log/debug "[native-module] multiaccount-store-account")
   (when (status)
     (.multiAccountStoreAccount (status)
                                (types/clj->json {:accountID account-id
@@ -110,6 +125,7 @@
 (defn multiaccount-store-derived
   "NOTE: beware, the password has to be sha3 hashed"
   [account-id paths hashed-password callback]
+  (log/debug "[native-module]  multiaccount-store-derived")
   (.multiAccountStoreDerived (status)
                              (types/clj->json {:accountID account-id
                                                :paths paths
@@ -123,6 +139,7 @@
    `multiaccount-store-account` on the selected multiaccount
    to store the key"
   [n mnemonic-length paths callback]
+  (log/debug "[native-module]  multiaccount-generate-and-derive-addresses")
   (.multiAccountGenerateAndDeriveAddresses (status)
                                            (types/clj->json {:n n
                                                              :mnemonicPhraseLength mnemonic-length
@@ -132,6 +149,7 @@
 
 (defn multiaccount-import-mnemonic
   [mnemonic password callback]
+  (log/debug "[native-module] multiaccount-import-mnemonic")
   (.multiAccountImportMnemonic (status)
                                (types/clj->json {:mnemonicPhrase  mnemonic
                                                  ;;NOTE this is not the multiaccount password
@@ -142,17 +160,22 @@
 (defn verify
   "NOTE: beware, the password has to be sha3 hashed"
   [address hashed-password callback]
+  (log/debug "[native-module] verify")
   (.verify (status) address hashed-password callback))
 
 (defn login-with-keycard
   [{:keys [multiaccount-data password chat-key]}]
+  (log/debug "[native-module] login-with-keycard"
+             "password" password)
   (clear-web-data)
   (.loginWithKeycard (status) multiaccount-data password chat-key))
 
 (defn set-soft-input-mode [mode]
+  (log/debug "[native-module]  set-soft-input-mode")
   (.setSoftInputMode (status) mode))
 
 (defn call-rpc [payload callback]
+  (log/debug "[native-module] call-rpc")
   (.callRPC (status) payload callback))
 
 (defn call-private-rpc [payload callback]
@@ -161,62 +184,77 @@
 (defn hash-transaction
   "used for keycard"
   [rpcParams callback]
+  (log/debug "[native-module] hash-transaction")
   (.hashTransaction (status) rpcParams callback))
 
 (defn hash-message
   "used for keycard"
   [message callback]
+  (log/debug "[native-module] hash-message")
   (.hashMessage (status) message callback))
 
 (defn hash-typed-data
   "used for keycard"
   [data callback]
+  (log/debug "[native-module] hash-typed-data")
   (.hashTypedData (status) data callback))
 
 (defn send-transaction-with-signature
   "used for keycard"
   [rpcParams sig callback]
+  (log/debug "[native-module] send-transaction-with-signature")
   (.sendTransactionWithSignature (status) rpcParams sig callback))
 
 (defn sign-message
   "NOTE: beware, the password in rpcParams has to be sha3 hashed"
   [rpcParams callback]
+  (log/debug "[native-module] sign-message")
   (.signMessage (status) rpcParams callback))
 
 (defn send-transaction
   "NOTE: beware, the password has to be sha3 hashed"
   [rpcParams hashed-password callback]
+  (log/debug "[native-module] send-transaction")
   (.sendTransaction (status) rpcParams hashed-password callback))
 
 (defn sign-typed-data
   "NOTE: beware, the password has to be sha3 hashed"
   [data account hashed-password callback]
+  (log/debug "[native-module] clear-web-data")
   (.signTypedData (status) data account hashed-password callback))
 
 (defn send-logs [dbJson js-logs callback]
+  (log/debug "[native-module] send-logs")
   (.sendLogs (status) dbJson js-logs callback))
 
 (defn add-peer [enode on-result]
+  (log/debug "[native-module] add-peer")
   (.addPeer (status) enode on-result))
 
 (defn close-application []
+  (log/debug "[native-module] close-application")
   (.closeApplication (status)))
 
 (defn connection-change [type expensive?]
+  (log/debug "[native-module] connection-change")
   (.connectionChange (status) type (boolean expensive?)))
 
 (defn app-state-change [state]
+  (log/debug "[native-module] app-state-change")
   (.appStateChange (status) state))
 
 (defn set-blank-preview-flag [flag]
+  (log/debug "[native-module] set-blank-preview-flag")
   (.setBlankPreviewFlag (status) flag))
 
 (defn is24Hour []
+  (log/debug "[native-module] is24Hour")
   ;;NOTE: we have to check for status module because of tests
   (when (status)
     (.-is24Hour (status))))
 
 (defn get-device-model-info []
+  (log/debug "[native-module] get-device-model-info")
   ;;NOTE: we have to check for status module because of tests
   (when (status)
     {:model     (.-model (status))
@@ -226,23 +264,29 @@
 
 (defn extract-group-membership-signatures
   [signature-pairs callback]
+  (log/debug "[native-module] extract-group-membership-signatures")
   (.extractGroupMembershipSignatures (status) signature-pairs callback))
 
 (defn sign-group-membership [content callback]
+  (log/debug "[native-module] sign-group-membership")
   (.signGroupMembership (status) content callback))
 
 (defn update-mailservers
   [enodes on-result]
+  (log/debug "[native-module] update-mailservers")
   (.updateMailservers (status) enodes on-result))
 
 (defn chaos-mode-update [on on-result]
+  (log/debug "[native-module] chaos-mode-update")
   (.chaosModeUpdate (status) on on-result))
 
 (defn get-nodes-from-contract
   [rpc-endpoint contract-address on-result]
+  (log/debug "[native-module] get-nodes-from-contract")
   (.getNodesFromContract (status) rpc-endpoint contract-address on-result))
 
 (defn rooted-device? [callback]
+  (log/debug "[native-module] rooted-device?")
   (cond
     ;; we assume that iOS is safe by default
     platform/ios?
@@ -267,9 +311,11 @@
   "Generate a 3 words random name based on the user public-key, synchronously"
   [public-key]
   {:pre [(utils.db/valid-public-key? public-key)]}
+  (log/debug "[native-module] generate-gfycat")
   (.generateAlias (status) public-key))
 
 (defn identicon
   "Generate a icon based on a string, synchronously"
   [seed]
+  (log/debug "[native-module] identicon")
   (.identicon (status) seed))


### PR DESCRIPTION
fix #9446 

Currently there are two ways to initiate logging in with keycard:
- enter PIN code and after that connect card to the phone
- connect card to the phone and enter PIN after that

Before this commit in both cases when connection to the keyacrd was lost
and then restored, logging in didn't resume. In result a user saw a
pop-up with endless spinner.

The reason of this bug was that `:on-card-connected` and `:on-card-read`
actions were not restored in app-db after losing connection to the card.

This commit introduces helper functions for both `:on-card-connected` and
`:on-card-read` which allow to reset these values and stash them until
particular flow of calls to keycard will be finished. In case if
connection was lost before the flow is finished the valueas are restored
so that it can be succesfully resumed on th next connection.

Also a banch of log entries were added to simplify debugging of
interactions with keycard and native module.

status: ready