### PR TITLE
Update react-native-gesture-handler version

### DIFF
--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -4789,10 +4789,15 @@ react-dom@^16.4.2:
     prop-types "^15.6.2"
     scheduler "^0.16.2"
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.7.0, react-is@^16.8.4, react-is@^16.8.6:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
+
+react-is@^16.8.1:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react-native-background-timer@^2.1.1:
   version "2.1.1"
@@ -4829,9 +4834,9 @@ react-native-fs@^2.14.1:
     utf8 "^2.1.1"
 
 react-native-gesture-handler@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz#c38d9e57637b95e221722a79f2bafac62e3aeb21"
-  integrity sha512-Ffcs+SbEbkGaal0CClYL+v7A9y4OA5G5lW01qrzjxaqASp5C8BfnWSKuqYKE00s6bLwE5L4xnlHkG0yIxAtbrQ==
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.2.tgz#281111550bf1eee10b7feba5278d142169892731"
+  integrity sha512-Xp03dq4XYVTD0xmWx4DW4eX+ox1NQLjHmbykspTdS5FCNIVIOekVXRLFCw1698/v8dYUHApNo6K3s3BCD8fqPA==
   dependencies:
     hammerjs "^2.0.8"
     hoist-non-react-statics "^2.3.1"


### PR DESCRIPTION
fixes #9585

### Summary
`Unsupported top level event` turned out to be a [well-known problem](https://github.com/kmagiera/react-native-gesture-handler/issues/320) in a `react-native-gesture-handler`. After `react-native` upgrade it revealed again and was [fixed](https://github.com/kmagiera/react-native-gesture-handler/pull/845) in latest rngh version.


#### Platforms
- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing


### Steps to test
- Open Status
- Open any chat
- Swipe back on a `back` button
- Make sure there is no error (need to be checked in Release!)

status: ready