### PR TITLE
temporary fix for contacts signal

### DIFF
--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -53,7 +53,10 @@
       (seq contacts)
       (let [contact (.pop contacts)]
         (fx/merge cofx
-                  {:utils/dispatch-later [{:ms 20 :dispatch [::process response-js]}]}
+                  ;;TODO temporary fix for release, we have and issue with contacts updates , UI is really slow
+                  ;;we need to inspect all subsctiptions and views, but for now to temporary make it better
+                  ;; we use dispatch instead dispatch-later
+                  {:dispatch [::process response-js]}
                   (handle-contact (-> contact (types/js->clj) (data-store.contacts/<-rpc)))))
 
       (seq chats)


### PR DESCRIPTION
every 30s app receives a signal with new contacts and app is slow if we use dispatch-later, this is a temporary solution for release, should be fixed properly later