### PR TITLE
Remove react/modal view from android navigation

### DIFF
--- a/components/src/status_im/ui/components/react.cljs
+++ b/components/src/status_im/ui/components/react.cljs
@@ -311,10 +311,7 @@
      children)))
 
 (defn main-screen-modal-view [current-view & components]
-  ;; NOTE on Android we use Modal component and it manages statusbar area by itself
-  [(if platform/ios?
-     (create-main-screen-view current-view)
-     view)
+  [(create-main-screen-view current-view)
    styles/flex
    [(if (= current-view :chat-modal)
       view

--- a/src/status_im/ui/screens/routing/core.cljs
+++ b/src/status_im/ui/screens/routing/core.cljs
@@ -99,27 +99,9 @@
   (fn [args]
     (let [params  (get-in args [:navigation :state :params])
           active? (reagent.core/atom true)]
-      (if platform/android?
-        [react/view common-styles/modal
-         [react/modal
-          {:transparent      true
-           :animation-type   :slide
-           :on-request-close (fn []
-                               (cond
-                                 (#{:wallet-send-transaction-modal
-                                    :wallet-sign-message-modal}
-                                  modal-view)
-                                 (re-frame/dispatch
-                                  [:wallet/discard-transaction-navigate-back])
-
-                                 :else
-                                 (re-frame/dispatch [:navigate-back])))}
-          [react/main-screen-modal-view modal-view
-           [component params active?]]
-          [navigation-events modal-view true active?]]]
-        [react/main-screen-modal-view modal-view
-         [component params active?]
-         [navigation-events modal-view true active?]]))))
+      [react/main-screen-modal-view modal-view
+       [component params active?]
+       [navigation-events modal-view true active?]])))
 
 (defn prepare-config [config]
   (-> config


### PR DESCRIPTION
Fixes #9884 

React modal is drawn above the app (maximum z-index) while the bottom sheet and popover are part of the app with position absolute. https://facebook.github.io/react-native/docs/modal.html documentation also suggest to not use modal in that case cause we lose some control over navigation. Now modal are handled by navigation and we can draw our popover and bottom sheet on bigger z-index and  better control what should be on the top.

Further changes will come in another PR which upgrades react-navigation and adds some more control over it.

An extra benefit of that is unifying the handling on iOs and Android which should make easier maintenance in future.