### PR TITLE
[#9061] Fix balances fetching of a new keycard account

### DIFF
--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -22,7 +22,8 @@
             [status-im.constants :as constants]
             [status-im.multiaccounts.update.core :as multiaccounts.update]
             [status-im.ui.components.bottom-sheet.core :as bottom-sheet]
-            [status-im.multiaccounts.recover.core :as recover]))
+            [status-im.multiaccounts.recover.core :as recover]
+            [status-im.ethereum.eip55 :as eip55]))
 
 (def default-pin "000000")
 
@@ -1747,10 +1748,12 @@
                        (assoc-in [:hardwallet :setup-step] nil)
                        (assoc :intro-wizard nil))}
               (multiaccounts.create/on-multiaccount-created
-               {:derived              {constants/path-whisper-keyword        {:publicKey whisper-public-key
-                                                                              :address   whisper-address}
-                                       constants/path-default-wallet-keyword {:publicKey wallet-public-key
-                                                                              :address   wallet-address}}
+               {:derived              {constants/path-whisper-keyword
+                                       {:publicKey whisper-public-key
+                                        :address   (eip55/address->checksum whisper-address)}
+                                       constants/path-default-wallet-keyword
+                                       {:publicKey wallet-public-key
+                                        :address   (eip55/address->checksum wallet-address)}}
                 :mnemonic             ""
                 :address              address
                 :publicKey            public-key


### PR DESCRIPTION
fix #9061 again

This issue wasn't properly fixed for a newly created account, balance
was properly fetched only after re-login.

As @yenda mentioned in discord a few weeks ago, we need to normalise addresses on account creation.