### PR TITLE
[Fixes: #9900] Use component-did-update

### DIFF
--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -312,7 +312,7 @@
    modal?]
   (letsubs [messages           [:chats/current-chat-messages-stream]
             current-public-key [:multiaccount/public-key]]
-    {:component-did-mount
+    {:component-did-update
      (fn [args]
        (when-not (:messages-initialized? (second (.-argv (.-props args))))
          (re-frame/dispatch [:chat.ui/load-more-messages]))


### PR DESCRIPTION
fixes:  #9900

When moving from chat to chat, component-did-mount is not fired as the
component is never unmounted, therefore messages were not loaded.
This changes the behavior to use the component-did-update lifecycle
method.

status: ready