### PR TITLE
Predefined multiaccounts for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ status-modules/resources
 /fiddle/resources/public/images/
 
 trace.edn
+.dev-multiaccounts.json

--- a/src/status_im/multiaccounts/dev.cljs
+++ b/src/status_im/multiaccounts/dev.cljs
@@ -1,0 +1,28 @@
+(ns status-im.multiaccounts.dev
+  (:require [status-im.utils.types :as types])
+  (:require-macros [status-im.utils.slurp :as slurp]))
+
+;; Predefined accounts can be added to .dev-multiaccounts.json to simplify
+;; multiacc creation, restoring, and unlocking during development.
+;; Example JSON:
+;; ```
+;; {
+;;   "multiaccounts": {
+;;                      "account-name1": "seed-word#1 seed-word#2 ...",
+;;                      "account-name2": "seed-word#1 seed-word#2 ..."
+;;                    },
+;;   "password": "123123"
+;; }
+;; ```
+;; A single password is used for all account, it allows to avoid mapping
+;; multiacc -> password mapping during unlocking and in most cases we use a
+;; single password during development anyway.
+
+(defn data []
+  (when js/goog.DEBUG
+    (->
+     (slurp/dev-slurp ".dev-multiaccounts.json")
+     types/json->clj)))
+
+(defn dev-multiaccounts [] (:multiaccounts (data)))
+(defn dev-password [] (:password (data)))

--- a/src/status_im/ui/screens/multiaccounts/login/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/login/views.cljs
@@ -14,7 +14,8 @@
             [status-im.utils.security :as security]
             [status-im.utils.utils :as utils]
             [status-im.ui.components.icons.vector-icons :as icons]
-            [status-im.ui.components.topbar :as topbar])
+            [status-im.ui.components.topbar :as topbar]
+            [status-im.multiaccounts.dev :as multiaccounts.dev])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn login-toolbar [can-navigate-back?]
@@ -43,6 +44,21 @@
      name]
     [react/text {:style styles/login-badge-pubkey}
      (utils/get-shortened-address public-key)]]])
+
+(defn dev-password-button []
+  (when js/goog.DEBUG
+    (when-let [password (multiaccounts.dev/dev-password)]
+      [components.common/button
+       {:label        "dev pass"
+        :button-style styles/bottom-button
+        :label-style  {:color colors/blue}
+        :background?  true
+        :on-press
+        #(do
+           (re-frame/dispatch
+            [:set-in [:multiaccounts/login :password] password])
+           (re-frame/dispatch
+            [:multiaccounts.login.ui/password-input-submitted]))}])))
 
 (defview login []
   (letsubs [{:keys [error processing save-password?] :as multiaccount} [:multiaccounts/login]
@@ -105,6 +121,7 @@
         :on-press     #(do
                          (react/dismiss-keyboard!)
                          (re-frame/dispatch [:multiaccounts.recover.ui/recover-multiaccount-button-pressed]))}]
+      [dev-password-button]
       [components.common/button
        {:label     (i18n/label :t/submit)
         :button-style styles/bottom-button

--- a/src/status_im/utils/slurp.clj
+++ b/src/status_im/utils/slurp.clj
@@ -29,3 +29,8 @@
                  (reset! ~res (js/require ~(str file-name ".js"))))))))
     `(fn []
        ~(clojure.core/slurp file))))
+
+(defmacro dev-slurp [file]
+  (when-not prod?
+    (try (clojure.core/slurp file)
+         (catch Exception _ nil))))


### PR DESCRIPTION
This commit allows to add predefined multiaccs to `.dev-multiaccounts.json` to avoid manual entering password/seed during account creation/restoring/unlocking.

```json
{
"multiaccounts":
{
"account-name1": "seed-word#1 seed-word#2 ...",
"account-name2": "seed-word#1 seed-word#2 ..."
},
"password": "123123"
}
```

status: ready

