### PR TITLE
don't multiply version codes by 1048576, could mess up upgrades

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -268,8 +268,7 @@ android {
             def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
-                output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+                output.versionCodeOverride = versionCodes.get(abi) + defaultConfig.versionCode
             }
 
         }


### PR DESCRIPTION
Our different arch APKs uploaded to Play store have fucked up `versionCode` values:
```
11:29:48  [10:29:48]: Preparing apk at path 'result/StatusIm-200211-100600-739522-release-arm64-v8a.apk' for upload...
11:29:53  [10:29:53]:     Version Code: 2023166838
11:29:53  [10:29:53]: Preparing apk at path 'result/StatusIm-200211-100600-739522-release-armeabi-v7a.apk' for upload...
11:29:59  [10:29:58]:     Version Code: 2021069686
11:29:59  [10:29:58]: Preparing apk at path 'result/StatusIm-200211-100600-739522-release-universal.apk' for upload...
11:30:09  [10:30:08]:     Version Code: 2020021110
```
https://ci.status.im/job/status-react/job/release/job/release%252F1.0.x/