### PR TITLE
Nix: Expose .env feature flags to Nix as attrset

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -36,10 +36,11 @@ def bundle() {
     /* Nix target which produces the final APKs */
     nix.build(
       attr: 'targets.mobile.android.release',
-      args: [
-        'gradle-opts': gradleOpt,
-        'build-number': utils.readBuildNumber(),
-        'build-type': btype,
+      conf: [
+        'status-im.ci': '1',
+        'status-im.build-type': btype,
+        'status-im.status-react.gradle-opts': gradleOpt,
+        'status-im.status-react.build-number': utils.readBuildNumber(),
       ],
       safeEnv: [
         'STATUS_RELEASE_KEY_ALIAS',

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 {
-  config ? { }, # for passing status_go.src_override
+  config ? { status-im = { build-type = ""; }; }, # for passing build options, see nix/README.md
 }:
 
 let

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -246,7 +246,7 @@ PODS:
     - ReactCommon/jscallinvoker (= 0.61.5)
   - RNFS (2.14.1):
     - React
-  - RNGestureHandler (1.4.1):
+  - RNGestureHandler (1.5.2):
     - React
   - RNImageCropPicker (0.25.3):
     - QBImagePickerController
@@ -456,7 +456,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   RNFS: a8fbe7060fa49157d819466404794ad9c58e58cf
-  RNGestureHandler: 4cb47a93019c1a201df2644413a0a1569a51c8aa
+  RNGestureHandler: 946a7691e41df61e2c4b1884deab41a4cdc3afff
   RNImageCropPicker: bfb3ea9c8622f290532e2fe63f369e0d5a52f597
   RNKeychain: 216f37338fcb9e5c3a2530f1e3295f737a690cb1
   RNLanguages: 962e562af0d34ab1958d89bcfdb64fafc37c513e

--- a/nix/README.md
+++ b/nix/README.md
@@ -8,6 +8,26 @@ The main config file is [`nix/nix.conf`](/nix/nix.conf) and its main purpose is 
 
 __NOTE:__ If you are in Asia you might want to add the `https://nix-cache-cn.status.im/` to be first in order of `substituters`. Removing `cache.nixos.org` could also help.
 
+## Build arguments
+
+We leverage the standard nixpkgs `config` argument for our own parameterization of the builds (e.g. to pass a build number or build type). Here is a sample structure of the `config` attribute set:
+
+```nix
+config = {
+  status-im = {
+    ci = "1";                 # This flag is present when running in a CI environment
+    build-type = "pr";        # Build type (influences which .env file gets used for feature flags)
+    status-go = {
+      src-override = "$GOPATH/src/github.com/status-im/status-go";
+    };
+    status-react = {
+      build-number = "9999";  # Build number to be assigned to the app bundle
+      gradle-opts = "";       # Gradle options passed for Android builds
+    };
+  };
+};
+```
+
 ## Shell
 
 In order to access an interactive Nix shell a user should run `make shell`.

--- a/nix/scripts/shell.sh
+++ b/nix/scripts/shell.sh
@@ -51,13 +51,14 @@ if [[ "$TARGET" =~ (linux|windows|darwin|macos) ]]; then
   nix-shell ${shellArgs[@]} --run "scripts/prepare-for-desktop-platform.sh" || exit
 fi
 
-statusGoConfig=''
+config=''
 if [ -n "${STATUS_GO_SRC_OVERRIDE}" ]; then
-  statusGoConfig+="status_go.src_override=\"${STATUS_GO_SRC_OVERRIDE}\";"
+  config+="status-im.status-go.src-override=\"${STATUS_GO_SRC_OVERRIDE}\";"
 fi
+config+="status-im.build-type=\"${BUILD_TYPE}\";"
 
-if [ -n "$statusGoConfig" ]; then
-  shellArgs+=("--arg config {$statusGoConfig}")
+if [ -n "$config" ]; then
+  shellArgs+=("--arg config {$config}")
 fi
 
 # if _NIX_ATTR is specified we shouldn't use shell.nix, the path will be different

--- a/nix/status-go/build-mobile-status-go.nix
+++ b/nix/status-go/build-mobile-status-go.nix
@@ -5,19 +5,18 @@
 
   # mobile-only arguments
   goBuildFlags, goBuildLdFlags,
-  config } @ args':
+  targetConfig } @ args':
 
 let
   inherit (stdenv.lib) concatStringsSep makeBinPath optional;
 
-  targetConfig = config;
   buildStatusGo = callPackage ./build-status-go.nix {
     inherit buildGoPackage go xcodeWrapper utils;
   };
 
   # Remove mobile-only arguments from args
   args = removeAttrs args' [
-    "config" "goBuildFlags" "goBuildLdFlags"
+    "targetConfig" "goBuildFlags" "goBuildLdFlags"
   ];
 
   buildStatusGoMobileLib = buildStatusGo (args // {

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -12,8 +12,8 @@ let
   buildStatusGoDesktopLib = callPackage ./build-desktop-status-go.nix { inherit buildGoPackage go xcodeWrapper utils; };
   buildStatusGoMobileLib = callPackage ./build-mobile-status-go.nix { inherit buildGoPackage go gomobile xcodeWrapper utils; };
   srcData =
-    # If config.status_go.src_override is defined, instruct Nix to use that path to build status-go
-    if (attrByPath ["status_go" "src_override"] "" config) != "" then rec {
+    # If config.status-im.status-go.src-override is defined, instruct Nix to use that path to build status-go
+    if (attrByPath ["status-im" "status-go" "src-override"] "" config) != "" then rec {
         owner = "status-im";
         repo = "status-go";
         rev = "unknown";
@@ -22,7 +22,7 @@ let
         cleanVersion = rawVersion;
         goPackagePath = "github.com/${owner}/${repo}";
         src =
-          let path = traceValFn (path: "Using local ${repo} sources from ${path}\n") config.status_go.src_override;
+          let path = traceValFn (path: "Using local ${repo} sources from ${path}\n") config.status-im.status-go.src-override;
           in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
             inherit path;
             name = "${repo}-source-${shortRev}";
@@ -106,12 +106,12 @@ let
 
     android = buildStatusGoMobileLib (statusGoArgs // {
       host = mobileConfigs.android.name;
-      config = mobileConfigs.android;
+      targetConfig = mobileConfigs.android;
     });
 
     ios = buildStatusGoMobileLib (statusGoArgs // {
       host = mobileConfigs.ios.name;
-      config = mobileConfigs.ios;
+      targetConfig = mobileConfigs.ios;
     });
   };
 

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -1,4 +1,4 @@
-{ 
+{
   config ? {},
   pkgs ? import ./pkgs.nix { inherit config; }
 }:
@@ -9,7 +9,7 @@ let
     inherit stdenv;
   };
 
-  status-go = callPackage ./status-go { 
+  status-go = callPackage ./status-go {
     inherit (mobile) xcodeWrapper;
     androidPkgs = mobile.android.androidComposition;
   };

--- a/nix/tools/envParser.nix
+++ b/nix/tools/envParser.nix
@@ -1,0 +1,36 @@
+# This Nix expression takes care of reading/parsing the correct .env configuration file and return it as an attr set
+{ config, stdenv }:
+
+let
+  inherit (builtins) listToAttrs head tail readFile;
+  inherit (stdenv.lib) attrByPath filter hasPrefix nameValuePair splitString;
+
+  build-type = attrByPath ["status-im" "build-type"] "" config;
+  ci = (attrByPath ["status-im" "ci"] "" config) != "";
+
+  readLinesFromFile =
+    file:
+      let
+        lines = splitString "\n" (readFile file);
+        removeComments = filter (line: line != "" && !(hasPrefix "#" line));
+        meaningfulLines = removeComments lines;
+      in
+        meaningfulLines;
+  readFlagsFromFile =
+    file:
+      let
+        lines = readLinesFromFile file;
+        genAttrs = lines:
+          listToAttrs (map (line:
+            let flag = splitString "=" line;
+            in nameValuePair (head flag) (head (tail flag))) lines);
+      in
+        genAttrs lines;
+  envFileName =
+    if build-type == "release" then ../../.env.release else
+    if build-type == "nightly" then ../../.env.nightly else
+    if build-type == "e2e" then ../../.env.e2e else
+    if ci then ../../.env.jenkins else ../../.env;
+  flags = readFlagsFromFile envFileName; # TODO: Simplify this path search with lib.locateDominatingFile
+
+in flags

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -6,23 +6,22 @@ source "$_current_dir/lib/setup/path-support.sh"
 
 source_lib "platform.sh"
 
-statusGoConfig=''
+config=''
+config+="status-im.build-type=\"${BUILD_TYPE}\";"
 if [ -n "${STATUS_GO_SRC_OVERRIDE}" ]; then
-  statusGoConfig+="status_go.src_override=\"${STATUS_GO_SRC_OVERRIDE}\";"
+  config+="status-im.status-go.src-override=\"${STATUS_GO_SRC_OVERRIDE}\";"
 fi
-
+config+="status-im.status-react.build-number=\"${BUILD_NUMBER}\";"
+config+="status-im.status-react.keystore-file=\"${STORE_FILE}\";"
 nixOpts=(
-  "--arg config {${statusGoConfig}}"
+  "--arg config {${config}}"
   "--arg env {BUILD_ENV=\"${BUILD_ENV}\";ANDROID_ABI_SPLIT=\"${ANDROID_ABI_SPLIT}\";ANDROID_ABI_INCLUDE=\"${ANDROID_ABI_INCLUDE}\";}"
-  "--argstr build-type ${BUILD_TYPE}"
-  "--argstr build-number ${BUILD_NUMBER}"
-  "--argstr keystore-file ${STORE_FILE}"
 )
 
 if is_macos; then
   # Start a watchman instance if not started already and store its socket path.
   # In order to get access to the right versions of watchman and jq, we start an ad-hoc nix-shell that imports the packages from nix/nixpkgs-bootstrap.
-  WATCHMAN_SOCKFILE = $(watchman get-sockname --no-pretty | jq -r .sockname)
+  WATCHMAN_SOCKFILE=$(watchman get-sockname --no-pretty | jq -r .sockname)
   nixOpts+=(
     "--argstr watchmanSockPath ${WATCHMAN_SOCKFILE}"
     "--option extra-sandbox-paths ${STORE_FILE};${WATCHMAN_SOCKFILE}"

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 {
-  config ? { },      # for passing status_go.src_override
+  config ? { },      # for passing build options, see nix/README.md
   target ? "default" # see nix/shells.nix for all valid values
 }:
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR allows Nix code to read feature flags present in the correct .env file.

Currently only tested for Android builds (since this is where we'll use this for Nimbus).

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->