### PR TITLE
Update react-native-webview to 8.0.7_5

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -205,7 +205,7 @@ PODS:
     - React
   - react-native-splash-screen (3.2.0):
     - React
-  - react-native-webview (8.0.6):
+  - react-native-webview (8.0.7):
     - React
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -434,7 +434,7 @@ SPEC CHECKSUMS:
   FBLazyVector: aaeaf388755e4f29cd74acbc9e3b8da6d807c37f
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  glog: 353a32027a69db3807b94c7cbc2900fc4370098c
   QBImagePickerController: d54cf93db6decf26baf6ed3472f336ef35cae022
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
@@ -453,7 +453,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: e200d4433aba6b7e60b52da5f37af11f7a0b0392
   react-native-shake: de052eaa3eadc4a326b8ddd7ac80c06e8d84528c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
-  react-native-webview: e32e5ced4c99d7240362690a65e3467d7ef535ef
+  react-native-webview: f51a7a42278b01b07464a65c586aa0086c1e741e
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72
@@ -480,6 +480,6 @@ SPEC CHECKSUMS:
   TouchID: ba4c656d849cceabc2e4eef722dea5e55959ecf4
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
-PODFILE CHECKSUM: 6133ef51e21994956d642302ee6b9f5a96c6dcd5
+PODFILE CHECKSUM: 37924c57abbfcd77aec07d65c45ecba137cdf289
 
 COCOAPODS: 1.8.4

--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -47,7 +47,7 @@
     "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.20",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
-    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v8.0.7_4",
+    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v8.0.7_6",
     "web3-utils": "^1.2.1"
   },
   "devDependencies": {

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -4996,9 +4996,9 @@ react-native-touch-id@^4.4.1:
   resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz#8b1bb2d04c30bac36bb9696d2d723e719c4a8b08"
   integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
 
-"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v8.0.7_4":
+"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v8.0.7_6":
   version "8.0.7"
-  resolved "git+https://github.com/status-im/react-native-webview.git#fb3f4d616381a3c201272c32ced44ab1fc2d16be"
+  resolved "git+https://github.com/status-im/react-native-webview.git#5578e63fc609b770408ddbdead5a4a211c45218b"
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
Fixes #10221 

Turns out that using `WebViewClient.onPageStarted()` event handler for evaluating injected web3.js might introduce racing conditions, as it might not finish evaluating before page processing  begins.

It is possible to add result callbacks to `WebView.evaluateJavascript()` method. Also, by overloading `WebView.onConsoleMessage()` as described here https://developer.android.com/guide/webapps/debugging.html#WebView, one can see JS console logs in `adb logcat`. Thus the racing condition manifests itself in logs, when `evaluateJavascript` callback log output (for web3 provider JS) executes later than JS console logs from `status-dapp`.

Overriding `WebViewClient.shouldInterceptRequest()` seems to fix this error.

This is a port of @rasom 's and @dmitryn 's work on https://github.com/status-im/react-native-webview-bridge.