### PR TITLE
[#10005] Show only 1 line of ens name

### DIFF
--- a/src/status_im/ui/screens/chat/utils.cljs
+++ b/src/status_im/ui/screens/chat/utils.cljs
@@ -14,7 +14,8 @@
 (defn format-author [alias style name]
   (let [additional-styles (style false)]
     (if name
-      [react/text {:style (merge {:color       colors/blue
+      [react/text {:number-of-lines 1
+                   :style (merge {:color       colors/blue
                                   :font-size   13
                                   :line-height 18
                                   :font-weight "500"} additional-styles)}


### PR DESCRIPTION


fixes #10005

Before
![image](https://user-images.githubusercontent.com/11790366/74141534-60b98e00-4bf7-11ea-937f-ffe8d07090a2.png)


After
![image](https://user-images.githubusercontent.com/11790366/74141475-4384bf80-4bf7-11ea-87a3-f7c2311315fb.png)