### PR TITLE
allow lint stage fail in CI and still upload build result

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -63,7 +63,16 @@ pipeline {
         stage('Checks') { stages {
           stage('Lint') {
             steps {
-              script { nix.shell('lein cljfmt check', attr: 'shells.lein') }
+              script {
+                /* We want the build result to be uploaded */
+                catchError(
+                  message: 'Linting check failed!',
+                  buildResult: 'FAILURE',
+                  stageResult: 'FAILURE'
+                ) {
+                  nix.shell('lein cljfmt check', attr: 'shells.lein')
+                }
+              }
             }
           }
           stage('Tests') {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -54,7 +54,16 @@ pipeline {
         stage('Checks') { stages {
           stage('Lint') {
             steps {
-              script { nix.shell('lein cljfmt check', attr: 'shells.lein') }
+              script {
+                /* We want the build result to be uploaded */
+                catchError(
+                  message: 'Linting check failed!',
+                  buildResult: 'FAILURE',
+                  stageResult: 'FAILURE'
+                ) {
+                  nix.shell('lein cljfmt check', attr: 'shells.lein')
+                }
+              }
             }
           }
           stage('Tests') {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -57,7 +57,16 @@ pipeline {
         stage('Checks') { stages {
           stage('Lint') {
             steps {
-              script { nix.shell('lein cljfmt check', attr: 'shells.lein') }
+              script {
+                /* We want the build result to be uploaded */
+                catchError(
+                  message: 'Linting check failed!',
+                  buildResult: 'FAILURE',
+                  stageResult: 'FAILURE'
+                ) {
+                  nix.shell('lein cljfmt check', attr: 'shells.lein')
+                }
+              }
             }
           }
           stage('Tests') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -55,7 +55,16 @@ pipeline {
         stage('Checks') { stages {
           stage('Lint') {
             steps {
-              script { nix.shell('lein cljfmt check', attr: 'shells.lein') }
+              script {
+                /* We want the build result to be uploaded */
+                catchError(
+                  message: 'Linting check failed!',
+                  buildResult: 'FAILURE',
+                  stageResult: 'FAILURE'
+                ) {
+                  nix.shell('lein cljfmt check', attr: 'shells.lein')
+                }
+              }
             }
           }
           stage('Tests') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -60,7 +60,16 @@ pipeline {
         stage('Checks') { stages {
           stage('Lint') {
             steps {
-              script { nix.shell('lein cljfmt check', attr: 'shells.lein') }
+              script {
+                /* We want the build result to be uploaded */
+                catchError(
+                  message: 'Linting check failed!',
+                  buildResult: 'FAILURE',
+                  stageResult: 'FAILURE'
+                ) {
+                  nix.shell('lein cljfmt check', attr: 'shells.lein')
+                }
+              }
             }
           }
           stage('Tests') {


### PR DESCRIPTION
This should allow linting stage to fail but let the rest of the stages continue so we can get the APK/IPA files to upload and be available for testers. I've tested this already in a manual build:

![status_react_failed_lint_job](https://user-images.githubusercontent.com/2212681/77655454-b6ad7f80-6f72-11ea-8ed1-69f4f5ca8788.png)
https://ci.status.im/blue/organizations/jenkins/status-react%2Fcombined%2Fmobile-android/detail/mobile-android/12464/pipeline/59/

You can see the upload stages still ran, but the while job is marked as failed, as is the `Lint` stage.

I'm using [`catchError`](https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/#catcherror-catch-error-and-set-build-result-to-failure) to catch the error but mark both stage and build as failed.