### PR TITLE
fix: deserialize custom bootnodes settings correctly

### DIFF
--- a/src/status_im/data_store/settings.cljs
+++ b/src/status_im/data_store/settings.cljs
@@ -21,7 +21,7 @@
 
 (defn rpc->custom-bootnodes [custom-bootnodes]
   (reduce-kv (fn [acc chain custom-bootnodes]
-               (assoc acc (str chain) custom-bootnodes))
+               (assoc acc (name chain) custom-bootnodes))
              {}
              custom-bootnodes))
 
@@ -39,4 +39,6 @@
       (update :wallet/visible-tokens rpc->visible-tokens)
       (update :pinned-mailservers rpc->pinned-mailservers)
       (update :stickers/packs-installed rpc->stickers-packs)
+      (update :custom-bootnodes rpc->custom-bootnodes)
+      (update :custom-bootnodes-enabled? rpc->custom-bootnodes)
       (update :currency keyword)))


### PR DESCRIPTION
This PR fixes reading bootnodes from settings so the app is aware of the correct preferences.

Fixes #9752 

Thank you @yenda for the help.

### Testing notes
Follow steps on #9752 to validate working

##### Functional

- bootnodes

status: ready