### PR TITLE
Fix tabbar notification badge position

### DIFF
--- a/src/status_im/ui/components/badge.cljs
+++ b/src/status_im/ui/components/badge.cljs
@@ -9,9 +9,12 @@
                  {:height 18 :border-radius 9 :min-width 18 :padding-horizontal 6}
                  {:height 22 :border-radius 11 :min-width 22 :padding-horizontal 8})
                {:background-color colors/blue
-                :justify-content :center
-                :align-items :center})
-   [react/text {:style {:typography :caption :color colors/white}} label]])
+                :justify-content  :center
+                :align-items      :center})
+   [react/text {:style {:typography  :caption
+                        :font-weight "500"
+                        :color       colors/white}}
+    label]])
 
 (defn message-counter [value & [small?]]
   [badge

--- a/src/status_im/ui/components/tabbar/styles.cljs
+++ b/src/status_im/ui/components/tabbar/styles.cljs
@@ -46,9 +46,13 @@
    :top      0
    :position :absolute})
 
+;; NOTE: Extra padding to allow badge width to be up to 42 (in case of 99+)
+;; 42 Max allowed width, 24 icon width as per spec, 16 left pos as per spec.
+(def ^:private message-counter-left (+ (/ (- 42 24) 2) 16))
+
 (def message-counter
-  {:right    -10
-   :top      0
+  {:left     message-counter-left
+   :bottom   6
    :position :absolute})
 
 (def touchable-container


### PR DESCRIPTION
Fix: #9436 
![Screenshot 2020-01-02 at 14 55 30](https://user-images.githubusercontent.com/5794620/71665956-ee3fcd80-2d6f-11ea-8e82-1bff57a2a31c.png)
![Screenshot 2020-01-02 at 14 56 17](https://user-images.githubusercontent.com/5794620/71665987-0879ab80-2d70-11ea-90e7-dbb99dc30d9d.png)
![Screenshot 2020-01-02 at 14 56 01](https://user-images.githubusercontent.com/5794620/71665995-13ccd700-2d70-11ea-830d-e5106eac08dd.png)


