### PR TITLE
disable dependabot for desktop js modules

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -20,17 +20,3 @@ update_configs:
         update_type: security
     default_reviewers:
     - "jakubgs"
-  # Keep /desktop/js_files/yarn.lock up to date, batching pull requests weekly
-  - package_manager: "javascript"
-    directory: "/desktop/js_files"
-    update_schedule: "weekly"
-    allowed_updates:
-    - match:
-        update_type: all
-        dependency_type: direct
-    - match:
-        update_type: security
-        dependency_type: indirect
-    default_reviewers:
-    - "vkjr"
-    - "jakubgs"


### PR DESCRIPTION
Since desktop work is on-hold and the bot is noisy.