### PR TITLE
Fix qr navigation bug in qr scanning

### DIFF
--- a/src/status_im/qr_scanner/core.cljs
+++ b/src/status_im/qr_scanner/core.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.utils.utils :as utils]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            [status-im.utils.navigation :as navigation]))
 
 (fx/defn scan-qr-code
   [{:keys [db]} {:keys [deny-handler] :as identifier} qr-codes]
@@ -21,11 +22,16 @@
 
 (fx/defn set-qr-code
   [{:keys [db]} context data]
-  (merge {:db (-> db
-                  (update :qr-codes dissoc context)
-                  (dissoc :current-qr-context))}
-         (when-let [qr-codes (get-in db [:qr-codes context])]
-           {:dispatch [(:handler qr-codes) context data (dissoc qr-codes :handler)]})))
+  (let [navigation-stack {:chat-stack :home}]
+    (navigation/navigate-reset {:index   0
+                                :key     :chat-stack
+                                :actions [{:routeName :home}]})
+    (merge {:db (-> db
+                    (update :qr-codes dissoc context)
+                    (dissoc :current-qr-context)
+                    (update :navigation-stack navigation-stack))}
+           (when-let [qr-codes (get-in db [:qr-codes context])]
+             {:dispatch [(:handler qr-codes) context data (dissoc qr-codes :handler)]}))))
 
 (fx/defn set-qr-code-cancel
   [{:keys [db]} context]


### PR DESCRIPTION
fixes #9381 

### Summary

When the Scan QR code option is selected from the Chat home navigation and a QR code is scanned, later navigating back to the Chat tab returns to the QR scanner rather than the Chat Home and is clunky to the user.  This fixes this issue and navigates the user to the chat home page upon next tap on the Chat menu item.


#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats


##### Non-functional


### Steps to test

Open Status
(From the Chats Tab) tap on the + plus button
Tap on Scan QR code
Scan some code
Tap Chat to navigate to chat screen
Chat home view should display

status: ready

![fix-qr-scan-navigation](https://user-images.githubusercontent.com/17355484/69089319-208ea900-0a16-11ea-9ebd-e80568fb2e59.gif)
