### PR TITLE
Use default keyboard for username input

### DIFF
--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -204,7 +204,6 @@
          :auto-complete-type     "off"
          :auto-focus             true
          :auto-correct           false
-         :keyboard-type          :visible-password
          :default-value          ""
          :text-align             :center
          :placeholder            placeholder


### PR DESCRIPTION
Seems like there is no reason for custom keyboard type as the input is used to input a username.