### PR TITLE
Correctly dispatch on updates & disable them

### DIFF
--- a/src/status_im/multiaccounts/update/publisher.cljs
+++ b/src/status_im/multiaccounts/update/publisher.cljs
@@ -1,5 +1,6 @@
 (ns status-im.multiaccounts.update.publisher
   (:require [taoensso.timbre :as log]
+            [re-frame.core :as re-frame]
             [status-im.constants :as constants]
             [status-im.multiaccounts.update.core :as multiaccounts]
             [status-im.ethereum.json-rpc :as json-rpc]
@@ -25,4 +26,9 @@
         (log/debug "sending contact updates")
         (json-rpc/call {:method "shhext_sendContactUpdates"
                         :params [(or preferred-name name) photo-path]
-                        :on-success #(log/debug "sent contact updates")})))))
+                        :on-failure #(do
+                                       (log/warn "failed to send contact updates")
+                                       (re-frame/dispatch [:multiaccounts.update.callback/failed-to-publish]))
+                        :on-success #(do
+                                       (log/debug "sent contact updates")
+                                       (re-frame/dispatch [:multiaccounts.update.callback/published]))})))))

--- a/src/status_im/utils/publisher.cljs
+++ b/src/status_im/utils/publisher.cljs
@@ -20,7 +20,6 @@
              (let [cofx {:now  (datetime/timestamp)
                          :db   @re-frame.db/app-db}]
                (mailserver/check-connection!)
-               (multiaccounts/publish-update! cofx)
                (done-fn)))
            sync-interval-ms
            sync-timeout-ms)))


### PR DESCRIPTION
On moving updates to status-go we removed the dispatch on the rpc request, and therefore updates were published too often. should have listen to @yenda more carefully ;) 
this commit fixes the issue and disables them for now, as we don't really need them (ens is not resolved in contact updates).

status: ready
