### PR TITLE
Fix the way STATUS_GO_ENABLE_NIMBUS is read in cljs

### DIFF
--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -36,6 +36,7 @@
 (def blank-preview? (enabled? (get-config :BLANK_PREVIEW "1")))
 (def group-chat-enabled? (enabled? (get-config :GROUP_CHATS_ENABLED "0")))
 (def tooltip-events? (enabled? (get-config :TOOLTIP_EVENTS "0")))
+(def nimbus-enabled? (enabled? (get-config :STATUS_GO_ENABLE_NIMBUS "0")))
 
 ;; CONFIG VALUES
 (def log-level
@@ -50,4 +51,3 @@
 (def pow-target (js/parseFloat (get-config :POW_TARGET "0.002")))
 (def pow-time (js/parseInt (get-config :POW_TIME "1")))
 (def max-installations 2)
-(def nimbus-enabled? (enabled? (get-config :STATUS_GO_ENABLE_NIMBUS "0")))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes the way the `STATUS_GO_ENABLE_NIMBUS` feature flag is read in Clojure, so that the 0 value is correctly interpreted.

status: ready <!-- Can be ready or wip -->
