### PR TITLE
Add missing keycard event handlers

### DIFF
--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -82,6 +82,11 @@
                     (onboarding/proceed-with-generating-key)))
         (recovery/load-pair-screen cofx)))))
 
+(fx/defn on-register-card-events
+  {:events [:hardwallet.callback/on-register-card-events]}
+  [{:keys [db]} listeners]
+  {:db (update-in db [:hardwallet :listeners] merge listeners)})
+
 (fx/defn navigate-to-keycard-settings
   {:events [:profile.ui/keycard-settings-button-pressed]}
   [{:keys [db] :as cofx}]
@@ -301,6 +306,7 @@
 ; original - new PIN when user changes it or creates new one
 ; confirmation - confirmation for new PIN
 (fx/defn process-pin-input
+  {:events [:hardwallet/process-pin-input]}
   [{:keys [db]}]
   (let [enter-step (get-in db [:hardwallet :pin :enter-step])
         pin (get-in db [:hardwallet :pin enter-step])

--- a/src/status_im/hardwallet/recovery.cljs
+++ b/src/status_im/hardwallet/recovery.cljs
@@ -147,11 +147,13 @@
     ;; if a name is still `nil` we have to generate it before multiaccount's
     ;; creation otherwise spec validation will fail
     (if (nil? name)
-      {::generate-name-and-photo whisper-public-key}
+      {:hardwallet/generate-name-and-photo
+       {:public-key whisper-public-key
+        :on-success :hardwallet/on-name-and-photo-generated}}
       (fx/merge cofx
                 {:db (-> db
                          (assoc-in [:hardwallet :setup-step] nil)
-                         (assoc :intro-wizard nil))}
+                         (dissoc :intro-wizard))}
                 (multiaccounts.create/on-multiaccount-created
                  {:derived              {constants/path-wallet-root-keyword
                                          {:public-key wallet-root-public-key
@@ -245,7 +247,7 @@
             (navigation/navigate-to-cofx :keycard-recovery-pin nil)))
 
 (fx/defn on-name-and-photo-generated
-  {:events [::on-name-and-photo-generated]
+  {:events [:hardwallet/on-name-and-photo-generated]
    :interceptors [(re-frame/inject-cofx :random-guid-generator)
                   (re-frame/inject-cofx ::multiaccounts.create/get-signing-phrase)]}
   [{:keys [db] :as cofx} whisper-name photo-path]

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -68,6 +68,7 @@
              ::open-multiaccounts                   #(re-frame/dispatch [::initialize-multiaccounts % {:logout? false}])
              :ui/listen-to-window-dimensions-change nil
              ::network/listen-to-network-info       nil
+             :hardwallet/register-card-events       nil
              :hardwallet/check-nfc-support          nil
              :hardwallet/check-nfc-enabled          nil
              :hardwallet/retrieve-pairings          nil}


### PR DESCRIPTION
Some of the keycard event handlers have gone missing, as a result Keycard login was not working.

This PR restores them.