### PR TITLE
Refresh token balances after adding custom token

### DIFF
--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -334,7 +334,9 @@
   (let [chain        (ethereum/chain-keyword db)
         settings     (update-toggle-in-settings cofx symbol true)
         new-settings (assoc-in settings [:wallet :custom-tokens chain address] token)]
-    (multiaccounts.update/update-settings cofx new-settings {})))
+    (fx/merge cofx
+              (multiaccounts.update/update-settings cofx new-settings {})
+              (update-balances nil))))
 
 (fx/defn remove-custom-token
   [{:keys [db] :as cofx} {:keys [symbol address]}]


### PR DESCRIPTION
fixes #9632 

### Summary

When a custom token is added to the wallet, the token's balance is not refreshed and remains 0 until next login.  This PR resolves this issue by refreshing the token balance as soon as the token is successfully added.

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Tap on Wallet
- Add a custom token the given Ethereum address has a balance in
- Verify that a positive balance is displayed for that token.

status: ready 

![custom-token](https://user-images.githubusercontent.com/17355484/70631126-b0c9a380-1bfa-11ea-8d3a-c83c27bcddf3.gif)

