### PR TITLE
Ensure that keycard flows continue when card is already connected

### DIFF
--- a/src/status_im/hardwallet/export_key.cljs
+++ b/src/status_im/hardwallet/export_key.cljs
@@ -24,14 +24,14 @@
                                                                  :sign         []
                                                                  :export-key   []
                                                                  :error-label  :t/pin-mismatch})}
-                    (common/hide-pair-sheet)
+                    (common/hide-connection-sheet)
                     (common/get-application-info (common/get-pairing db) nil))
 
           :else
           (fx/merge cofx
                     (common/show-wrong-keycard-alert true)
                     (common/clear-pin)
-                    (common/hide-pair-sheet)))))
+                    (common/hide-connection-sheet)))))
 
 (fx/defn on-export-key-success
   {:events [:hardwallet.callback/on-export-key-success]}
@@ -40,4 +40,4 @@
     (fx/merge cofx
               {:dispatch (callback-fn pubkey)}
               (common/clear-pin)
-              (common/hide-pair-sheet))))
+              (common/hide-connection-sheet))))

--- a/src/status_im/hardwallet/login.cljs
+++ b/src/status_im/hardwallet/login.cljs
@@ -62,36 +62,36 @@
     (cond
       (empty? application-info)
       (fx/merge cofx
-                (common/hide-pair-sheet)
+                (common/hide-connection-sheet)
                 (navigation/navigate-to-cofx :not-keycard nil))
 
       (empty? key-uid)
       (fx/merge cofx
-                (common/hide-pair-sheet)
+                (common/hide-connection-sheet)
                 (navigation/navigate-to-cofx :keycard-blank nil))
 
       multiaccount-mismatch?
       (fx/merge cofx
-                (common/hide-pair-sheet)
+                (common/hide-connection-sheet)
                 (navigation/navigate-to-cofx :keycard-wrong nil))
 
       (empty? pairing)
       (fx/merge cofx
-                (common/hide-pair-sheet)
+                (common/hide-connection-sheet)
                 (navigation/navigate-to-cofx :keycard-unpaired nil))
 
       :else
       (common/get-keys-from-keycard cofx))))
 
 (fx/defn proceed-to-login
-  [{:keys [db] :as cofx}]
-  (let [{:keys [card-connected?]} (:hardwallet db)]
-    (fx/merge cofx
-              (common/set-on-card-connected :hardwallet/get-application-info)
-              (common/set-on-card-read :hardwallet/login-with-keycard)
-              (if card-connected?
-                (login-with-keycard)
-                (common/show-pair-sheet {:on-cancel [::common/cancel-sheet-confirm]})))))
+  [cofx]
+  (log/debug "[hardwallet] proceed-to-login")
+  (common/show-connection-sheet
+   cofx
+   {:sheet-options     {:on-cancel [::common/cancel-sheet-confirm]}
+    :on-card-connected :hardwallet/get-application-info
+    :on-card-read      :hardwallet/login-with-keycard
+    :handler           (common/get-application-info nil :hardwallet/login-with-keycard)}))
 
 (fx/defn on-hardwallet-keychain-keys
   {:events [:multiaccounts.login.callback/get-hardwallet-keys-success]}

--- a/src/status_im/hardwallet/mnemonic.cljs
+++ b/src/status_im/hardwallet/mnemonic.cljs
@@ -53,13 +53,12 @@
 (fx/defn load-generating-mnemonic-screen
   {:events [:hardwallet/load-generating-mnemonic-screen]}
   [{:keys [db] :as cofx}]
-  (let [card-connected? (get-in db [:hardwallet :card-connected?])]
-    (fx/merge cofx
-              {:db (assoc-in db [:hardwallet :setup-step] :generating-mnemonic)}
-              (common/set-on-card-connected :hardwallet/load-generating-mnemonic-screen)
-              (if card-connected?
-                (common/dispatch-event :hardwallet/generate-mnemonic)
-                (common/show-pair-sheet {})))))
+  (fx/merge
+   cofx
+   {:db (assoc-in db [:hardwallet :setup-step] :generating-mnemonic)}
+   (common/show-connection-sheet
+    {:on-card-connected :hardwallet/load-generating-mnemonic-screen
+     :handler           (common/dispatch-event :hardwallet/generate-mnemonic)})))
 
 (fx/defn on-generate-mnemonic-error
   {:events [:hardwallet.callback/on-generate-mnemonic-error]}
@@ -81,10 +80,9 @@
   {:events [:hardwallet.ui/recovery-phrase-confirm-pressed
             :hardwallet/load-loading-keys-screen]}
   [{:keys [db] :as cofx}]
-  (let [card-connected? (get-in db [:hardwallet :card-connected?])]
-    (fx/merge cofx
-              {:db (assoc-in db [:hardwallet :setup-step] :loading-keys)}
-              (common/set-on-card-connected :hardwallet/load-loading-keys-screen)
-              (if card-connected?
-                (common/dispatch-event :hardwallet/generate-and-load-key)
-                (common/show-pair-sheet {})))))
+  (fx/merge
+   cofx
+   {:db (assoc-in db [:hardwallet :setup-step] :loading-keys)}
+   (common/show-connection-sheet
+    {:on-card-connected :hardwallet/load-loading-keys-screen
+     :handler           (common/dispatch-event :hardwallet/generate-and-load-key)})))

--- a/src/status_im/hardwallet/unpair.cljs
+++ b/src/status_im/hardwallet/unpair.cljs
@@ -94,16 +94,17 @@
 
 (fx/defn remove-key-with-unpair
   {:events [:hardwallet/remove-key-with-unpair]}
-  [{:keys [db] :as cofx}]
-  (let [pin             (common/vector->string (get-in db [:hardwallet :pin :current]))
-        pairing         (common/get-pairing db)
-        card-connected? (get-in db [:hardwallet :card-connected?])]
-    (if card-connected?
-      {:hardwallet/remove-key-with-unpair {:pin     pin
-                                           :pairing pairing}}
-      (fx/merge cofx
-                (common/set-on-card-connected :hardwallet/remove-key-with-unpair)
-                (common/show-pair-sheet {})))))
+  [cofx]
+  (common/show-connection-sheet
+   cofx
+   {:on-card-connected :hardwallet/remove-key-with-unpair
+    :handler
+    (fn [{:keys [db]}]
+      (let [pin     (common/vector->string (get-in db [:hardwallet :pin :current]))
+            pairing (common/get-pairing db)]
+        {:hardwallet/remove-key-with-unpair
+         {:pin     pin
+          :pairing pairing}}))}))
 
 (fx/defn on-remove-key-success
   {:events [:hardwallet.callback/on-remove-key-success]}

--- a/src/status_im/hardwallet/wallet.cljs
+++ b/src/status_im/hardwallet/wallet.cljs
@@ -1,6 +1,5 @@
 (ns status-im.hardwallet.wallet
   (:require [status-im.ethereum.core :as ethereum]
-            [status-im.ui.components.colors :as colors]
             [status-im.utils.fx :as fx]
             [status-im.hardwallet.common :as common]
             [status-im.constants :as constants]
@@ -9,21 +8,25 @@
 (fx/defn generate-new-keycard-account
   {:events [:wallet.accounts/generate-new-keycard-account]}
   [{:keys [db] :as cofx}]
-  (let [path-num        (inc (get-in db [:multiaccount :latest-derived-path]))
-        path            (str constants/path-wallet-root "/" path-num)
-        card-connected? (get-in db [:hardwallet :card-connected?])
-        pin             (common/vector->string (get-in db [:hardwallet :pin :export-key]))
-        pairing         (common/get-pairing db)]
-    (if card-connected?
-      (fx/merge cofx
-                {:db (assoc-in db [:hardwallet :on-export-success]
-                               #(vector :wallet.accounts/account-stored
-                                        {;; Strip leading 04 prefix denoting uncompressed key format
-                                         :address (eip55/address->checksum (str "0x" (ethereum/public-key->address (subs % 2))))
-                                         :public-key (str "0x" %)
-                                         :path path}))
-                 :hardwallet/export-key {:pin pin :pairing pairing :path path}}
-                (common/set-on-card-connected :wallet.accounts/generate-new-keycard-account))
-      (fx/merge cofx
-                (common/set-on-card-connected :wallet.accounts/generate-new-keycard-account)
-                (common/show-pair-sheet {})))))
+  (let [path-num (inc (get-in db [:multiaccount :latest-derived-path]))
+        path     (str constants/path-wallet-root "/" path-num)
+        pin      (common/vector->string (get-in db [:hardwallet :pin :export-key]))
+        pairing  (common/get-pairing db)]
+    (common/show-connection-sheet
+     cofx
+     {:on-card-connected :hardwallet/load-loading-keys-screen
+      :handler
+      (fn [cofx]
+        (fx/merge
+         cofx
+         {:db
+          (assoc-in
+           db [:hardwallet :on-export-success]
+           #(vector :wallet.accounts/account-stored
+                    {;; Strip leading 04 prefix denoting uncompressed key format
+                     :address    (eip55/address->checksum (str "0x" (ethereum/public-key->address (subs % 2))))
+                     :public-key (str "0x" %)
+                     :path       path}))
+
+          :hardwallet/export-key {:pin pin :pairing pairing :path path}}
+         (common/set-on-card-connected :wallet.accounts/generate-new-keycard-account)))})))

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -310,7 +310,7 @@
                        (assoc-in [:hardwallet :pin :status] nil)
                        (dissoc :signing/tx :signing/in-progress? :signing/sign))}
               (check-queue)
-              (hardwallet.common/hide-pair-sheet)
+              (hardwallet.common/hide-connection-sheet)
               (hardwallet.common/clear-pin)
               #(when on-error
                  {:dispatch (conj on-error "transaction was cancelled by user")}))))

--- a/src/status_im/ui/screens/keycard/components/keycard_animation.cljs
+++ b/src/status_im/ui/screens/keycard/components/keycard_animation.cljs
@@ -5,7 +5,8 @@
             [status-im.ui.components.animation :as animation]
             [status-im.hardwallet.card :as keycard-nfc]
             [status-im.react-native.resources :as resources]
-            [status-im.ui.components.colors :as colors]))
+            [status-im.ui.components.colors :as colors]
+            [taoensso.timbre :as log]))
 
 (defn circle [{:keys [animation-value color size]}]
   [react/animated-view

--- a/test/cljs/status_im/test/hardwallet/common.cljs
+++ b/test/cljs/status_im/test/hardwallet/common.cljs
@@ -1,0 +1,43 @@
+(ns status-im.test.hardwallet.common
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.hardwallet.common :as common]))
+
+(deftest test-show-connection-sheet
+  (testing "the card is not connected yet"
+    (let [db  {:hardwallet {:card-connected? false}}
+          res (common/show-connection-sheet
+               {:db db}
+               {:on-card-connected :do-something
+                :handler           (fn [{:keys [db]}]
+                                     {:db (assoc db :some-key :some-value)})})]
+      (is (= :do-something
+             (get-in res [:db :hardwallet :on-card-connected])))
+      (is (nil? (get-in res [:db :some-key])))
+      (is (true? (get-in res [:db :bottom-sheet/show?])))))
+  (testing "the card is connected before the interaction"
+    (let [db  {:hardwallet {:card-connected? true}}
+          res (common/show-connection-sheet
+               {:db db}
+               {:on-card-connected :do-something
+                :handler           (fn [{:keys [db]}]
+                                     {:db (assoc db :some-key :some-value)})})]
+      (is (nil? (get-in res [:db :hardwallet :on-card-connected])))
+      (is (= :do-something
+             (get-in res [:db :hardwallet :last-on-card-connected])))
+      (is (= :some-value (get-in res [:db :some-key])))
+      (is (true? (get-in res [:db :bottom-sheet/show?])))))
+  (testing "on-card-connected is not specified"
+    (is
+     (thrown?
+      js/Error
+      (common/show-connection-sheet
+       {:db {}}
+       {:handler (fn [_])}))))
+  (testing "handler is not specified"
+    (is
+     (thrown?
+      js/Error
+      (common/show-connection-sheet
+       {:db {}}
+       {:on-card-connected :do-something})))))
+

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -21,6 +21,7 @@
             [status-im.test.ethereum.stateofus]
             [status-im.test.fleet.core]
             [status-im.test.hardwallet.core]
+            [status-im.test.hardwallet.common]
             [status-im.test.i18n]
             [status-im.test.mailserver.core]
             [status-im.test.mailserver.topics]
@@ -92,6 +93,7 @@
  'status-im.test.ethereum.stateofus
  'status-im.test.fleet.core
  'status-im.test.hardwallet.core
+ 'status-im.test.hardwallet.common
  'status-im.test.i18n
  'status-im.test.mailserver.core
  'status-im.test.mailserver.topics


### PR DESCRIPTION
This commit ensures that a user can flawlessly interact with a keycard, regardless of the moment when the card was tapped to the device. To make it so:
- in case if the card was tapped before the interaction the user doesn't need to re-connect card to continue 
- in case if the connection with the card was lost during the interaction the application restarts that interaction as soon as the card was connected again (unless the user canceled the flow)

 Keycard related flows fixed in this PR:
- multiaccount creation (didn't work without card re-tapping after entering pin)
- multiaccount restoring via seed (didn't work without card re-tapping after entering pin and other steps)
- multiaccount restoring via pairing (didn't work without card re-tapping after entering pin and other steps)
- multiaccount unlocking (if card was tapped before entering pin app returns weird error popup)
<img width=320 src=https://user-images.githubusercontent.com/2364994/76685841-74557b80-661f-11ea-82a0-7b8aedca9db8.jpg />


 

status: ready