### PR TITLE
Clarify wallet 'send' button

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1106,7 +1106,7 @@
     "wallet-manage-assets": "Manage assets",
     "wallet-offline": "Wallet offline",
     "wallet-request": "Request",
-    "wallet-send": "Send",
+    "wallet-send": "Next",
     "wallet-send-min-wei": "Min 1 wei",
     "wallet-settings": "Wallet settings",
     "wallet-total-value": "Total value",


### PR DESCRIPTION
The 'Send' button in the wallet generated Tx flow leads to the Tx overview, where you can edit network fee and check details.

I changed the button that leads to this screen from 'Send' to 'Next', so users know there is another step in the process.

Simon's screenshot:
![image](https://user-images.githubusercontent.com/15470435/73188016-d54ef000-4154-11ea-807d-c594c4b79111.png)
