### PR TITLE
use Android keystore from Jenkins credentials

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -244,7 +244,6 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://facebook.github.io/react-native/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -29,8 +29,6 @@ pipeline {
     BUILD_ENV = 'prod'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
     FASTLANE_DISABLE_COLORS = 1
-    /* since we are mounting it we need to specify location */
-    STATUS_RELEASE_STORE_FILE = '/home/jenkins/status-im.keystore'
     /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
     LEIN_HOME = "/var/tmp/lein-${EXECUTOR_NUMBER}"
     /* coverage report identification */

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -25,6 +25,10 @@ def bundle() {
 
   /* credentials necessary to open the keystore and sign the APK */
   withCredentials([
+    file(
+      credentialsId: 'status-im.keystore',
+      variable: 'STATUS_RELEASE_STORE_FILE'
+    ),
     string(
       credentialsId: 'android-keystore-pass',
       variable: 'STATUS_RELEASE_STORE_PASSWORD'


### PR DESCRIPTION
To improve security of Keystore I'm moving it to Jenkins credentials store.
This way we won't have to store the Keystore on individual CI hosts, only the `master-01`.