### PR TITLE
Fix incorrect loading of messages

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -162,7 +162,7 @@
   (when-let [current-chat-id (:current-chat-id db)]
     (if-not (get-in db [:chats current-chat-id :messages-initialized?])
       (do
-       ; reset chat viewable-items state
+       ; reset chat first-not-visible-items state
         (chat.state/reset)
         (fx/merge cofx
                   {:db (-> db

--- a/src/status_im/ui/screens/chat/state.cljs
+++ b/src/status_im/ui/screens/chat/state.cljs
@@ -1,6 +1,6 @@
 (ns status-im.ui.screens.chat.state)
 
-(defonce viewable-item (atom nil))
+(defonce first-not-visible-item (atom nil))
 
 (defn reset []
-  (reset! viewable-item nil))
+  (reset! first-not-visible-item nil))

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -95,7 +95,7 @@
 
 (defn on-viewable-items-changed [e]
   (when @messages-list-ref
-    (reset! state/viewable-item
+    (reset! state/first-not-visible-item
             (when-let [last-visible-element (aget (.-viewableItems e) (dec (.-length (.-viewableItems e))))]
               (let [index             (.-index last-visible-element)
                     ;; Get first not visible element, if it's a datemark/gap


### PR DESCRIPTION
In some instances when receiving messages from a mailsever in the chat
you are in, the flag `all-loaded?` would not be reset, meaning that
messages not in the current view would be added to the db, but would not be seen until actually
reloading the chat (go back home, open again).

### Testing

1) Open a chat with a few messages (> 50)
2) Keep scrolling on the latest message (basically scroll in place without moving) wait until all messages are received
3) Scroll up, you should see all messages
you can use the chat `test123` messages are ordered from 1 to 100, on 1.2 there are gaps, while there won't be if using this PR.

status: ready