### PR TITLE
Fix camera usage description

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -76,9 +76,9 @@
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>Please allow Status to use your phone camera</string>
+	<string>The app uses your camera to scan QR codes.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>We need to access your contacts</string>
+	<string>We need to access your contacts.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Location access is required for some DApps to function properly.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -77,8 +77,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>The app uses your camera to scan QR codes.</string>
-	<key>NSContactsUsageDescription</key>
-	<string>We need to access your contacts.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Location access is required for some DApps to function properly.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
### Summary

Fixes an Apple rejection issue where our explanation for using the camera wasn't explicit.

### Testing notes

This should be tested in a clean install, as the permissions dialogue will have to be validated.

#### Platforms

- iOS

##### Functional

- 1-1 chats

### Steps to test

1. Open app and go to the Chats screen
1. Press ➕ on the bottom of the screen
1. "Start new chat"
1. Press QR code on the top right of the screen
1. Validate that the message reads "The app uses your camera to scan QR codes." instead of "Please allow Status to use your phone camera"

status: ready
