### PR TITLE
refactor and simplify mkFilter, use more restrictive rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ _run-%:
 	npx react-native run-$(SYSTEM)
 
 # TODO: Migrate this to a Nix recipe, much the same way as nix/mobile/android/targets/release-android.nix
-run-android: export TARGET := android
+run-android: export TARGET := default
 run-android: ##@run Run Android build
 	npx react-native run-android --appIdSuffix debug
 

--- a/nix/mobile/android/jsbundle/default.nix
+++ b/nix/mobile/android/jsbundle/default.nix
@@ -20,12 +20,22 @@ in stdenv.mkDerivation {
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {
-          dirRootsToInclude = [ 
-            "components/src" "react-native/src/cljsjs" "react-native/src/mobile" "src" "env/prod" "prod" # Taken from project.clj :profiles :prod :cljsbuild :builds :android :source-paths
-            "resources" "status-modules/cljs" "status-modules/resources" "scripts/version"
+          include = [ 
+            "src/.*" "prod/.*" "env/prod/.*"
+            "components/src/.*" 
+            "react-native/src" 
+            "react-native/src/cljsjs/.*"
+            "react-native/src/mobile/.*"
+            "status-modules/cljs/.*"
+            "status-modules/resources/.*"
+            "build.clj" "externs.js"
+            "project.clj" "prepare-modules.js"
+            "resources/js/.*"
+            "resources/config/.*"
           ];
-          dirsToExclude = [ ".git" ".svn" "CVS" ".hg" ".gradle" "build" "intermediates" "libs" "obj" ];
-          filesToInclude = [ "build.clj" "externs.js" "project.clj" "prepare-modules.js" "VERSION" "BUILD_NUMBER"];
+          exclude = [
+            "resources/images/.*"
+          ];
           root = path;
         };
     };

--- a/nix/mobile/android/maven-and-npm-deps/default.nix
+++ b/nix/mobile/android/maven-and-npm-deps/default.nix
@@ -37,14 +37,14 @@ let
             filter =
               # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
               mkFilter {
-                dirRootsToInclude = [
-                  "android" "mobile/js_files" "resources"
-                  "translations" "status-modules"
-                ];
-                dirsToExclude = [ ".git" ".svn" "CVS" ".hg" ".gradle" "build" "intermediates" "libs" "obj" ];
-                filesToInclude = [ ".babelrc" ];
-                filesToExclude = [ "VERSION" "android/gradlew" ];
                 root = path;
+                include = [
+                  "android/.*" "translations/.*" "status-modules/.*"
+                  "resources/.*" "mobile/js_files/.*" ".babelrc"
+                ];
+                exclude = [
+                  ".*.keystore" "node_modules"
+                ];
               };
           };
         phases = [ "unpackPhase" "patchPhase" "installPhase" "fixupPhase" ];

--- a/nix/mobile/android/targets/release-android.nix
+++ b/nix/mobile/android/targets/release-android.nix
@@ -44,20 +44,13 @@ in stdenv.mkDerivation {
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {
-          dirRootsToInclude = [
-            "mobile/js_files"
-            "modules/react-native-status/android"
-            "resources"
-          ];
-          dirsToExclude = [
-            ".git" ".svn" "CVS" ".hg" ".gradle"
-            "build" "intermediates" "libs" "obj"
-          ];
-          filesToInclude = [
+          root = path;
+          include = [
+            "mobile/js_files.*" "resources.*"
+            "modules/react-native-status/android.*"
             envFileName "VERSION" ".watchmanconfig"
             "status-go-version.json" "react-native.config.js"
           ];
-          root = path;
         };
     };
   nativeBuildInputs = [ bash gradle unzip ] ++ lib.optionals stdenv.isDarwin [ file gnumake patchedWatchman ];

--- a/nix/mobile/ios/default.nix
+++ b/nix/mobile/ios/default.nix
@@ -12,15 +12,16 @@ let
 
   src =
     let path = ./../../..;
-    in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
+    # We use builtins.path so that we can name the resulting derivation,
+    # otherwise the name would be taken from the checkout directory, which is outside of our control
+    in builtins.path {
       inherit path;
       name = "status-react-source-npm-deps";
       filter =
-        # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
+        # Keep this filter as restrictive as possible in order to avoid 
+        # unnecessary rebuilds and limit closure size
         mkFilter {
-          dirRootsToInclude = [ "mobile/js_files" ];
-          dirsToExclude = [ ".git" ".svn" "CVS" ".hg" ];
-          filesToInclude = [ ".babelrc" ];
+          include = [ ".babelrc" "mobile/js_files.*" ];
           root = path;
         };
     };

--- a/nix/status-go/nimbus/default.nix
+++ b/nix/status-go/nimbus/default.nix
@@ -12,10 +12,11 @@ let
     filter =
       # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
       mkFilter {
-        dirRootsToInclude = [ "nix" "wrappers" "vendor" ];
-        dirsToExclude = [ ".git" ".svn" "CVS" ".hg" ".vscode" ".dependabot" ".github" "examples" "docs" ];
-        filesToInclude = [ "Makefile" "nim.cfg" "nimbus.nimble" "default.nix" ];
         root = path;
+        include = [
+          "nix.*" "wrappers.*" "vendor.*"
+          "Makefile" "nim.cfg" "nimbus.nimble" "default.nix"
+        ];
       };
   };
 

--- a/scripts/generate-keystore.sh
+++ b/scripts/generate-keystore.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euf pipefail
+set -ef pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/scripts/colors.sh"

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -56,7 +56,6 @@ if [[ "$OS" =~ Darwin ]]; then
     " --option" "extra-sandbox-paths" "${KEYSTORE_PATH} ${SECRETS_FILE_PATH} ${WATCHMAN_SOCKFILE}"
   )
 else
-  echo wtf
   nixOpts+=(
     "--option" "extra-sandbox-paths" "${KEYSTORE_PATH} ${SECRETS_FILE_PATH}"
   )


### PR DESCRIPTION
This should improve #10234 which was related to the derivation for `status-react-patched-npm-gradle-modules` using too broad filter and including some files which would cause unnecessary rebuilds when running targets like `make run-android`.

The thing is, XML files like `AndroidManifest.xml` need to be part of the `status-react-source-gradle-install` derivation because they are used in the build of `status-react-patched-npm-gradle-modules`.

I also changed the `TARGET` to `default` for `make run-android` to stop rebuilds of unnecessary things.

Status: __Ready__