### PR TITLE
fix awkward caps

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -743,7 +743,7 @@
 	"offline-messaging-settings": "Mailserver settings",
 	"ok": "OK",
 	"ok-continue": "Okay, continue",
-	"ok-got-it": "OKay, got it",
+	"ok-got-it": "Okay, got it",
 	"okay": "Okay",
 	"on": "On",
 	"open": "Open",


### PR DESCRIPTION
`OKay, got it` > `Okay, got it`