### PR TITLE
Remove balances for deleted watch account

### DIFF
--- a/src/status_im/wallet/accounts/core.cljs
+++ b/src/status_im/wallet/accounts/core.cljs
@@ -102,12 +102,15 @@
   {:events [:wallet.accounts/delete-account]}
   [{:keys [db] :as cofx} account]
   (let [accounts (:multiaccount/accounts db)
-        new-accounts (vec (remove #(= account %) accounts))]
+        new-accounts (vec (remove #(= account %) accounts))
+        deleted-address (get-in account [:address])]
     (fx/merge cofx
               {::json-rpc/call [{:method     "accounts_deleteAccount"
                                  :params     [(:address account)]
                                  :on-success #()}]
-               :db (assoc db :multiaccount/accounts new-accounts)}
+               :db (-> db
+                       (assoc :multiaccount/accounts new-accounts)
+                       (assoc-in [:wallet :accounts deleted-address] nil))}
               (navigation/navigate-to-cofx :wallet nil))))
 
 (fx/defn save-generated-account


### PR DESCRIPTION
FIxes #9717 

### Summary

Overall wallet balance is not updated when a watch account is deleted.  This PR removes the deleted account's balance from the total so it updates correctly.

#### Platforms
- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test
- Open Status
- Add watch account with balances
- Delete watch account
- Verify that watch account balances aren't reflected in overall balance

status: ready 