### PR TITLE
Do not use naked-address when hashing messages prior to Keycard signing

### DIFF
--- a/src/status_im/signing/keycard.cljs
+++ b/src/status_im/signing/keycard.cljs
@@ -39,7 +39,7 @@
   (if typed?
     {::hash-typed-data {:data         data
                         :on-completed #(re-frame/dispatch [:signing.keycard.callback/hash-message-completed %])}}
-    {::hash-message {:message      (ethereum/naked-address data)
+    {::hash-message {:message      data
                      :on-completed #(re-frame/dispatch [:signing.keycard.callback/hash-message-completed %])}}))
 
 (fx/defn hash-message-completed


### PR DESCRIPTION
Fixes #9668 

Tested it with CryptoKitties. Turns out that wrapping `data` field in `ethereum/naked-address` causes CryptoKitties signup error - it throws HTTP 401 (Unauthorized) silently (visible when debugging embedded WebView contents).