### PR TITLE
[#9184] Set password keyboard starts uppercase on old android (6.0.1)

### DIFF
--- a/src/status_im/ui/screens/intro/views.cljs
+++ b/src/status_im/ui/screens/intro/views.cljs
@@ -227,6 +227,7 @@
        (if confirm-failure? (i18n/label :t/password_error1) " ")]
 
       [react/text-input {:secure-text-entry true
+                         :auto-capitalize :none
                          :auto-focus true
                          :accessibility-label :password-input
                          :text-align :center


### PR DESCRIPTION


fixes #9184