### PR TITLE
[#8797] Error scrollToIndex when tapping [Fetch messages] twice in a row

### DIFF
--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -335,6 +335,7 @@
                                           :list-ref           messages-list-ref}])
            :inverted                  true
            :onEndReached              #(re-frame/dispatch [:chat.ui/load-more-messages])
+           :onScrollToIndexFailed     #()
            :keyboardShouldPersistTaps :handled}
           group-header {:header [group-chat-footer chat-id]}]
       (if pending-invite-inviter-name


### PR DESCRIPTION


fixes #8797