### PR TITLE
Add safearea for Android and remove statusbar component

### DIFF
--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -41,7 +41,8 @@
               "functional-red-black-tree"
               "react-native-mail"
               "react-native-shake"
-              "@react-native-community/netinfo"]
+              "@react-native-community/netinfo"
+              "react-native-safe-area-context"]
  ;; Desktop modules
  :desktop-modules ["buffer"
                    "bignumber.js"

--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -34,6 +34,7 @@
     "react-native-languages": "^3.0.2",
     "react-native-mail": "git+https://github.com/status-im/react-native-mail.git#v4.0.0-status",
     "react-native-navigation-twopane": "git+https://github.com/status-im/react-native-navigation-twopane.git#v0.0.2-status",
+    "react-native-safe-area-context": "^0.6.0",
     "react-native-screens": "^1.0.0-alpha.23",
     "react-native-shake": "^3.3.1",
     "react-native-splash-screen": "^3.2.0",

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -4846,6 +4846,11 @@ react-native-languages@^3.0.2:
   version "0.0.2"
   resolved "git+https://github.com/status-im/react-native-navigation-twopane.git#04ed5fddfb46a6a3ee30776987acb4d3b11c27d4"
 
+react-native-safe-area-context@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.6.0.tgz#f53f5a5bcafb462a8798a26b145e68946389ad60"
+  integrity sha512-blY0akr3ZLTuZFdUotmjV+7LVXpBnd5CGFlNhTiarNNGJoHu79K42IJpUpmtg75iC9aWbSW7QHstlP0xz11V0A==
+
 react-native-safe-area-view@^0.14.1:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.8.tgz#ef33c46ff8164ae77acad48c3039ec9c34873e5b"

--- a/react-native/src/desktop/status_im/react_native/js_dependencies.cljs
+++ b/react-native/src/desktop/status_im/react_native/js_dependencies.cljs
@@ -37,3 +37,4 @@
 (def react-native-mail      #js {:mail (fn [])})
 (def async-storage          #js {})
 (def back-handler           #js {})
+(def safe-area-context      #js {})

--- a/react-native/src/mobile/status_im/react_native/js_dependencies.cljs
+++ b/react-native/src/mobile/status_im/react_native/js_dependencies.cljs
@@ -40,3 +40,4 @@
 (def desktop-menu           #js {:addEventListener (fn [])})
 (def desktop-config         #js {:addEventListener (fn [])})
 (def desktop-shortcuts      #js {:addEventListener (fn [])})
+(def safe-area-context      (js/require "react-native-safe-area-context"))

--- a/src/status_im/network/ui/edit_network/views.cljs
+++ b/src/status_im/network/ui/edit_network/views.cljs
@@ -6,7 +6,6 @@
    [status-im.i18n :as i18n]
    [status-im.ui.components.styles :as components.styles]
    [status-im.ui.components.common.common :as components.common]
-   [status-im.ui.components.status-bar.view :as status-bar]
    [status-im.ui.components.toolbar.view :as toolbar]
    [status-im.ui.components.list.views :as list]
    [status-im.ui.components.text-input.view :as text-input]
@@ -31,7 +30,6 @@
                   is-valid?      [:manage-network-valid?]]
     (let [custom? (= (get-in manage-network [:chain :value]) :custom)]
       [react/view styles/container
-       [status-bar/status-bar]
        [react/keyboard-avoiding-view components.styles/flex
         [toolbar/simple-toolbar (i18n/label :t/add-network)]
         [react/scroll-view

--- a/src/status_im/network/ui/network_details/views.cljs
+++ b/src/status_im/network/ui/network_details/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.network.ui.network-details.views
   (:require-macros [status-im.utils.views :as views])
   (:require [re-frame.core :as re-frame]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.react :as react]
             [status-im.i18n :as i18n]
@@ -19,7 +18,6 @@
           connected?               (= id current-network)
           custom?                  (seq (filter #(= (:id %) id) (:custom networks)))]
       [react/view st/container
-       [status-bar/status-bar]
        [react/view components.styles/flex
         [toolbar/simple-toolbar (i18n/label :t/network-details)]
         [react/view components.styles/flex

--- a/src/status_im/network/ui/views.cljs
+++ b/src/status_im/network/ui/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]
             [status-im.ui.components.toolbar.view :as toolbar])
@@ -46,7 +45,6 @@
   (views/letsubs [current-network [:networks/current-network]
                   networks        [:get-networks]]
     [react/view components.styles/flex
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/network-settings)]

--- a/src/status_im/ui/components/status_bar/styles.cljs
+++ b/src/status_im/ui/components/status_bar/styles.cljs
@@ -1,6 +1,5 @@
 (ns status-im.ui.components.status-bar.styles
   (:require [status-im.ui.components.colors :as colors]
-            [status-im.utils.platform :as platform]
             [status-im.utils.styles :as styles]))
 
 (defn- create-status-bar-style [{:keys [background-color bar-style translucent?]
@@ -9,106 +8,12 @@
    :translucent      translucent?
    :bar-style        bar-style})
 
-(defn- create-view-style
-  [{:keys [background-color height]
-    :or   {height (get platform/platform-specific :status-bar-default-height)}}]
-  {:background-color background-color
-   :height           height})
-
-;; :main
-(styles/def status-bar-main
-  {:ios     (create-status-bar-style {:background-color colors/white
-                                      :bar-style        "default"})
-   :android (create-status-bar-style {:translucent?     true
-                                      :bar-style        "dark-content"})})
-
-(styles/def status-bar-main-main
-  {:ios     (create-status-bar-style {:background-color colors/white
-                                      :bar-style        "default"})
-   :android (create-status-bar-style {:background-color colors/black
-                                      :bar-style        "light-content"})})
-
-(def view-main
-  (create-view-style {:background-color colors/white}))
-
-(styles/def view-modal-main
-  {:ios     (create-view-style {:background-color colors/white})
-   :android (create-view-style {:background-color colors/black
-                                :height           0})})
-
-;; :transparent
-(styles/def status-bar-transparent
-  {:ios     (create-status-bar-style {:background-color colors/transparent})
-   :android (create-status-bar-style {:translucent?     true})})
-
-(def view-transparent
-  (create-view-style {:background-color colors/transparent}))
-
-;; :modal
-(styles/def status-bar-modal
-  {:ios     (create-status-bar-style {:background-color "#2f3031"})
-   :android (create-status-bar-style {:background-color colors/black})})
-
-(styles/def view-modal
-  {:ios     (create-view-style {:background-color "#2f3031"})
-   :android (create-view-style {:background-color colors/black
-                                :height           0})})
-
-;; :modal-white
-(styles/def status-bar-modal-white
-  {:ios     (create-status-bar-style {:background-color colors/white
-                                      :bar-style        "default"})
-   :android (create-status-bar-style {:background-color colors/black
-                                      :bar-style        "light-content"})})
-
-(styles/def view-modal-white
-  {:ios     (create-view-style {:background-color colors/white})
-   :android (create-view-style {:background-color colors/black
-                                :height           0})})
-
-;; :modal-wallet
-(def status-bar-modal-wallet
-  (create-status-bar-style {:background-color colors/blue}))
-
-(styles/def view-modal-wallet
-  {:ios     (create-view-style {:background-color colors/blue})
-   :android (create-view-style {:background-color colors/blue
-                                :height           0})})
-
-;; :transaction
-(styles/def status-bar-transaction
-  {:ios     (create-status-bar-style {:background-color colors/transparent})
-   :android (create-status-bar-style {:background-color colors/black})})
-
-(styles/def view-transaction
-  {:ios     (create-view-style {:background-color colors/transparent})
-   :android (create-view-style {:background-color colors/black
-                                :height           0})})
-
-;; TODO(jeluard) Fix status-bar mess by removing useless view and introducing 2dn level tab-bar
-
-;; :wallet HOME
-(styles/def status-bar-wallet-tab
-  {:ios     (create-status-bar-style {:background-color colors/blue})
-   :android (create-status-bar-style {:translucent?     true})})
-
-(def view-wallet-tab
-  (create-view-style {:background-color colors/blue}))
-
-;; :wallet
-(styles/def status-bar-wallet
-  {:ios     (create-status-bar-style {:background-color colors/blue})
-   :android (create-status-bar-style {:translucent?     true})})
-
-(def view-wallet
-  (create-view-style {:background-color colors/blue}))
-
-;; :default
 (styles/def status-bar-default
   {:ios     (create-status-bar-style {:background-color colors/white
                                       :bar-style        "default"})
    :android (create-status-bar-style {:translucent?     true
                                       :bar-style        "dark-content"})})
 
-(def view-default
-  (create-view-style {}))
+(styles/def status-bar-transparent
+  {:ios     (create-status-bar-style {:background-color colors/transparent})
+   :android (create-status-bar-style {:translucent?     true})})

--- a/src/status_im/ui/components/status_bar/view.cljs
+++ b/src/status_im/ui/components/status_bar/view.cljs
@@ -3,28 +3,8 @@
             [status-im.ui.components.status-bar.styles :as styles]
             [status-im.utils.platform :as platform]))
 
-(defn status-bar [{:keys [type flat?]}]
-  (let [view-style
-        (case type
-          :main styles/view-main
-          :modal-main styles/view-modal-main
-          :transparent styles/view-transparent
-          :modal styles/view-modal
-          :modal-white styles/view-modal-white
-          :modal-wallet styles/view-modal-wallet
-          :transaction styles/view-transaction
-          :wallet styles/view-wallet
-          :wallet-tab styles/view-wallet-tab
-          styles/view-default)]
-    (when-not platform/desktop?
-      [react/view {:style (cond-> view-style flat? (assoc :elevation 0))}])))
-
 (defn get-config [view-id]
-  (or (get {:create-multiaccount             {:flat? true}
-            :chat-modal                      {:type :modal-white}
-            :intro                           {:flat? true}
-            :recipient-qr-code               {:type :transparent}
-            :wallet-transactions-filter      {:type :modal-main}}
+  (or (get {:recipient-qr-code {:type :transparent}}
            view-id)
       {:type :main}))
 
@@ -46,15 +26,7 @@
                 network-activity-indicator-visible
                 translucent]}
         (case type
-          :main styles/status-bar-main
-          :modal-main styles/status-bar-main-main
           :transparent styles/status-bar-transparent
-          :modal styles/status-bar-modal
-          :modal-white styles/status-bar-modal-white
-          :modal-wallet styles/status-bar-modal-wallet
-          :transaction styles/status-bar-transaction
-          :wallet styles/status-bar-wallet
-          :wallet-tab styles/status-bar-wallet-tab
           styles/status-bar-default)]
     (when (and background-color platform/android?)
       (.setBackgroundColor react/status-bar-class (clj->js background-color)))

--- a/src/status_im/ui/components/tabbar/core.cljs
+++ b/src/status_im/ui/components/tabbar/core.cljs
@@ -110,8 +110,7 @@
     content
     (when platform/iphone-x?
       [react/view
-       {:style tabs.styles/ios-titles-cover}])]
-   [react/safe-area-view {:flex 1}]])
+       {:style tabs.styles/ios-titles-cover}])]])
 
 (defn tabs-animation-wrapper-android
   [keyboard-shown? view-id content]

--- a/src/status_im/ui/screens/about_app/views.cljs
+++ b/src/status_im/ui/screens/about_app/views.cljs
@@ -8,7 +8,6 @@
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.list-item.views :as list-item]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.about-app.styles :as styles]))
 
@@ -57,7 +56,6 @@
   (views/letsubs [app-version  [:get-app-short-version]
                   node-version [:get-app-node-version]]
     [react/view {:flex 1 :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/about-app)]
      [list/flat-list

--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar.view]
             [status-im.ui.screens.add-new.styles :as add-new.styles]
             [status-im.ui.screens.add-new.new-chat.styles :as styles]
@@ -30,7 +29,6 @@
                   new-identity  [:contacts/new-identity]
                   error-message [:new-identity-error]]
     [react/view {:style {:flex 1}}
-     [status-bar/status-bar]
      [toolbar.view/simple-toolbar (i18n/label :t/new-chat) true]
      [react/view add-new.styles/new-chat-container
       [react/view add-new.styles/new-chat-input-container

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -2,7 +2,6 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as common.styles]
             [status-im.ui.components.text-input.view :as text-input.view]
             [status-im.ui.components.toolbar.view :as toolbar]
@@ -74,7 +73,6 @@
   (views/letsubs [topic [:public-group-topic]
                   error [:public-chat.new/topic-error-message]]
     [react/view {:style styles/group-container}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/new-public-group-chat)
       true]

--- a/src/status_im/ui/screens/add_new/views.cljs
+++ b/src/status_im/ui/screens/add_new/views.cljs
@@ -4,7 +4,6 @@
             [status-im.ui.components.common.common :as common]
             [status-im.ui.components.list-selection :as list-selection]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.utils.platform :as platform]
             [status-im.ui.components.list-item.views :as list-item]))
@@ -51,7 +50,6 @@
 
 (defn add-new []
   [react/view {:flex 1 :background-color :white}
-   [status-bar/status-bar]
    [toolbar/simple-toolbar (i18n/label :t/new)]
    [common/separator]
    [options-list]])

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -5,7 +5,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]))
 
 (defn- normal-mode-settings-data [network-name current-log-level
@@ -137,7 +136,6 @@
                   current-log-level        [:settings/current-log-level]
                   current-fleet            [:settings/current-fleet]]
     [react/view {:flex 1 :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/advanced)]
      [list/flat-list

--- a/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/views.cljs
+++ b/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/views.cljs
@@ -9,7 +9,6 @@
    [status-im.ui.components.common.common :as components.common]
    [status-im.ui.components.colors :as colors]
    [status-im.ui.components.icons.vector-icons :as vector-icons]
-   [status-im.ui.components.status-bar.view :as status-bar]
    [status-im.ui.components.toolbar.view :as toolbar]
    [status-im.ui.components.text-input.view :as text-input]
    [status-im.ui.screens.bootnodes-settings.edit-bootnode.styles :as styles]
@@ -42,7 +41,6 @@
           is-valid?    (empty? validation-errors)
           invalid-url? (contains? validation-errors :url)]
       [react/view styles/container
-       [status-bar/status-bar]
        [react/keyboard-avoiding-view components.styles/flex
         [toolbar/simple-toolbar (i18n/label (if id :t/bootnode-details :t/add-bootnode))]
         [react/scroll-view {:keyboard-should-persist-taps :handled}

--- a/src/status_im/ui/screens/bootnodes_settings/views.cljs
+++ b/src/status_im/ui/screens/bootnodes_settings/views.cljs
@@ -7,7 +7,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]
             [status-im.ui.screens.profile.components.views :as profile.components]
@@ -29,7 +28,6 @@
   (views/letsubs [bootnodes-enabled [:settings/bootnodes-enabled]
                   bootnodes         [:settings/network-bootnodes]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/bootnodes-settings)]

--- a/src/status_im/ui/screens/browser/open_dapp/views.cljs
+++ b/src/status_im/ui/screens/browser/open_dapp/views.cljs
@@ -4,7 +4,6 @@
    [status-im.i18n :as i18n]
    [status-im.ui.components.colors :as colors]
    [status-im.ui.components.react :as react]
-   [status-im.ui.components.status-bar.view :as status-bar]
    [status-im.ui.screens.browser.open-dapp.styles :as styles]
    [status-im.ui.components.list.views :as list]
    [status-im.ui.components.common.common :as components.common]
@@ -125,7 +124,6 @@
   (views/letsubs [browsers [:browser/browsers-vals]
                   url-text (atom nil)]
     [react/keyboard-avoiding-view {:style {:flex 1}}
-     [status-bar/status-bar]
      [react/text-input {:on-change-text      #(reset! url-text %)
                         :on-submit-editing   #(re-frame/dispatch [:browser.ui/open-url @url-text])
                         :placeholder         (i18n/label :t/enter-url)

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -9,7 +9,6 @@
             [status-im.ui.components.connectivity.view :as connectivity]
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as toolbar.view]
@@ -179,7 +178,6 @@
           url-original    (browser/get-current-url browser)
           opt-in?         (or (nil? (:web3-opt-in? settings)) (:web3-opt-in? settings))]
       [react/view {:style styles/browser}
-       [status-bar/status-bar]
        [toolbar error? url url-original browser browser-id url-editing? webview]
        [react/view
         (when loading?

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -13,7 +13,6 @@
             [status-im.ui.components.list-selection :as list-selection]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.chat.actions :as actions]
@@ -404,8 +403,6 @@
     [react/view {:style     style/chat-view
                  :on-layout (fn [e]
                               (re-frame/dispatch [:set :layout-height (-> e .-nativeEvent .-layout .-height)]))}
-     ^{:key current-chat-id}
-     [status-bar/status-bar (when modal? {:type :modal-white})]
      [toolbar/toolbar
       {:chat? true
        :style {:z-index 2}}

--- a/src/status_im/ui/screens/contacts_list/views.cljs
+++ b/src/status_im/ui/screens/contacts_list/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.components.react :as react]
             [status-im.i18n :as i18n]
             [status-im.ui.components.contact.contact :as contact-view]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar.view])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
@@ -21,7 +20,6 @@
   (letsubs [blocked-contacts-count [:contacts/blocked-count]
             contacts      [:contacts/active]]
     [react/view {:flex 1}
-     [status-bar/status-bar {:type :main}]
      [toolbar.view/toolbar nil
       toolbar.view/default-nav-back
       (toolbar.view/content-title (i18n/label :t/contacts))]
@@ -43,7 +41,6 @@
   (letsubs [blocked-contacts [:contacts/blocked]]
     [react/view {:flex 1
                  :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar.view/simple-toolbar (i18n/label :t/blocked-users)]
      [react/scroll-view {:style {:background-color colors/white
                                  :padding-vertical 8}}

--- a/src/status_im/ui/screens/currency_settings/views.cljs
+++ b/src/status_im/ui/screens/currency_settings/views.cljs
@@ -5,7 +5,6 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.profile.components.views :as profile.components]
             [status-im.ui.screens.currency-settings.styles :as styles]
@@ -26,7 +25,6 @@
 (views/defview currency-settings []
   (views/letsubs [currency-id [:wallet.settings/currency]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/main-currency)]
      [react/view styles/wrapper

--- a/src/status_im/ui/screens/dapps_permissions/views.cljs
+++ b/src/status_im/ui/screens/dapps_permissions/views.cljs
@@ -3,7 +3,6 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.colors :as colors]
@@ -33,7 +32,6 @@
 (views/defview dapps-permissions []
   (views/letsubs [permissions [:dapps/permissions]]
     [react/view {:flex 1 :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/dapps-permissions)]
      [list/flat-list
@@ -45,7 +43,6 @@
   (views/letsubs [{:keys [dapp permissions]} [:get-screen-params]
                   {:keys [name]} [:dapps-account]]
     [react/view {:flex 1 :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar dapp]
      [list/flat-list
       {:data      (vec (map (prepare-items-manage name) permissions))

--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -216,7 +216,6 @@
   (views/letsubs [{:keys [state custom-domain? username]}
                   [:ens/search-screen]]
     [react/keyboard-avoiding-view {:flex 1}
-     [status-bar/status-bar {:type :main}]
      [toolbar]
      [react/scroll-view {:style {:flex 1}
                          ;;NOTE required so that switching custom-domain
@@ -316,7 +315,6 @@
                   [:ens/checkout-screen]]
     (let [checked? (reagent/atom false)]
       [react/keyboard-avoiding-view {:flex 1}
-       [status-bar/status-bar {:type :main}]
        [toolbar]
        [react/scroll-view {:style {:flex 1}}
         [react/view {:style {:flex 1
@@ -397,7 +395,6 @@
 (views/defview confirmation []
   (views/letsubs [{:keys [state username]} [:ens/confirmation-screen]]
     [react/keyboard-avoiding-view {:flex 1}
-     [status-bar/status-bar {:type :main}]
      [toolbar]
      [react/view {:style {:flex 1
                           :align-items :center
@@ -441,7 +438,6 @@
 (views/defview terms []
   (views/letsubs [{:keys [contract]} [:get-screen-params :ens-terms]]
     [react/scroll-view {:style {:flex 1}}
-     [status-bar/status-bar {:type :main}]
      [toolbar/simple-toolbar
       (i18n/label :t/ens-terms-registration)]
      [react/view {:style {:height 136 :background-color colors/gray-lighter :justify-content :center :align-items :center}}
@@ -484,7 +480,6 @@
   (views/letsubs [{:keys [name address custom-domain? public-key pending?]}
                   [:ens.name/screen]]
     [react/view {:style {:flex 1}}
-     [status-bar/status-bar {:type :main}]
      [toolbar/simple-toolbar
       name]
      [react/scroll-view {:style {:flex 1}}
@@ -669,7 +664,6 @@
 (views/defview main []
   (views/letsubs [{:keys [names multiaccount show?]} [:ens.main/screen]]
     [react/keyboard-avoiding-view {:style {:flex 1}}
-     [status-bar/status-bar {:type :main}]
      [toolbar/simple-toolbar
       (i18n/label :t/ens-usernames)]
      (if (seq names)

--- a/src/status_im/ui/screens/fleet_settings/views.cljs
+++ b/src/status_im/ui/screens/fleet_settings/views.cljs
@@ -4,7 +4,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.fleet-settings.styles :as styles]
             [status-im.node.core :as node]
@@ -41,7 +40,6 @@
   (views/letsubs [custom-fleets [:fleets/custom-fleets]
                   current-fleet [:settings/current-fleet]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/fleet-settings)]]

--- a/src/status_im/ui/screens/group/views.cljs
+++ b/src/status_im/ui/screens/group/views.cljs
@@ -14,7 +14,6 @@
             [status-im.ui.components.common.common :as components.common]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.list.views :as list]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.utils.platform :as platform]
             [status-im.ui.components.contact.contact :as contact]
@@ -128,7 +127,6 @@
   (views/letsubs [contacts                [:contacts/active]
                   selected-contacts-count [:selected-contacts-count]]
     [react/keyboard-avoiding-view {:style styles/group-container}
-     [status-bar/status-bar]
      [toolbar
       (i18n/label :t/new-group-chat)
       (i18n/label :t/group-chat-members-count
@@ -148,7 +146,6 @@
     (let [save-btn-enabled? (and (spec/valid? :global/not-empty-string group-name) (pos? (count contacts)))]
       [react/keyboard-avoiding-view (merge {:behavior :padding}
                                            styles/group-container)
-       [status-bar/status-bar]
        [toolbar
         (i18n/label :t/new-group-chat)
         (i18n/label :t/group-chat-members-count
@@ -176,7 +173,6 @@
                   selected-contacts-count         [:selected-participants-count]]
     (let [current-participants-count (count (:contacts current-chat))]
       [react/keyboard-avoiding-view {:style styles/group-container}
-       [status-bar/status-bar]
        [toolbar
         name
         (i18n/label :t/group-chat-members-count

--- a/src/status_im/ui/screens/hardwallet/authentication_method/views.cljs
+++ b/src/status_im/ui/screens/hardwallet/authentication_method/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.common.common :as common]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.i18n :as i18n]
             [status-im.ui.components.colors :as colors]
             [status-im.react-native.resources :as resources]))
@@ -24,7 +23,6 @@
 
 (defn hardwallet-authentication-method []
   [react/view styles/container
-   [status-bar/status-bar]
    [react/view components.styles/flex
     [toolbar/toolbar {}
      toolbar/default-nav-back

--- a/src/status_im/ui/screens/hardwallet/connect/views.cljs
+++ b/src/status_im/ui/screens/hardwallet/connect/views.cljs
@@ -7,7 +7,6 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.styles :as components.styles]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.i18n :as i18n]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]))
@@ -44,7 +43,6 @@
   (letsubs [nfc-enabled? [:hardwallet/nfc-enabled?]
             setup-step [:hardwallet-setup-step]]
     [react/view styles/container
-     [status-bar/status-bar]
      [react/view {:flex            1
                   :flex-direction  :column
                   :justify-content :space-between}

--- a/src/status_im/ui/screens/hardwallet/pin/views.cljs
+++ b/src/status_im/ui/screens/hardwallet/pin/views.cljs
@@ -7,7 +7,6 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.hardwallet.pin.styles :as styles]
             [status-im.ui.components.toolbar.view :as toolbar]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]))
 
@@ -129,7 +128,6 @@
             error-label [:hardwallet/pin-error-label]]
     [react/view {:flex             1
                  :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar/toolbar
       nil
       [toolbar/nav-button (assoc toolbar.actions/default-back

--- a/src/status_im/ui/screens/hardwallet/settings/views.cljs
+++ b/src/status_im/ui/screens/hardwallet/settings/views.cljs
@@ -3,7 +3,6 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.react-native.resources :as resources]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
@@ -52,7 +51,6 @@
 (defview reset-card []
   (letsubs [disabled? [:keycard-reset-card-disabled?]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/reset-card)]
      [react/view {:flex             1
@@ -91,7 +89,6 @@
             puk-retry-counter [:hardwallet/puk-retry-counter]
             pairing [:keycard-multiaccount-pairing]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/status-keycard)]
      [react/view {:flex             1

--- a/src/status_im/ui/screens/help_center/views.cljs
+++ b/src/status_im/ui/screens/help_center/views.cljs
@@ -2,7 +2,6 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.colors :as colors]
@@ -37,7 +36,6 @@
 
 (defn help-center []
   [react/view {:flex 1 :background-color colors/white}
-   [status-bar/status-bar]
    [toolbar/simple-toolbar
     (i18n/label :t/need-help)]
    [list/flat-list

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -45,7 +45,6 @@
 (defn welcome []
   [react/view {:style {:flex 1}}
    [react/view {:style styles/welcome-view}
-    [status-bar/status-bar {:type :main}]
     [welcome-image-wrapper]
     [react/i18n-text {:style styles/welcome-text :key :welcome-to-status}]
     [react/view
@@ -127,7 +126,7 @@
          [list/flat-list {:data           all-home-items
                           :key-fn         first
                           :header         [react/view {:height 4 :flex 1}]
-                          :footer 				[react/view {:height 380 :margin-top 70} [home-tooltip-view false hide-home-tooltip?]]
+                          :footer         [react/view {:height 380 :margin-top 70} [home-tooltip-view false hide-home-tooltip?]]
                           :on-scroll-begin-drag
                           (fn [e]
                             (reset! scrolling-from-top?
@@ -167,7 +166,6 @@
                            {:margin-bottom tabs.styles/tabs-diff})
                          (when two-pane-ui-enabled?
                            {:border-right-width 1 :border-right-color colors/gray-lighter}))
-       [status-bar/status-bar {:type :main}]
        [react/keyboard-avoiding-view {:style     {:flex 1}
                                       :on-layout (fn [e]
                                                    (re-frame/dispatch

--- a/src/status_im/ui/screens/intro/views.cljs
+++ b/src/status_im/ui/screens/intro/views.cljs
@@ -21,7 +21,6 @@
             [status-im.utils.platform :as platform]
             [status-im.utils.security :as security]
             [status-im.i18n :as i18n]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.constants :as constants]
             [status-im.utils.config :as config]
             [status-im.utils.platform :as platform]))
@@ -83,7 +82,6 @@
 (defview intro []
   (letsubs  [{window-height :height} [:dimensions/window]]
     [react/view {:style styles/intro-view}
-     [status-bar/status-bar {:flat? true}]
      [intro-viewer [{:image (:intro1 resources/ui)
                      :title :intro-title1
                      :text :intro-text1}

--- a/src/status_im/ui/screens/language_settings/views.cljs
+++ b/src/status_im/ui/screens/language_settings/views.cljs
@@ -2,11 +2,9 @@
   (:require [status-im.i18n :as i18n]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]))
 
 (defn language-settings []
   [react/view {:flex 1 :background-color colors/white}
-   [status-bar/status-bar]
    [toolbar/simple-toolbar
     (i18n/label :t/language)]])

--- a/src/status_im/ui/screens/log_level_settings/views.cljs
+++ b/src/status_im/ui/screens/log_level_settings/views.cljs
@@ -4,7 +4,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.log-level-settings.styles :as styles]
             [status-im.utils.platform :as platform])
@@ -50,7 +49,6 @@
 (views/defview log-level-settings []
   (views/letsubs [current-log-level [:settings/current-log-level]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/log-level-settings)]]

--- a/src/status_im/ui/screens/mobile_network_settings/view.cljs
+++ b/src/status_im/ui/screens/mobile_network_settings/view.cljs
@@ -6,7 +6,6 @@
             [re-frame.core :as re-frame]
             status-im.ui.screens.mobile-network-settings.events
             [status-im.ui.components.toolbar.view :as toolbar]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.screens.profile.components.views :as profile.components]
             [status-im.utils.platform :as platform]
             [status-im.ui.screens.mobile-network-settings.sheets :as sheets]))
@@ -21,7 +20,6 @@
              remember-syncing-choice?]}
      [:multiaccount]]
     [react/view {:style styles/container}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar (i18n/label :t/mobile-network-settings)]
      (when platform/ios?
        [settings-separator])

--- a/src/status_im/ui/screens/multiaccounts/login/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/login/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.common.common :as components.common]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.text-input.view :as text-input]
             [status-im.ui.components.toolbar.actions :as act]
             [status-im.ui.components.toolbar.view :as toolbar]
@@ -55,7 +54,6 @@
             view-id [:view-id]
             supported-biometric-auth [:supported-biometric-auth]]
     [react/keyboard-avoiding-view {:style ast/multiaccounts-view}
-     [status-bar/status-bar]
      [login-toolbar can-navigate-back?]
      [react/scroll-view styles/login-view
       [react/view styles/login-badge-container

--- a/src/status_im/ui/screens/multiaccounts/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.screens.multiaccounts.styles :as styles]
             [status-im.utils.utils :as utils]
             [status-im.ui.components.list.views :as list]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.react :as react]
             [status-im.i18n :as i18n]
             [status-im.ui.components.icons.vector-icons :as icons]
@@ -47,7 +46,6 @@
 (defview multiaccounts []
   (letsubs [multiaccounts [:multiaccounts/multiaccounts]]
     [react/view styles/multiaccounts-view
-     [status-bar/status-bar]
      [react/text {:style {:typography :header :margin-top 24 :text-align :center}}
       (i18n/label :t/unlock)]
      [react/view styles/multiaccounts-container

--- a/src/status_im/ui/screens/notifications_settings/views.cljs
+++ b/src/status_im/ui/screens/notifications_settings/views.cljs
@@ -2,12 +2,10 @@
   (:require [status-im.i18n :as i18n]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]))
 
 (defn notifications-settings []
   [react/view {:flex 1 :background-color colors/white}
-   [status-bar/status-bar]
    [toolbar/simple-toolbar
     (i18n/label :t/notifications)]])
 

--- a/src/status_im/ui/screens/offline_messaging_settings/edit_mailserver/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/edit_mailserver/views.cljs
@@ -9,7 +9,6 @@
    [status-im.ui.components.icons.vector-icons :as vector-icons]
    [status-im.ui.components.styles :as components.styles]
    [status-im.ui.components.common.common :as components.common]
-   [status-im.ui.components.status-bar.view :as status-bar]
    [status-im.ui.components.toolbar.view :as toolbar]
    [status-im.ui.components.list.views :as list]
    [status-im.ui.components.text-input.view :as text-input]
@@ -51,7 +50,6 @@
           is-valid?    (empty? validation-errors)
           invalid-url? (contains? validation-errors :url)]
       [react/view components.styles/flex
-       [status-bar/status-bar]
        [react/keyboard-avoiding-view components.styles/flex
         [toolbar/simple-toolbar (i18n/label (if id :t/mailserver-details :t/add-mailserver))]
         [react/scroll-view {:keyboard-should-persist-taps :handled}

--- a/src/status_im/ui/screens/offline_messaging_settings/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/views.cljs
@@ -7,7 +7,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.utils.platform :as platform]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]
@@ -53,7 +52,6 @@
                   preferred-mailserver-id [:mailserver/preferred-id]
                   mailservers             [:mailserver/fleet-mailservers]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/offline-messaging-settings)]

--- a/src/status_im/ui/screens/pairing/views.cljs
+++ b/src/status_im/ui/screens/pairing/views.cljs
@@ -13,7 +13,6 @@
             [status-im.ui.components.checkbox.view :as checkbox.views]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.text-input.view :as text-input]
             [status-im.ui.screens.pairing.styles :as styles]))
@@ -187,7 +186,6 @@
 (views/defview installations []
   (views/letsubs [installations [:pairing/installations]]
     [react/view {:flex 1}
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/devices)]]

--- a/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
@@ -7,7 +7,6 @@
             [status-im.ui.components.common.common :as components.common]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.multiaccounts.biometric.core :as biometric])
   (:require-macros [status-im.utils.views :as views]))
@@ -90,7 +89,6 @@
     (let [show-backup-seed? (and (not seed-backed-up?)
                                  (not (string/blank? mnemonic)))]
       [react/view {:flex 1 :background-color colors/white}
-       [status-bar/status-bar]
        [toolbar/simple-toolbar
         (i18n/label :t/privacy-and-security)]
        [list/flat-list

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -8,7 +8,6 @@
             [status-im.ui.components.tabbar.styles :as tabs.styles]
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.large-toolbar.view :as large-toolbar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.profile.components.views :as profile.components]
@@ -142,11 +141,10 @@
                             header
                             content
                             list-ref)]
-        [react/safe-area-view
+        [react/view
          {:style
           (merge {:flex 1}
                  (when platform/ios?
                    {:margin-bottom tabs.styles/tabs-diff}))}
-         [status-bar/status-bar {:type :main}]
          (:minimized-toolbar generated-view)
          (:content-with-header generated-view)]))))

--- a/src/status_im/ui/screens/profile/group_chat/views.cljs
+++ b/src/status_im/ui/screens/profile/group_chat/views.cljs
@@ -9,7 +9,6 @@
             [status-im.ui.components.contact.contact :as contact]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.colors :as colors]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [re-frame.core :as re-frame]
             [status-im.ui.components.common.styles :as common.styles]
@@ -85,7 +84,6 @@
             allow-adding-members? (and admin?
                                        (< (count members) constants/max-group-chat-participants))]
         [react/view profile.components.styles/profile
-         [status-bar/status-bar]
          ;;TODO doesn't work, needs to be fixed
          ;(if editing?
            ;[group-chat-profile-edit-toolbar]

--- a/src/status_im/ui/screens/profile/photo_capture/views.cljs
+++ b/src/status_im/ui/screens/profile/photo_capture/views.cljs
@@ -3,7 +3,6 @@
             [reagent.core :as reagent]
             [status-im.ui.components.camera :as camera]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.i18n :as i18n]
             [status-im.ui.screens.profile.photo-capture.styles :as styles]
@@ -25,7 +24,6 @@
 (defn profile-photo-capture []
   (let [camera-ref (reagent/atom nil)]
     [react/view styles/container
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/image-source-title)]]

--- a/src/status_im/ui/screens/profile/seed/views.cljs
+++ b/src/status_im/ui/screens/profile/seed/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.profile.seed.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.colors :as colors]
@@ -145,7 +144,6 @@
   (letsubs [current-multiaccount [:multiaccount]
             {:keys [step first-word second-word error word]} [:my-profile/recovery]]
     [react/keyboard-avoiding-view {:style {:flex 1}}
-     [status-bar/status-bar]
      [toolbar/toolbar
       nil
       (when-not (= :finish step)

--- a/src/status_im/ui/screens/profile/tribute_to_talk/views.cljs
+++ b/src/status_im/ui/screens/profile/tribute_to_talk/views.cljs
@@ -7,7 +7,6 @@
             [status-im.ui.components.common.common :as components.common]
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.profile.tribute-to-talk.styles :as styles])
@@ -326,8 +325,7 @@
                     fiat-value disable-button? state]}
             [:tribute-to-talk/settings-ui]]
     [react/keyboard-avoiding-view {:style styles/container}
-     [react/safe-area-view {:style {:flex 1}}
-      [status-bar/status-bar]
+     [react/view {:style {:flex 1}}
       [toolbar/toolbar
        nil
        (when-not (= :finish step)

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -15,7 +15,6 @@
             [status-im.ui.components.list.views :as list.views]
             [status-im.ui.components.qr-code-viewer.views :as qr-code-viewer]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.tabbar.styles :as tabs.styles]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.chat.photos :as photos]
@@ -244,11 +243,10 @@
         scroll-y (animation/create-value 0)]
     (large-toolbar/add-listener anim-opacity scroll-y)
     (fn []
-      [react/safe-area-view
+      [react/view
        {:style
         (merge {:flex 1}
                (when platform/ios?
                  {:margin-bottom tabs.styles/tabs-diff}))}
-       [status-bar/status-bar {:type :main}]
        [minimized-toolbar-handler anim-opacity]
        [content-with-header list-ref scroll-y]])))

--- a/src/status_im/ui/screens/qr_scanner/views.cljs
+++ b/src/status_im/ui/screens/qr_scanner/views.cljs
@@ -5,14 +5,12 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.camera :as camera]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.qr-scanner.styles :as styles]
             [status-im.ui.components.toolbar.actions :as actions]))
 
 (defview qr-scanner-toolbar [title identifier]
   [react/view
-   [status-bar/status-bar]
    [toolbar/toolbar {:style {:background-color :white}}
     [toolbar/nav-button (actions/back
                          #(do

--- a/src/status_im/ui/screens/stickers/views.cljs
+++ b/src/status_im/ui/screens/stickers/views.cljs
@@ -5,7 +5,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.stickers.styles :as styles]
@@ -61,7 +60,6 @@
 (defview packs []
   (letsubs [packs [:stickers/all-packs]]
     [react/view styles/screen
-     [status-bar/status-bar]
      [react/keyboard-avoiding-view components.styles/flex
       [toolbar/simple-toolbar (i18n/label :t/sticker-market)]
       [react/scroll-view {:keyboard-should-persist-taps :handled :style {:padding 16}}
@@ -75,7 +73,6 @@
 (defview pack-main [modal?]
   (letsubs [{:keys [id name author price thumbnail stickers installed owned pending]} [:stickers/get-current-pack]]
     [react/view styles/screen
-     [status-bar/status-bar]
      [react/keyboard-avoiding-view components.styles/flex
       [toolbar/simple-toolbar nil modal?]
       [react/view {:height 74 :align-items :center :flex-direction :row :padding-horizontal 16}

--- a/src/status_im/ui/screens/sync_settings/views.cljs
+++ b/src/status_im/ui/screens/sync_settings/views.cljs
@@ -5,7 +5,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]))
 
 (defn- list-data [mailserver-id use-mobile-data?]
@@ -52,7 +51,6 @@
   (views/letsubs [{:keys [syncing-on-mobile-network?]} [:multiaccount]
                   mailserver-id                        [:mailserver/current-id]]
     [react/view {:flex 1 :background-color colors/white}
-     [status-bar/status-bar]
      [toolbar/simple-toolbar
       (i18n/label :t/sync-settings)]
      [list/flat-list

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -154,18 +154,19 @@
       :reagent-render
       (fn []
         (when (and @view-id main-component)
-          [react/view {:flex 1}
-           [:> (if @two-pane? @main-component-two-pane @main-component)
-            {:ref                    (fn [r]
-                                       (navigation/set-navigator-ref r)
-                                       (when (and
-                                              platform/android?
-                                              (not js/goog.DEBUG)
-                                              (not (contains? #{:intro :login :progress} @view-id)))
-                                         (navigation/navigate-to @view-id nil)))
-              ;; see https://reactnavigation.org/docs/en/state-persistence.html#development-mode
-             :persistNavigationState (when js/goog.DEBUG persist-state)
-             :loadNavigationState    (when js/goog.DEBUG load-state)}]
-           [signing/signing]
-           [bottom-sheet]
-           [popover/popover]]))})))
+          [react/safe-area-provider
+           [react/view {:flex 1}
+            [:> (if @two-pane? @main-component-two-pane @main-component)
+             {:ref                    (fn [r]
+                                        (navigation/set-navigator-ref r)
+                                        (when (and
+                                               platform/android?
+                                               (not js/goog.DEBUG)
+                                               (not (contains? #{:intro :login :progress} @view-id)))
+                                          (navigation/navigate-to @view-id nil)))
+               ;; see https://reactnavigation.org/docs/en/state-persistence.html#development-mode
+              :persistNavigationState (when js/goog.DEBUG persist-state)
+              :loadNavigationState    (when js/goog.DEBUG load-state)}]
+            [signing/signing]
+            [bottom-sheet]
+            [popover/popover]]]))})))

--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.wallet.account.views
   (:require-macros [status-im.utils.views :as views])
   (:require [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.colors :as colors]
             [re-frame.core :as re-frame]
@@ -23,7 +22,6 @@
 
 (defn toolbar-view [title]
   [react/view
-   [status-bar/status-bar]
    [toolbar/toolbar {:transparent? true}
     toolbar/default-nav-back
     [toolbar/content-title title]

--- a/src/status_im/ui/screens/wallet/account_settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/account_settings/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.wallet.account-settings.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as topbar]
             [status-im.ui.components.text-input.view :as text-input]
             [re-frame.core :as re-frame]
@@ -36,7 +35,6 @@
 (defview account-added []
   (letsubs [{:keys [account]} [:generate-account]]
     [react/keyboard-avoiding-view {:flex 1}
-     [status-bar/status-bar]
      [react/scroll-view {:keyboard-should-persist-taps :handled
                          :style                        {:margin-top 70 :flex 1}}
       [react/view {:align-items :center :padding-horizontal 40}
@@ -82,7 +80,6 @@
   (letsubs [{:keys [address color path] :as account} [:current-account]
             new-account (reagent/atom nil)]
     [react/keyboard-avoiding-view {:flex 1}
-     [status-bar/status-bar]
      [topbar/toolbar {}
       topbar/default-nav-back
       [topbar/content-title (i18n/label :t/account-settings)]

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.wallet.accounts.views
   (:require-macros [status-im.utils.views :as views])
   (:require [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.ui.components.toolbar.styles :as toolbar.styles]
             [status-im.ui.components.colors :as colors]
@@ -133,7 +132,6 @@
 
 (defn accounts-overview []
   [react/view {:flex 1}
-   [status-bar/status-bar]
    [react/scroll-view
     [accounts-options]
     [react/view {:margin-top 8 :padding-horizontal 16}

--- a/src/status_im/ui/screens/wallet/add_new/views.cljs
+++ b/src/status_im/ui/screens/wallet/add_new/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.wallet.add-new.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.i18n :as i18n]
             [re-frame.core :as re-frame]
@@ -14,7 +13,6 @@
 
 (defn add-account []
   [react/view {:flex 1}
-   [status-bar/status-bar]
    [toolbar/toolbar {:transparent? true} toolbar/default-nav-back nil]
    [react/scroll-view {:keyboard-should-persist-taps :handled
                        :style                        {:flex 1}}
@@ -39,7 +37,6 @@
   (letsubs [{:keys [error]} [:generate-account]
             entered-password (reagent/atom "")]
     [react/keyboard-avoiding-view {:style {:flex 1}}
-     [status-bar/status-bar {:flat? true}]
      [toolbar/toolbar {:transparent? true} toolbar/default-nav-back nil]
      [react/view {:flex 1}
       [react/view {:style {:flex            1

--- a/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
@@ -5,7 +5,6 @@
             [status-im.ui.components.toolbar :as toolbar]
             [status-im.ui.components.camera :as camera]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as topbar]
             [status-im.ui.screens.wallet.choose-recipient.styles :as styles]
@@ -48,7 +47,6 @@
             dimensions        [:dimensions/window]
             camera-flashlight [:wallet.send/camera-flashlight]]
     [react/view {:style styles/qr-code}
-     [status-bar/status-bar {:type :transparent}]
      [topbar camera-flashlight]
      [react/text {:style               (styles/qr-code-text dimensions)
                   :accessibility-label :scan-qr-code-with-wallet-address-text}

--- a/src/status_im/ui/screens/wallet/collectibles/views.cljs
+++ b/src/status_im/ui/screens/wallet/collectibles/views.cljs
@@ -4,7 +4,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as component.styles]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.wallet.collectibles.styles :as styles]))
@@ -20,7 +19,6 @@
             collectibles [:screen-collectibles]]
     [react/view styles/container
      [react/view {:style component.styles/flex}
-      [status-bar/status-bar]
       [toolbar/toolbar {}
        toolbar/default-nav-back
        [toolbar/content-title name]]

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -15,7 +15,6 @@
             [status-im.ui.components.list.styles :as list.styles]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as topbar]
@@ -56,7 +55,6 @@
   ([toolbar content] (simple-screen nil toolbar content))
   ([{:keys [avoid-keyboard?]} toolbar content]
    [(top-view avoid-keyboard?) {:flex 1}
-    [status-bar/status-bar]
     toolbar
     content]))
 

--- a/src/status_im/ui/screens/wallet/custom_tokens/views.cljs
+++ b/src/status_im/ui/screens/wallet/custom_tokens/views.cljs
@@ -4,7 +4,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.toolbar.view :as toolbar]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.text-input.view :as text-input]
             [status-im.ui.components.common.common :as components.common]
             [clojure.string :as string]
@@ -25,7 +24,6 @@
   (letsubs [{:keys [contract name symbol balance decimals in-progress? error error-name error-symbol]}
             [:wallet/custom-token-screen]]
     [react/keyboard-avoiding-view {:flex 1 :background-color :white}
-     [status-bar/status-bar]
      [toolbar/toolbar nil
       toolbar/default-nav-back
       [toolbar/content-title
@@ -108,7 +106,6 @@
   (letsubs [{:keys [address name symbol decimals custom?] :as token}
             [:get-screen-params]]
     [react/keyboard-avoiding-view {:flex 1 :background-color :white}
-     [status-bar/status-bar]
      [toolbar/toolbar nil
       toolbar/default-nav-back
       [toolbar/content-title name]]

--- a/src/status_im/ui/screens/wallet/settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/settings/views.cljs
@@ -6,7 +6,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as toolbar]
@@ -57,7 +56,6 @@
 (defview manage-assets []
   (letsubs [{custom-tokens true default-tokens nil} [:wallet/grouped-chain-tokens]]
     [react/view (merge components.styles/flex {:background-color :white})
-     [status-bar/status-bar]
      [toolbar]
      [react/view {:style components.styles/flex}
       [list/section-list
@@ -86,7 +84,6 @@
   (letsubs [{:keys [label view on-close]} [:get-screen-params :wallet-settings-hook]
             {address :address} [:multiaccount]]
     [react/keyboard-avoiding-view {:style {:flex 1 :background-color colors/blue}}
-     [status-bar/status-bar {:type :wallet}]
      [toolbar/toolbar
       {:style {:border-bottom-color colors/white-transparent-10}}
       [toolbar/nav-button

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -4,7 +4,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.styles :as components.styles]
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as toolbar]
@@ -114,7 +113,6 @@
   (letsubs [{:keys [filters all-filters? on-touch-select-all]}
             [:wallet.transactions.filters/screen]]
     [react/view styles/filter-container
-     [status-bar/status-bar {:type :modal-main}]
      [toolbar/toolbar {}
       [toolbar/nav-clear-text
        {:accessibility-label :done-button}
@@ -223,7 +221,6 @@
              :as transaction}
             [:wallet.transactions.details/screen hash address]]
     [react/view {:style components.styles/flex}
-     [status-bar/status-bar]
      [toolbar/toolbar {}
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/transaction-details)]

--- a/test/cljs/status_im/react_native/js_dependencies.cljs
+++ b/test/cljs/status_im/react_native/js_dependencies.cljs
@@ -53,3 +53,4 @@
 (def react-native-shake  #js {})
 (def net-info  #js {})
 (def touchid  #js {})
+(def safe-area-context #js {})


### PR DESCRIPTION
new safearea component manages statusbar area as well, so we don't need empty view anymore, and status-bar component has been removed

DEMO: https://www.youtube.com/watch?v=0k3hjC4HrEI

for QA: test all screens on different devices with a notch and without, and make sure all screens look great!