### PR TITLE
[#9288]Improve 'snackbar' animation behavior

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -21,13 +21,14 @@
 (fx/defn initialize-app-db
   "Initialize db to initial state"
   [{{:keys [view-id hardwallet initial-props desktop/desktop
-            supported-biometric-auth network/type]} :db}]
+            supported-biometric-auth network/type app-active-since]} :db now :now}]
   {:db (assoc app-db
               :initial-props initial-props
               :desktop/desktop (merge desktop (:desktop/desktop app-db))
               :network/type type
               :hardwallet (dissoc hardwallet :secrets)
               :supported-biometric-auth supported-biometric-auth
+              :app-active-since (or app-active-since now)
               :view-id view-id)})
 
 (fx/defn initialize-views

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -78,9 +78,12 @@
 (spec/def ::tab-bar-visible? (spec/nilable boolean?))
 ;;:online - presence of internet connection in the phone
 (spec/def ::network-status (spec/nilable keyword?))
+;; ui connectivity status
+(spec/def :connectivity/ui-status-properties (spec/nilable map?))
 
 (spec/def ::app-state string?)
 (spec/def ::app-in-background-since (spec/nilable number?))
+(spec/def ::app-active-since (spec/nilable number?))
 
 ;;;;NODE
 
@@ -275,6 +278,7 @@
                                    ::chain
                                    ::app-state
                                    ::app-in-background-since
+                                   ::app-active-since
                                    ::hardwallet
                                    ::auth-method
                                    :multiaccount/multiaccount
@@ -301,6 +305,7 @@
                                    :chat/last-clock-value
                                    :chat/loaded-chats
                                    :chat/bot-db
+                                   :connectivity/ui-status-properties
                                    :ens/registration
                                    :wallet/wallet
                                    :prices/prices

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -145,15 +145,18 @@
                            (>= (- now app-in-background-since)
                                const/ms-in-bg-for-require-bioauth))]
     (fx/merge cofx
-              {:db (assoc db :app-in-background-since nil)}
+              {:db (-> db
+                       (dissoc :app-in-background-since)
+                       (assoc :app-active-since now))}
               (mailserver/process-next-messages-request)
               (hardwallet/return-back-from-nfc-settings)
               #(when requires-bio-auth
                  (biometric/authenticate % on-biometric-auth-result authentication-options)))))
 
-(fx/defn on-going-in-background [{:keys [db now] :as cofx}]
-  (fx/merge cofx
-            {:db (assoc db :app-in-background-since now)}))
+(fx/defn on-going-in-background [{:keys [db now]}]
+  {:db (-> db
+           (dissoc :app-active-since)
+           (assoc :app-in-background-since now))})
 
 (defn app-state-change [state {:keys [db] :as cofx}]
   (let [app-coming-from-background? (= state "active")

--- a/translations/en.json
+++ b/translations/en.json
@@ -1082,7 +1082,7 @@
 	"view-profile": "View profile",
 	"view-signing": "View signing phrase",
 	"view-superrare": "View in SuperRare",
-	"waiting-for-wifi": "History syncing offline, waiting for Wi-Fi.",
+	"waiting-for-wifi": "Offline, waiting for Wi-Fi.",
 	"waiting-for-wifi-change": "Change",
 	"waiting-to-sign": "Waiting to sign transaction...",
 	"wallet": "Wallet",


### PR DESCRIPTION
fixes #9288

~~I started moving the logic from `subscription` to an `fx.` The idea is that, from `fx,` I set a new connectivity state in `db` (by "absorbing"\"smoothing" the unwanted fast state changes). The connectivity view subscribes directly to this new `:connectivity/status`.
**a feedback is needed on that**
I don't like a lot the "intrusiveness" in `mailserver` but I didn't find an alternative way to completely decouple state logic from subscription\ui.~~

still need to do:
- [x] "absorbing" \ "smoothing" logic
    - transition from `connected` or `connecting` to `offline` are immediate.
    - all other transitions (including activation of 'nightrider') will be applied no more than 1 per second.
- [x] wallet state\chat state separation
    - states are offline-connecting-connected.
    - I left the three error messages currently supported, showed here:
       https://github.com/status-im/status-react/issues/9288#issuecomment-560474381
       https://github.com/status-im/status-react/issues/9288#issuecomment-560496633 
    - wallet offline state can be based on `:offline?` subscription.
- [x] avoid simulaneous snackbar\nightrider
   - when snackbar goes away, if still loading, nightrider appears.
- [x] avoid "connecting" when coming back from background
   - coming back from background, in the first 5 seconds, all state transitions are delayed by 5s. Thus if the app is able to reconnect within this timeframe, no 'snackbar' is displayed. The same applies to 'nightrider'.
- [x] code cleanup


status: ready
