### PR TITLE
Change safe-area from position to padding

### DIFF
--- a/src/status_im/ui/components/tabbar/core.cljs
+++ b/src/status_im/ui/components/tabbar/core.cljs
@@ -104,9 +104,8 @@
 
 (defn tabs-animation-wrapper-ios
   [content]
-  [react/view
+  [react/view {:style tabs.styles/title-cover-wrapper-ios}
    [react/view
-    {:style tabs.styles/title-cover-wrapper}
     content
     (when platform/iphone-x?
       [react/view
@@ -119,7 +118,7 @@
             keyboard-shown?
             (main-tab? view-id))}
    [react/view
-    {:style tabs.styles/title-cover-wrapper}
+    {:style tabs.styles/title-cover-wrapper-android}
     content]])
 
 (defn tabs-animation-wrapper [keyboard-shown? view-id tab]

--- a/src/status_im/ui/components/tabbar/styles.cljs
+++ b/src/status_im/ui/components/tabbar/styles.cljs
@@ -129,20 +129,27 @@
    :position         :absolute
    :height           (- tabs-height minimized-tabs-height)
    :align-self       :stretch
-   :top              tabs-height
+   :top              0
    :right            0
    :left             0})
 
-(def title-cover-wrapper
-  {:position :absolute
-   :height   tabs-height
-   :bottom   (if platform/iphone-x? 34 0)
+(def title-cover-wrapper-ios
+  {:left             0
+   :right            0
+   :bottom           0
+   :padding-bottom   (if platform/iphone-x? 34 0)
+   :position         :absolute
+   :background-color :white})
+
+(def title-cover-wrapper-android
+  {:left     0
    :right    0
-   :left     0})
+   :bottom   0
+   :position :absolute})
 
 (defn animation-wrapper [keyboard-shown? main-tab?]
   {:height     (cond
                  keyboard-shown? 0
-                 main-tab? tabs-height
-                 :else minimized-tabs-height)
+                 main-tab?       tabs-height
+                 :else           minimized-tabs-height)
    :align-self :stretch})


### PR DESCRIPTION
Makes the view stretch to the size of the safe area instead of moving it from the bottom. Fixes transparent background on navigation animation on iPhone X. On android do not set background as it is drawn above the tabbar thus over the screens because of the absolute position. Needs manual QA cause it may affect the drawing of minimized tabbar over the UI, for example, the android with BG was drawn above the browser navigation. It could be refactored using `safe-area-view` but will take more time with the same result. Fixes #9695 