### PR TITLE
Fix bug reporting

### DIFF
--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -19,4 +19,5 @@
       (get 0)))
 
 (defn extract-url-components [address]
-  (rest (re-matches #"enode://(.*?)@(.*):(.*)" address)))
+  (when address
+    (rest (re-matches #"enode://(.*?)@(.*):(.*)" address))))

--- a/src/status_im/utils/logging/core.cljs
+++ b/src/status_im/utils/logging/core.cljs
@@ -81,6 +81,12 @@
       :on-cancel           #(re-frame/dispatch
                              [:logging/dialog-canceled])}}))
 
+(handlers/register-handler-fx
+ :show-client-error
+ (fn [_ _]
+   {:utils/show-popup {:title   (i18n/label :t/cant-report-bug)
+                       :content (i18n/label :t/mail-should-be-configured)}}))
+
 (fx/defn dialog-closed
   [{:keys [db]}]
   {:db (dissoc db :logging/dialog-shown?)})
@@ -102,7 +108,8 @@
               (str "App version: " build-version)
               (str "OS: " platform/os)
               (str "Node version: " web3-node-version)
-              (str "Mailserver: " (name current-id))
+              (when current-id
+                (str "Mailserver: " (name current-id)))
               separator
               "Node Info"
               (str "id: " enode-id)
@@ -136,7 +143,9 @@
       :attachment {:path archive-path
                    :type "zip"
                    :name "status_logs.zip"}}
-     (fn [])))))
+     (fn [event]
+       (when (= event "not_available")
+         (re-frame/dispatch [:show-client-error])))))))
 
 (handlers/register-handler-fx
  :logging/dialog-canceled

--- a/translations/en.json
+++ b/translations/en.json
@@ -1158,5 +1158,7 @@
 	"keycard-free-pairing-slots": "Keycard has {{n}} free pairing slots",
 	"public-chat-description": "Join public chats for your interests! Anyone can start a new one.",
 	"delete-account": "Delete account",
-	"watch-only": "Watch-only"
+	"watch-only": "Watch-only",
+	"cant-report-bug": "Can't report a bug",
+	"mail-should-be-configured": "Mail client should be configured"
 }


### PR DESCRIPTION
fixes #8325

### Summary

Fixed `re-matches must match against a string` error on bug reporting when user logged out.

Also it turned out that when mail client is not configured, we do not inform user and he can suppose that report was sent. To avoid this I added a notification for such scenario:

![Screenshot 2020-01-22 at 13 12 47](https://user-images.githubusercontent.com/5786310/72890590-e776fb80-3d1a-11ea-8a2c-c9068815cd74.png)


### Review notes
Related issue in a `react-native-mail` repo - https://github.com/chirag04/react-native-mail/issues/130

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Bug reporting


### Steps to test
- Open Status
- Shake device
- Press "send report"
- Make sure mail client is opened with bug report ready to send. Or alert shown if mail client is not configured.

status: ready