### PR TITLE
improvement on snackbar by considering login time

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -282,7 +282,7 @@
   (boolean (get-in cofx [:db :hardwallet :flow])))
 
 (fx/defn multiaccount-login-success
-  [{:keys [db] :as cofx}]
+  [{:keys [db now] :as cofx}]
   (let [{:keys [key-uid password save-password? creating?]} (:multiaccounts/login db)
         recovering? (get-in db [:intro-wizard :recovering?])
         login-only? (not (or creating?
@@ -294,12 +294,13 @@
                "recovering?" recovering?)
     (fx/merge cofx
               {:db (-> db
-                       (dissoc :multiaccounts/login)
+                       (dissoc :multiaccounts/login :connectivity/ui-status-properties)
                        (update :hardwallet dissoc
                                :on-card-read
                                :card-read-in-progress?
                                :pin
-                               :multiaccount))
+                               :multiaccount)
+                       (assoc :logged-in-since now))
                ::json-rpc/call
                [{:method "web3_clientVersion"
                  :on-success #(re-frame/dispatch [::initialize-web3-client-version %])}]}

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -99,6 +99,7 @@
 (reg-root-key-sub :supported-biometric-auth :supported-biometric-auth)
 (reg-root-key-sub :app-active-since :app-active-since)
 (reg-root-key-sub :connectivity/ui-status-properties :connectivity/ui-status-properties)
+(reg-root-key-sub :logged-in-since :logged-in-since)
 
 ;;NOTE this one is not related to ethereum network
 ;; it is about cellular network/ wifi network
@@ -1574,11 +1575,12 @@
                            disconnected?
                            :t/offline
 
-                           :else nil)]
+                           :else nil)
+         connected?       (and (nil? error-label) (not= :mobile-network error-label))]
      {:message            (or error-label :t/connected)
-      :connected?         (and (nil? error-label) (not= :mobile-network error-label))
+      :connected?         connected?
       :connecting?        (= error-label :t/connecting)
-      :loading-indicator? mailserver-fetching?
+      :loading-indicator? (and mailserver-fetching? connected?)
       :on-press-event       (cond
                               mailserver-connection-error?
                               :mailserver.ui/reconnect-mailserver-pressed

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -82,6 +82,7 @@
 (spec/def ::app-state string?)
 (spec/def ::app-in-background-since (spec/nilable number?))
 (spec/def ::app-active-since (spec/nilable number?))
+(spec/def ::logged-in-since (spec/nilable number?))
 
 ;;;;NODE
 
@@ -276,6 +277,7 @@
                                    ::app-state
                                    ::app-in-background-since
                                    ::app-active-since
+                                   ::logged-in-since
                                    ::hardwallet
                                    ::auth-method
                                    :multiaccount/multiaccount


### PR DESCRIPTION
I improved the snackbar "smoothiness" by considering also login time.

summary:
 - connectivity-ui update delay 5 seconds **if** have logged in from 5seconds OR app-in-foreground from 5 seconds
 - **else** connectivity-ui update delay 1 second

also:
- removed the immediate transition to "Offline" state, which was complicating the code without giving a meaningful benefit.
- improved avoidance of loading indicator when unnecessary
- cleaner code, more comments
- added debug log

so if you logoff and relogin, you don't get the "offline->connected" snackbar. 

@errorists this is for you 😄 

status: ready
