### PR TITLE
[#9975] Do not throw exception on invalid ens recipient

### DIFF
--- a/src/status_im/wallet/choose_recipient/core.cljs
+++ b/src/status_im/wallet/choose_recipient/core.cljs
@@ -96,7 +96,7 @@
   {:events [:wallet.send/set-recipient ::recipient-address-resolved]}
   [{:keys [db]} raw-recipient]
   (let [chain (ethereum/chain-keyword db)
-        recipient (string/trim raw-recipient)]
+        recipient (when raw-recipient (string/trim raw-recipient))]
     (cond
       (ethereum/address? recipient)
       (let [checksum (eip55/address->checksum recipient)]


### PR DESCRIPTION
in #9999 I didn't check the case when invalid ens name is passed. `string/trim` fails on `nil` value.

status: ready