### PR TITLE
Git ignore trace.edn and config.cljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ status-modules/resources
 /fiddle/node_modules/
 /fiddle/target/
 /fiddle/resources/public/images/
+
+trace.edn

--- a/env/dev/env/config.cljs
+++ b/env/dev/env/config.cljs
@@ -1,6 +1,0 @@
-(ns env.config)
-
-(def figwheel-urls {:android "ws://localhost:3449/figwheel-ws",
- :ios "ws://192.168.0.9:3449/figwheel-ws",
- :desktop "ws://localhost:3449/figwheel-ws"}
-)


### PR DESCRIPTION
They are auto generated and should not be present in git