### PR TITLE
Fix ens names in chat

### DIFF
--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -187,7 +187,8 @@
                      public-key (str "0x" (name public-key-keyword))
                      contact    (contact.db/public-key->contact contacts public-key)]
 
-                 (if error
+                 (if (or error
+                         (< ens-verified-at (:ens-verified-at contact)))
                    (assoc acc public-key contact)
                    (assoc acc public-key
                           (assoc contact

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,6 +3,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "v0.40.0",
-    "commit-sha1": "dc31c818fce6dbff6cfd76da09d901b0df742e2e",
-    "src-sha256": "1f0fp5c4lqnh244wcvbnl5i4p9fb0f3i0rjjvbiqwkz9zwwp3xlv"
+    "commit-sha1": "14a69d87080a9f9d53003377be3cceba79ca8f8a",
+    "src-sha256": "1ajfq80n1wni92i1dhi6sm1lsy36hq8ikyd0sylvkbg4jcz4fd1d"
 }

--- a/test/cljs/status_im/test/ens/core.cljs
+++ b/test/cljs/status_im/test/ens/core.cljs
@@ -1,0 +1,32 @@
+(ns status-im.test.ens.core
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.ens.core :as ens]))
+
+(deftest should-be-verified-test?
+  (testing "valid cases"
+    (testing "stateofus.eth name"
+      (let [cofx {:db {:contacts/contacts {}}}]
+        (is (ens/should-be-verified? cofx "user.stateofus.eth" "user" 1))))
+    (testing ".eth name"
+      (let [cofx {:db {:contacts/contacts {}}}]
+        (is (ens/should-be-verified? cofx "user.eth" "user" 1))))
+    (testing "clock value is greater and name is different"
+      (let [cofx {:db {:contacts/contacts {"user" {:ens-verified-at 1
+                                                   :name "user.eth"
+                                                   :ens-verified true}}}}]
+        (is (ens/should-be-verified? cofx "user2.eth" "user" 2)))))
+  (testing "invalid cases"
+    (testing "invalid name"
+      (let [cofx {:db {:contacts/contacts {}}}]
+        (is (not (ens/should-be-verified? cofx "user.stateofus.ethanol" "user" 1)))))
+    (testing "already verified"
+      (let [cofx {:db {:contacts/contacts {"user" {:ens-verified-at 0
+                                                   :name "user.eth"
+                                                   :ens-verified true}}}}]
+        (is (not (ens/should-be-verified? cofx "user.eth" "user" 0)))))
+    (testing "already verified, name identical"
+      (let [cofx {:db {:contacts/contacts {"user" {:ens-verified-at 0
+                                                   :name "user.eth"
+                                                   :ens-verified true}}}}]
+        (is (not (ens/should-be-verified? cofx "user.eth" "user" 1)))))))
+

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -23,6 +23,7 @@
             [status-im.test.hardwallet.core]
             [status-im.test.i18n]
             [status-im.test.mailserver.core]
+            [status-im.test.ens.core]
             [status-im.test.mailserver.topics]
             [status-im.test.models.bootnode]
             [status-im.test.models.contact]
@@ -93,6 +94,7 @@
  'status-im.test.fleet.core
  'status-im.test.hardwallet.core
  'status-im.test.i18n
+ 'status-im.test.ens.core
  'status-im.test.mailserver.core
  'status-im.test.mailserver.topics
  'status-im.test.models.bootnode


### PR DESCRIPTION
We now store the clock value of the message and check against it, to make sure we don't verify old usernames.
status: ready