### PR TITLE
[Fixes: #9492] Consider system messages always in their own group

### DIFF
--- a/src/status_im/chat/models/message_list.cljs
+++ b/src/status_im/chat/models/message_list.cljs
@@ -37,6 +37,8 @@
   We check the time, and the author"
   [a b]
   (and
+   (not (:system-message? a))
+   (not (:system-message? b))
    (= (:from a) (:from b))
    (<= (js/Math.abs (- (:whisper-timestamp a) (:whisper-timestamp b))) group-ms)))
 

--- a/test/cljs/status_im/test/chat/models/message_list.cljs
+++ b/test/cljs/status_im/test/chat/models/message_list.cljs
@@ -168,3 +168,32 @@
                    (s/->seq)
                    (nth 2)
                    :message-id)))))))
+
+(deftest same-group-test
+  (testing "two messages from the same author and close together"
+    (is (s/same-group? {:whisper-timestamp 1
+                        :from "1"}
+                       {:whisper-timestamp 2
+                        :from "1"})))
+  (testing "two messages from the same author, close together, first system-message"
+    (is (not (s/same-group? {:whisper-timestamp 1
+                             :system-message? true
+                             :from "1"}
+                            {:whisper-timestamp 2
+                             :from "1"}))))
+  (testing "two messages from the same author, close together, second system-message"
+    (is (not (s/same-group? {:whisper-timestamp 1
+                             :from "1"}
+                            {:whisper-timestamp 2
+                             :system-message? true
+                             :from "1"}))))
+  (testing "two messages from the same author and far apart"
+    (is (not (s/same-group? {:whisper-timestamp 1
+                             :from "1"}
+                            {:whisper-timestamp 2000000
+                             :from "1"}))))
+  (testing "two messages not from the same author and close together"
+    (is (not (s/same-group? {:whisper-timestamp 1
+                             :from "2"}
+                            {:whisper-timestamp 2
+                             :from "1"})))))


### PR DESCRIPTION
System messages should always display the user picture, and should never
be grouped.

status: ready