### PR TITLE
Use first-not-visible message instead of last-visible

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -116,7 +116,6 @@
     (when (and current-chat?
                (or (not cursor-clock-value)
                    (<= cursor-clock-value clock-value)))
-      ;; Not in the current view, offload to db and update cursor if necessary
       (if (or (not @view.state/viewable-item)
               (not= current-chat-id
                     (:chat-id @view.state/viewable-item))
@@ -124,10 +123,11 @@
                   clock-value))
         (add-message cofx {:message      message
                            :current-chat? current-chat?})
+        ;; Not in the current view, offload to db and update cursor if necessary
         (when (and (< clock-value
                       cursor-clock-value)
                    (= current-chat-id
-                      (:chat-id (.-item view.state/viewable-item))))
+                      (:chat-id @view.state/viewable-item)))
           {:db (assoc-in db [:chats chat-id :cursor] (chat-loading/clock-value->cursor clock-value))})))))
 
 (defn- add-to-chat?


### PR DESCRIPTION

fixes #10133

Using last visible message ignores an edge case:

If we are on top of the list (i.e oldest message), any received message
should be appended (it must be visible).

When using last-visible message for this, a newer message will have <
clock-value, therefore it will be offloaded to the database, which is
not correct.

Instead if we use the first-not-visible message, this should not be a
problem. If we are on top of the list, this will be nil, and therefore
the message will be appended.
cc @flexsurfer @rasom 
status: ready

Probably best to test it a bit, haven't had time.