### PR TITLE
[Fixes: #9489] Correctly pass `now` in cofx when receiving messages

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -184,7 +184,7 @@
                       :last-message-content-type content-type)})))
 
 (fx/defn receive-one
-  [{:keys [now] :as cofx} message]
+  [cofx message]
   (when-let [chat-id (extract-chat-id cofx message)]
     (let [message-with-chat-id (assoc message :chat-id chat-id)]
       (when (add-to-chat? cofx message-with-chat-id)

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -55,7 +55,7 @@
   dedup-id is passed by status-go and is used to deduplicate messages at that layer.
   Once a message has been successfuly processed, that id needs to be sent back
   in order to stop receiving that message"
-  [{:keys [db]} now-in-s filter-chat-id message-js]
+  [{:keys [db] :as cofx} now-in-s filter-chat-id message-js]
   (let [blocked-contacts (get db :contacts/blocked #{})
         timestamp (.-timestamp (.-message message-js))
         metadata-js (.-metadata message-js)
@@ -81,8 +81,7 @@
             sig)
            sig
            timestamp
-           {:db db
-            :metadata metadata}))
+           (assoc cofx :metadata metadata)))
         (catch :default e nil))))) ; ignore unknown message types
 
 (defn- js-obj->seq [obj]


### PR DESCRIPTION
`now` was not passed anymore in cofx, this fixes the issue.

status: ready