### PR TITLE
Fix geth logs on Android 10

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -159,7 +159,10 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     private File getLogsFile() {
-        final File pubDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        final Context context = this.getReactApplicationContext();
+        // Environment.getExternalStoragePublicDirectory doesn't work as expected on Android Q
+        // https://developer.android.com/reference/android/os/Environment#getExternalStoragePublicDirectory(java.lang.String)
+        final File pubDirectory = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
         final File logFile = new File(pubDirectory, gethLogFileName);
 
         return logFile;


### PR DESCRIPTION
From now on geth logs are stored at
`/storage/emulated/0/Android/data/im.status.ethereum.debug/files/Download/geth.log`
because app cant write to `sdcard/Download/geth.log`

status: ready