### PR TITLE
Weak-password disallows confirm code step

### DIFF
--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -138,12 +138,16 @@
 (fx/defn intro-step-forward
   {:events [:intro-wizard/step-forward-pressed]}
   [{:keys [db] :as cofx} {:keys [skip?] :as opts}]
-  (let  [{:keys [step first-time-setup? selected-storage-type processing?]} (:intro-wizard db)]
+  (let  [{:keys [step selected-storage-type processing? weak-password?]} (:intro-wizard db)]
     (cond (confirm-failure? db)
           (on-confirm-failure cofx)
 
           (= step :generate-key)
           (init-key-generation cofx)
+
+          (and  (= step :create-code)
+                (= weak-password? true))
+          nil
 
           (and (= step :confirm-code)
                (not processing?))


### PR DESCRIPTION
fixes #9453 

### Summary

When creating a new account in intro-wizard, on "Select Key Storage" screen, there is a race condition where you can double tap "Next" and skip Create Password Screen and get to "Confirm Password" screen with a blank password.

This PR fixes this bug and doesn't allow user to proceed to "Confirm Password" screen until a password is entered and passes the weak password checks.


### Testing notes
Run ADB logs to see console error message that is printed when user double taps "Next" button.

#### Platforms

- Android
- iOS

##### Functional

-new account

##### Non-functional
NA

### Steps to test

* Open Status
* Tap on "Generate new key"
* Proceed to "Select key storage" screen
* tap "Next" quickly 2 times
* Verify that you can't navigate to "Confirm Password" screen and that "Still weak password so not proceeding" appears in ADB logs

status: ready 
