### PR TITLE
Clean up after recent tx history changes:

### DIFF
--- a/src/status_im/ethereum/subscriptions.cljs
+++ b/src/status_im/ethereum/subscriptions.cljs
@@ -88,7 +88,7 @@
                      []
                      accounts)
       :before-block blockNumber
-      :page-size    20
+      :limit        20
       :historical?  true}}))
 
 (fx/defn new-wallet-event

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -88,11 +88,7 @@
                (rpc->accounts accounts))}
    (wallet/initialize-tokens custom-tokens)
    (wallet/update-balances nil)
-   (wallet/update-prices)
-   (transactions/initialize
-    (->> accounts
-         (filter :wallet)
-         (map :address)))))
+   (wallet/update-prices)))
 
 (fx/defn login
   {:events [:multiaccounts.login.ui/password-input-submitted]}

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -90,8 +90,7 @@
        {:color           colors/blue
         :container-style {:margin-right 5}}]
       [react/text
-       {:style {:marging-left 10
-                :color colors/blue}}
+       {:style {:color colors/blue}}
        (i18n/label :t/check-on-etherscan)]]]))
 
 (defn history-list


### PR DESCRIPTION
- unused code is removed
- "load more" button is hidden for a new account
- each next page of tx history contains 20 transfers
  unless thare is no enough transfers in history

status: ready