### PR TITLE
fix keystore generation, pass keystore vars to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ react-native-ios: export _NIX_PURE ?= true
 react-native-ios: ##@other Start react native packager for Android client
 	@scripts/start-react-native.sh
 
-geth-connect: export TARGET := adb
+geth-connect: export TARGET := android-env
 geth-connect: ##@other Connect to Geth on the device
 	adb forward tcp:8545 tcp:8545 && \
 	build/bin/geth attach http://localhost:8545
@@ -335,22 +335,22 @@ android-clean: ##@prepare Clean Gradle state
 	git clean -dxf -f ./android/app/build
 	[ -d android/.gradle ] && cd android && ./gradlew clean
 
-android-ports: export TARGET := adb
+android-ports: export TARGET := android-env
 android-ports: ##@other Add proxies to Android Device/Simulator
 	adb reverse tcp:8081 tcp:8081 && \
 	adb reverse tcp:3449 tcp:3449 && \
 	adb reverse tcp:4567 tcp:4567 && \
 	adb forward tcp:5561 tcp:5561
 
-android-devices: export TARGET := adb
+android-devices: export TARGET := android-env
 android-devices: ##@other Invoke adb devices
 	adb devices
 
-android-logcat: export TARGET := adb
+android-logcat: export TARGET := android-env
 android-logcat: ##@other Read status-react logs from Android phone using adb
 	adb logcat | grep -e RNBootstrap -e ReactNativeJS -e ReactNative -e StatusModule -e StatusNativeLogs -e 'F DEBUG   :' -e 'Go      :' -e 'GoLog   :' -e 'libc    :'
 
-android-install: export TARGET := adb
+android-install: export TARGET := android-env
 android-install: export BUILD_TYPE ?= release
 android-install:
 	adb install result/app-$(BUILD_TYPE).apk

--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -53,7 +53,7 @@ in {
     })
     (lib.catAttrs "shell" [ status-go mavenAndNpmDeps androidEnv ]);
 
-  adb = {
+  env = {
     shell = mkShell {
       buildInputs = [ androidEnv.drv ];
       inherit (androidEnv.shell) shellHook;

--- a/nix/scripts/build.sh
+++ b/nix/scripts/build.sh
@@ -49,19 +49,12 @@ nixOpts=(
   "--fallback"
   "--no-out-link"
   "--show-trace"
-  "--attr ${targetAttr}"
-  "${@}"
+  "--attr" "${targetAttr}"
 )
 
-# This variable allows specifying which env vars to keep for Nix pure shell.
-# The separator is a colon
-if [[ -n "${_NIX_KEEP}" ]]; then
-  nixOpts+=("--keep ${_NIX_KEEP//,/ --keep }")
-fi
-
 # Run the actual build
-echo "Running: nix-build ${nixOpts[@]} default.nix"
-nixResultPath=$(nix-build ${nixOpts[@]} default.nix)
+echo "Running: nix-build "${nixOpts[@]}" "${@}" default.nix"
+nixResultPath=$(nix-build "${nixOpts[@]}" "${@}" default.nix)
 
 echo "Extracting result: ${nixResultPath}"
 extractResults "${nixResultPath}"

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -56,7 +56,7 @@ in with pkgs; rec {
   watchman = watchman-sh;
   fastlane = fastlane-sh;
   keytool = keytool-sh;
-  adb = targets.mobile.android.adb.shell;
+  android-env = targets.mobile.android.env.shell;
   # helpers for use with target argument
   linux = targets.desktop.linux.shell;
   macos = targets.desktop.macos.shell;


### PR DESCRIPTION
Changes:
* Drop `--keep` from `nix/scripts/build.sh` as it does nothing
* Allow `scripts/release-android.sh` take passwords from env
* Use env file in `extra-sandbox-paths` to pass keystore passwords
* Quote ever segment of Nix options to avoid parsing errors
* Renamed `adb` target to `android-env` to be more descriptive