### PR TITLE
Temporarily drop status-keycard-java dep update (use 2.2.1 instead of 3.0.1)

### DIFF
--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -38,7 +38,7 @@
     "react-native-screens": "^1.0.0-alpha.23",
     "react-native-shake": "^3.3.1",
     "react-native-splash-screen": "^3.2.0",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.17",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.18",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
     "react-native-webview": "^6.11.1",

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -4900,9 +4900,9 @@ react-native-splash-screen@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
   integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.17":
-  version "2.5.17"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#8fb12850d72918d3e89e4fcfc8fa699c2ce3f203"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.18":
+  version "2.5.18"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#f4d707254a193248f92404e66f746453a2b86cd5"
 
 react-native-svg@^9.8.4:
   version "9.11.1"


### PR DESCRIPTION
Current `develop` relies on `react-native-status-keycard: 2.5.17` which depends on `status-keycard-java: 3.0.1` which in turn cannot be found by Gradle for some reason.

This PR uses a different tag `react-native-status-keycard: 2.5.18` that drops the commit necessitating `status-keycard-java` update (namely, signPinless updates that use CashCommandSet only available in versions 3+)