### PR TITLE
Add SNT/STT to default account settings

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -82,7 +82,8 @@
 (def default-multiaccount-settings
   {:web3-opt-in?     true
    :preview-privacy? false
-   :wallet           {:visible-tokens {}}})
+   :wallet           {:visible-tokens {}
+                      :first-login true}})
 
 (def currencies
   {:aed {:id :aed :code "AED" :display-name (i18n/label :t/currency-display-name-aed) :symbol "د.إ"}


### PR DESCRIPTION
fixes #9493 

### Summary

SNT is not shown on Wallet home page as a default.  This was previously the case but probably lost with the change from account to multiaccount.  This adds them back to default account settings so they appear when a new multiaccount is retrieved/created.

### Testing notes
STT will show as a default if testing on Ropsten network

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

-Open Status
- Create/restore a multiaccount
- Tap Wallet home page
- Verify that SNT is displayed beneath ETH by default

status: ready 

Below is from a newly created multiaccount.

![Screenshot_20191121-145806](https://user-images.githubusercontent.com/17355484/69373960-0b628600-0c73-11ea-801b-af1db592945d.jpg)

