### PR TITLE
Fix/slow checkbox in assets

### DIFF
--- a/src/status_im/ui/components/checkbox/view.cljs
+++ b/src/status_im/ui/components/checkbox/view.cljs
@@ -10,7 +10,7 @@
   [{:keys [on-value-change checked? accessibility-label
            disabled? style icon-style]
     :or   {accessibility-label :checkbox}}]
-  [react/touchable-highlight
+  [(if on-value-change react/touchable-highlight react/view)
    (merge {:style               (merge
                                  styles/wrapper
                                  style)

--- a/src/status_im/ui/components/list/views.cljs
+++ b/src/status_im/ui/components/list/views.cljs
@@ -103,7 +103,7 @@
                                       {:on-long-press on-long-press}))
    (conj item
          [react/view {:style (merge style styles/item-checkbox)}
-          [checkbox/checkbox props]])])
+          [checkbox/checkbox (dissoc props :on-value-change)]])])
 
 ;;TODO DEPRECATED, use status-im.ui.components.list-item.views
 (defn list-item-with-radio-button


### PR DESCRIPTION
There was two issues with the "Manage assets" screen when pressing a checkbox:
- it was taking extra time before subscriptions were recomputed
- it was taking extra time after as well

The first problem was apparently due to nested `touchable-highlight` components and fixed by making the checkbox a simple view
The second was caused by the re-rendering of every element of the list, sometimes multitple times, everytime the `:checked?` value of only one item was changed. To fix it I overwrote the `should-component-update` method.