### PR TITLE
upgrade react-native-status-keycard to 2.5.19

### DIFF
--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -38,7 +38,7 @@
     "react-native-screens": "^1.0.0-alpha.23",
     "react-native-shake": "^3.3.1",
     "react-native-splash-screen": "^3.2.0",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.17",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.19",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
     "react-native-webview": "^6.11.1",

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -4900,7 +4900,7 @@ react-native-splash-screen@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
   integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.17":
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.19":
   version "2.5.17"
   resolved "git+https://github.com/status-im/react-native-status-keycard.git#8fb12850d72918d3e89e4fcfc8fa699c2ce3f203"
 


### PR DESCRIPTION
This fixes the following error encountered by @corpetty in #10059:
```
error: cannot update ref 'refs/heads/v2.5.17':
trying to write non-commit object 9ef49ef22471b0eceb3f4ad69b1eb3066a55ec3f
to branch 'refs/heads/v2.5.17
```
Which is caused most probably by someone force-pushing to [`v2.5.17`](https://github.com/status-im/react-native-status-keycard/releases/tag/v2.5.17) tag.
There exists a [`v2.5.18`](https://github.com/status-im/react-native-status-keycard/releases/tag/v2.5.18) but that tag points at an earlier commit than `v2.5.17`.

For that reason I've created a new [`v2.5.19`](https://github.com/status-im/react-native-status-keycard/releases/tag/v2.5.19) tag which points at the same commit as `v2.5.17` but should at least solve the conflict caused by force pushing `v2.5.17`.