### PR TITLE
Validate enode url when blank

### DIFF
--- a/src/status_im/ui/screens/offline_messaging_settings/edit_mailserver/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/edit_mailserver/views.cljs
@@ -48,7 +48,9 @@
     (let [url          (get-in mailserver [:url :value])
           id           (get-in mailserver [:id :value])
           name         (get-in mailserver [:name :value])
-          is-valid?    (empty? validation-errors)
+          is-valid?    (and (not (string/blank? url))
+                            (not (string/blank? name))
+                            (empty? validation-errors))
           invalid-url? (contains? validation-errors :url)]
       [react/view components.styles/flex
        [react/keyboard-avoiding-view components.styles/flex

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -671,10 +671,9 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         profile_1.just_fyi('add custom mailserver (check address/name validation) and connect to it')
         profile_1.plus_button.click()
         server_name = 'test'
-        # TODO: blocked due to issue 7333
-        # profile_1.save_button.click()
-        # if profile_1.element_by_text(mailserver_staging_ams_1).is_element_displayed():
-        #     self.errors.append('Could add custom mailserver with empty address and name')
+        profile_1.save_button.click()
+        if profile_1.element_by_text(mailserver_ams).is_element_displayed():
+            self.errors.append('Could add custom mailserver with empty address and name')
         profile_1.specify_name_input.set_value(server_name)
         profile_1.mail_server_address_input.set_value(mailserver_address[:-3])
         profile_1.save_button.click()


### PR DESCRIPTION
Fixes: #7333

Validates enode url if blank as well, so `Save` button is disabled.
Handles as well if for any reason invalid values are passed.

status: ready