### PR TITLE
Update copy Choose key storage

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -544,7 +544,7 @@
 	"intro-title3": "Decentralized apps",
 	"intro-wizard-text1": "A set of keys controls your account. Your keys live on your phone, so only you can use them",
 	"intro-wizard-text2": "One key is for chat. It comes with a readable name that can’t be changed.",
-	"intro-wizard-text3": "Own a Keycard? Store your keys on it; you’ll need it for transactions",
+	"intro-wizard-text3": "If you own a Keycard, store your keys there for enhanced security.",
 	"intro-wizard-text4": "Secure and encrypt your keys",
 	"intro-wizard-text6": "Status will notify you about new messages. You can edit your notification preferences later in settings",
 	"intro-wizard-title-alt4": "Create a password",


### PR DESCRIPTION
Error with previous update, fixes #9707

Intro-wizard-3 (OLD): Own a Keycard? Store your keys on it; you'll need it for transactions
Intro-wizard-3 (NEW): If you own a Keycard, store your keys there for enhanced security.


