### PR TITLE
Add lint-fix target for simple style fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,10 @@ lint: export TARGET := lein
 lint: ##@test Run code style checks
 	lein cljfmt check
 
+lint-fix: export TARGET := lein
+lint-fix: ##@test Run code style checks and fix issues
+	lein cljfmt fix
+	
 test: export TARGET := lein
 test: ##@test Run tests once in NodeJS
 	lein with-profile test doo node test once


### PR DESCRIPTION
### Summary

The Makefile currently has a target `make lint` but this just runs the style checker without actually fixing code style/formatting errors and the output isn't always that easy to understand.  This adds a new `make lint-fix` target that runs `lein cljfmt fix` that will automatically reformat any issues identified by the linter and simplify the novice contributor's life tremendously since Clojurescript novices like yours truly didn't even know there was a linter until @yenda [helpfully pointed it out](https://github.com/status-im/status-react/pull/8917#issuecomment-529792167) to me.

If/when merged, I'll submit a secondary PR on the [makefile tour](https://status.im/build_status/makefile_tour.html) to add the new target.

#### Platforms
- macOS
- Linux

#### Areas that maybe impacted
Makefile

##### Functional

- Build tooling

##### Non-functional
N/A

### Steps to test
* Add a lot of extra spaces in any code.  
* Run `make lint-fix` from the command line.
* Verify that formatting is fixed.

status: ready
