### PR TITLE
Use atom for webview ref instead of storing it in re-frame's db

### DIFF
--- a/src/status_im/browser/permissions.cljs
+++ b/src/status_im/browser/permissions.cljs
@@ -4,7 +4,8 @@
             [status-im.i18n :as i18n]
             [status-im.qr-scanner.core :as qr-scanner]
             [status-im.ui.screens.navigation :as navigation]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            [status-im.browser.webview-ref :as webview-ref]))
 
 (declare process-next-permission)
 (declare send-response-to-bridge)
@@ -50,13 +51,12 @@
   "Send response to the bridge. If the permission is allowed, send data associated
    with the permission"
   [{:keys [db] :as cofx} permission message-id allowed? data]
-  {:browser/send-to-bridge {:message (cond-> {:type       constants/api-response
-                                              :isAllowed  allowed?
-                                              :permission permission
-                                              :messageId  message-id}
-                                       allowed?
-                                       (assoc :data data))
-                            :webview (:webview-bridge db)}})
+  {:browser/send-to-bridge (cond-> {:type       constants/api-response
+                                    :isAllowed  allowed?
+                                    :permission permission
+                                    :messageId  message-id}
+                             allowed?
+                             (assoc :data data))})
 
 (fx/defn update-dapp-permissions
   [{:keys [db]} dapp-name permission allowed?]

--- a/src/status_im/browser/webview_ref.cljs
+++ b/src/status_im/browser/webview_ref.cljs
@@ -1,0 +1,3 @@
+(ns status-im.browser.webview-ref)
+
+(def webview-ref (atom nil))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -68,7 +68,6 @@
 (spec/def ::web3 (spec/nilable any?))
 (spec/def ::web3-node-version (spec/nilable string?))
 ;;object?
-(spec/def ::webview-bridge (spec/nilable any?))
 
 ;;height of native keyboard if shown
 (spec/def ::keyboard-height (spec/nilable number?))
@@ -252,7 +251,6 @@
                                    ::initial-props
                                    ::web3
                                    ::web3-node-version
-                                   ::webview-bridge
                                    ::keyboard-height
                                    ::keyboard-max-height
                                    ::network-status

--- a/src/status_im/ui/screens/routing/browser_stack.cljs
+++ b/src/status_im/ui/screens/routing/browser_stack.cljs
@@ -10,5 +10,7 @@
           :header-mode        :none}
    [{:name      :open-dapp
      :component open-dapp/open-dapp}
-    {:name      :browser
-     :component browser/browser}]])
+    {:name         :browser
+     :back-handler :noop
+     :options      {:animationEnabled false}
+     :component    browser/browser}]])

--- a/test/cljs/status_im/test/browser/permissions.cljs
+++ b/test/cljs/status_im/test/browser/permissions.cljs
@@ -21,7 +21,7 @@
                                                                          :host       dapp-name
                                                                          :messageId  0
                                                                          :permission "FAKE_PERMISSION"}))]
-        (is (not (get-in result-ask [:browser/send-to-bridge :message :isAllowed])))))
+        (is (not (get-in result-ask [:browser/send-to-bridge :isAllowed])))))
 
     (testing "receiving a supported permission"
       (let [result-ask (browser/process-bridge-message cofx
@@ -35,7 +35,7 @@
 
         (testing "then user accepts the supported permission"
           (let [accept-result (permissions/allow-permission {:db (:db result-ask)})]
-            (is (= (get-in accept-result [:browser/send-to-bridge :message])
+            (is (= (get accept-result :browser/send-to-bridge)
                    {:type       "api-response"
                     :messageId  1
                     :isAllowed  true
@@ -52,8 +52,7 @@
                                                                                        :host       dapp-name
                                                                                        :messageId  2
                                                                                        :permission "contact-code"}))]
-                (is (= (get-in result-ask-again
-                               [:browser/send-to-bridge :message])
+                (is (= (get result-ask-again :browser/send-to-bridge)
                        {:type       "api-response"
                         :isAllowed  true
                         :messageId  2
@@ -71,8 +70,7 @@
                 (is (= (get-in result-ask2 [:db :dapps/permissions])
                        {"test.com" {:dapp "test.com", :permissions ["contact-code"]}})
                     "there should only be permissions for dapp-name at that point")
-                (is (nil? (get-in result-ask2
-                                  [:browser/send-to-bridge :message]))
+                (is (nil? (get result-ask2 :browser/send-to-bridge))
                     "no message should be sent to the bridge")
 
                 (testing "then user accepts permission for dapp-name2"
@@ -81,8 +79,7 @@
                            {"test.com"  {:dapp "test.com" :permissions ["contact-code"]}
                             "test2.org" {:dapp "test2.org" :permissions ["contact-code"]}})
                         "there should be permissions for both dapps now")
-                    (is (= (get-in accept-result2
-                                   [:browser/send-to-bridge :message])
+                    (is (= (get accept-result2 :browser/send-to-bridge)
                            {:type       "api-response"
                             :isAllowed  true
                             :messageId  3


### PR DESCRIPTION
Fixes #10189 

Kudos to @Ferossgp for finding the root cause of crashes and detailing it [here](https://github.com/status-im/status-react/issues/10189#issuecomment-601735469), this is essentially an implementation of a proposed fix.