### PR TITLE
fix nix-clean for MacOS

### DIFF
--- a/nix/clean.sh
+++ b/nix/clean.sh
@@ -15,19 +15,30 @@ function findRelated() {
     path="${1}"
     found+=("${path}")
     if [[ "${path}" =~ .*.chroot ]]; then
-        log " ! Chroot:    ${path}"
-        continue
+        log " ! Chroot:     ${path}"
+        return
+    elif [[ "${path}" =~ .*.lock ]]; then
+        log " ! Lock:       ${path}"
+        return
+    elif [[ "${path}" =~ .*status-react-shell.drv ]]; then
+        echo -n "${path}"
+        return
     fi
     log " ? Checking:   ${path}"
     drv=$(getDrvFiles "${path}")
     # if drv is unknown-deriver then path is a source
     if [[ "${drv}" == "unknown-deriver" ]]; then
-        drv=$(getReferrers "${path}")
+        drv=$(getReferrers "${path}" | head -n1)
         src="${path}"
     elif [[ -f "${drv}" ]]; then
         src=$(getSources "${drv}")
     fi
-    if [ $(getRoots "${drv}" | wc -l) -eq 0 ]; then
+    # empty paths means this is a source
+    if [[ -z "${drv}" ]]; then
+        echo -n "${src}"
+        return
+    fi
+    if [[ $(getRoots "${drv}" | wc -l) -eq 0 ]]; then
         log " - Derivation: ${drv}"
         log " - Source:     ${src}"
         found+=("${drv}" "${src}")

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -41,7 +41,7 @@ shellArgs=(
 if [[ -n "${TARGET_OS}" ]]; then
     shellArgs+=("--argstr target-os ${TARGET_OS}")
 else
-    echo -e "${YELLOW}Env is missing TARGET_OS, assuming no target platform.${NC} See nix/README.md for more details." > /dev/stderr
+    echo -e "${YELLOW}Env is missing TARGET_OS, assuming no target platform.${NC} See nix/README.md for more details." 1>&2
 fi
 
 if [[ "$TARGET_OS" =~ (linux|windows|darwin|macos) ]]; then
@@ -65,7 +65,7 @@ fi
 # ENTER_NIX_SHELL is the fake command used when `make shell` is run.
 # It is just a special string, not a variable, and a marker to not use `--run`.
 if [[ $@ == "ENTER_NIX_SHELL" ]]; then
-  echo -e "${GREEN}Configuring ${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS:-none}'...${NC}" > /dev/stderr
+  echo -e "${GREEN}Configuring ${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS:-none}'...${NC}" 1>&2
   exec nix-shell ${shellArgs[@]} ${entryPoint}
 else
   # Not all builds are ready to be run in a pure environment
@@ -78,6 +78,6 @@ else
   if [[ -n "${_NIX_KEEP}" ]]; then
     shellArgs+=("--keep ${_NIX_KEEP//;/ --keep }")
   fi
-  echo -e "${GREEN}Configuring ${pureDesc}${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS}'...${NC}" > /dev/stderr
+  echo -e "${GREEN}Configuring ${pureDesc}${_NIX_ATTR:-default} Nix shell for target '${TARGET_OS}'...${NC}" 1>&2
   exec nix-shell ${shellArgs[@]} --run "$@" ${entryPoint}
 fi


### PR DESCRIPTION
Some fixes for issues found in https://github.com/status-im/status.im/pull/425:

* Set `NIX_IGNORE_SYMLINK_STORE=1` on MacOS to avoid issues with `/opt/nix` symlink
* Set `_NIX_ROOT` depending on OS to make `make nix-purge` work on MacOS
* Use `1>&2` instead of `> /dev/stderr` to avoid `Permission denied` errors on MacOS
* Fix some edge cases in `nix/clean.sh` when treating `*.lock` files and empty results
* Add `make lint` that runs `lein cljfmt check`