### PR TITLE
[#9494] Don't show "Your key recovered" screen on account creation

### DIFF
--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -71,6 +71,7 @@
   {:events [:multiaccounts.create.ui/intro-wizard]}
   [{:keys [db] :as cofx} first-time-setup?]
   (fx/merge cofx
+            {:db (update db :hardwallet dissoc :flow)}
             (prepare-intro-wizard first-time-setup?)
             (navigation/navigate-to-cofx :create-multiaccount-generate-key nil)))
 


### PR DESCRIPTION
fix #9494

one case was missed, as described in this comment https://github.com/status-im/status-react/pull/9574#issuecomment-561519634