### PR TITLE
Add mnemonic validation

### DIFF
--- a/externs.js
+++ b/externs.js
@@ -614,5 +614,6 @@ var TopLevel = {
   "multiAccountReset" : function () {},
   "multiAccountLoadAccount" : function () {},
   "multiAccountStoreAccount" : function () {},
-  "multiAccountImportMnemonic" : function () {}
+  "multiAccountImportMnemonic" : function () {},
+  "validateMnemonic" : function () {}
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -1253,4 +1253,26 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     public void isDeviceRooted(final Callback callback) {
         callback.invoke(rootedDevice);
     }
+    
+    @ReactMethod
+    public void validateMnemonic(final String seed, final Callback callback) {
+        Log.d(TAG, "validateMnemonic");
+        if (!checkAvailability()) {
+            callback.invoke(false);
+            return;
+        }
+
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                String resValidateMnemonic = Statusgo.validateMnemonic(seed);
+
+                Log.d(TAG, resValidateMnemonic);
+                callback.invoke(resValidateMnemonic);
+            }
+        };
+
+        StatusThreadPoolExecutor.getInstance().execute(r);
+    }
 }
+

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -601,6 +601,15 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(identicon:(NSString *)publicKey) {
   return StatusgoIdenticon(publicKey);
 }
 
+RCT_EXPORT_METHOD(validateMnemonic:(NSString *)seed
+                  callback:(RCTResponseSenderBlock)callback) {
+#if DEBUG
+    NSLog(@"validateMnemonic() method called");
+#endif
+    NSString *result = StatusgoValidateMnemonic(seed);
+    callback(@[result]);
+}
+
 RCT_EXPORT_METHOD(identiconAsync:(NSString *)publicKey
                   callback:(RCTResponseSenderBlock)callback) {
 #if DEBUG

--- a/src/status_im/ethereum/mnemonic.cljs
+++ b/src/status_im/ethereum/mnemonic.cljs
@@ -6,7 +6,7 @@
 
 (defn sanitize-passphrase [s]
   (-> (string/trim s)
-      (string/replace #"\s+" " ")))
+      (string/replace #"[\s\n]+" " ")))
 
 (defn passphrase->words [s]
   (when s

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -338,3 +338,9 @@
   [seed callback]
   (log/debug "[native-module] gfycat-identicon-async")
   (.generateAliasAndIdenticonAsync (status) seed callback))
+
+(defn validate-mnemonic
+  "Validate that a mnemonic conforms to BIP39 dictionary/checksum standards"
+  [mnemonic callback]
+  (log/debug "[native-module] validate-mnemonic")
+  (.validateMnemonic (status) mnemonic callback))

--- a/src/status_im/ui/screens/multiaccounts/recover/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/recover/views.cljs
@@ -34,15 +34,9 @@
                :line-height 22}}
       (i18n/label :t/custom-seed-phrase-text-1)
       [{:style {:color colors/black}}
-       (i18n/label :t/custom-seed-phrase-text-2)]
-      (i18n/label :t/custom-seed-phrase-text-3)
-      [{:style {:color colors/black}}
-       (i18n/label :t/custom-seed-phrase-text-4)]]]
+       (i18n/label :t/custom-seed-phrase-text-2)]]]
     [react/view {:margin-vertical 24
                  :align-items     :center}
-     [button/button {:on-press            #(re-frame/dispatch [::multiaccounts.recover/continue-pressed])
-                     :accessibility-label :continue-custom-seed-phrase
-                     :label               (i18n/label :t/continue)}]
      [button/button {:on-press            #(re-frame/dispatch [:hide-popover])
                      :accessibility-label :cancel-custom-seed-phrase
                      :type                :secondary

--- a/test/cljs/status_im/test/multiaccounts/recover/core.cljs
+++ b/test/cljs/status_im/test/multiaccounts/recover/core.cljs
@@ -2,7 +2,6 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [status-im.multiaccounts.recover.core :as models]
             [status-im.multiaccounts.create.core :as multiaccounts.create]
-            [clojure.string :as string]
             [status-im.utils.security :as security]
             [status-im.i18n :as i18n]))
 
@@ -10,9 +9,7 @@
 
 
 (deftest check-phrase-warnings
-  (is (nil? (models/check-phrase-warnings "monkey monkey monkey monkey monkey monkey monkey monkey monkey monkey monkey monkey")))
-  (is (nil? (models/check-phrase-warnings "game buzz method pretty olympic fat quit display velvet unveil marine crater")))
-  (is (= :recovery-phrase-unknown-words  (models/check-phrase-warnings "game buzz method pretty zeus fat quit display velvet unveil marine crater"))))
+  (is (= :required-field (models/check-phrase-warnings ""))))
 
 ;;;; handlers
 

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -289,8 +289,6 @@
     "custom-seed-phrase": "عبارة البذور المخصصة",
     "custom-seed-phrase-text-1": "هذا يبدو وكأنه عبارة أولية مخصصة ولا يتطابق مع قاموس Status. هذا يمكن أن يعني أيضا",
     "custom-seed-phrase-text-2": "بعض الكلمات بها أخطاء إملائية.",
-    "custom-seed-phrase-text-3": "إذا كان الأمر كذلك ، فسوف ينتهي إنشاء",
-    "custom-seed-phrase-text-4": "حساب جديد",
     "dapp": "ÐApp",
     "dapp-would-like-to-connect-wallet": "ترغب في الاتصال",
     "dapps": "ÐApps",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1116,8 +1116,6 @@
 	"custom-seed-phrase": "Custom seed phrase",
 	"custom-seed-phrase-text-1": "This looks like a custom seed phrase and doesn't match the Status dictionary. This could also mean ",
 	"custom-seed-phrase-text-2": "some words are misspelled.",
-	"custom-seed-phrase-text-3": " If so, you'll end up creating a",
-	"custom-seed-phrase-text-4": " new account",
 	"to-enable-biometric": "To enable {{bio-type-label}}, your must save your password on the unlock screen",
 	"ok-save-pass": "OK, save password",
 	"lock-app-with": "Lock app with",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -281,8 +281,6 @@
     "custom-seed-phrase": "Phrase de récupération personnalisée",
     "custom-seed-phrase-text-1": "Cela ressemble à une phrase de récupération personnalisée et ne correspond pas au dictionnaire de Status. Cela pourrait aussi signifier",
     "custom-seed-phrase-text-2": "certains mots sont mal orthographiés.",
-    "custom-seed-phrase-text-3": "Si c'est le cas, vous allez créer un",
-    "custom-seed-phrase-text-4": "nouveau compte",
     "dapp": "ÐApp",
     "dapp-would-like-to-connect-wallet": "souhaite se connecter à votre portefeuille",
     "dapps": "ÐApps",

--- a/translations/it.json
+++ b/translations/it.json
@@ -281,8 +281,6 @@
     "custom-seed-phrase": "Frase di recupero personalizzata",
     "custom-seed-phrase-text-1": "Sembra una frase seed personalizzata e non corrisponde al dizionario di Status. Questo potrebbe anche significare",
     "custom-seed-phrase-text-2": "alcune parole sono scritte male.",
-    "custom-seed-phrase-text-3": "In tal caso, finirai per creare un",
-    "custom-seed-phrase-text-4": "Nuovo account",
     "dapp": "ÐApp",
     "dapp-would-like-to-connect-wallet": "vorrebbe connettersi a",
     "dapps": "ÐApps",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -279,8 +279,6 @@
     "custom-seed-phrase": "커스텀 시드 구문",
     "custom-seed-phrase-text-1": "커스텀 시드 구문이 스테이터스 딕셔너리와 일치하지 않습니다. 또한",
     "custom-seed-phrase-text-2": "일부 단어의 철자가 잘못되었을 수 있습니다.",
-    "custom-seed-phrase-text-3": " 이 경우",
-    "custom-seed-phrase-text-4": "새 계정을 생성하게 됩니다.",
     "dapp": "디앱",
     "dapp-would-like-to-connect-wallet": "(이)가 사용자 다음에 연결합니다",
     "dapps": "디앱",

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -279,8 +279,6 @@
     "custom-seed-phrase": "自定义助记词",
     "custom-seed-phrase-text-1": "这好像是一个自定义的助记词，与“Status”字库不匹配。这也可能意味着",
     "custom-seed-phrase-text-2": "有些单词拼写错误。",
-    "custom-seed-phrase-text-3": "如果是这样，您最终将创建一个",
-    "custom-seed-phrase-text-4": "新账户",
     "dapp": "ÐApp",
     "dapp-would-like-to-connect-wallet": "想要连接到",
     "dapps": "ÐApp",


### PR DESCRIPTION
Fixes #9050 and #9670 

### Summary

In account recovery, `status-react` doesn't currently validate that a mnemonic seed phrase only contains words from the BIP39 dictionary and also doesn't validate the checksum.  This PR will ultimately replace the existing mnemonic validation code in the account-recovery flow with a single call to `validate-mnemonic` from status-go that validates the checksum appropriately.

### Testing notes
Needs to be tested on iOS as I do not have a Mac or iPhone so can't test the iOS native code.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Account onboarding

##### Functional

- account recovery
- new account

### Steps to test

For #9050 
- Open Status
- Select recover an account from seed phrase
- Enter an invalid seedphrase with the right number of words but with one not in the BIP39 dictionary
- Verify that erorr message is presented

For #9670 
- Open Status
- Select recover an account from seed phrase
- Enter a valid seedphrase
- Add spaces at end
- Verify that it generates the same multiaccount as with no spaces

status: ready