### PR TITLE
include VERSION file in jsbundle derivation source

### DIFF
--- a/nix/mobile/android/jsbundle/default.nix
+++ b/nix/mobile/android/jsbundle/default.nix
@@ -3,7 +3,7 @@
 #
 
 { target-os ? "android",
-  stdenv, mkFilter, clojure, leiningen, nodejs,
+  stdenv, mkFilter, clojure, leiningen, nodejs, bash, git,
   leinProjectDeps, localMavenRepoBuilder, projectNodePackage }:
 
 let
@@ -20,7 +20,12 @@ in stdenv.mkDerivation {
       filter =
         # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
         mkFilter {
+          root = path;
+          ignoreVCS = false;
           include = [ 
+            "VERSION" "BUILD_NUMBER" "scripts/version/.*"
+            # I want to avoid including the whole .git directory
+            ".git/HEAD" ".git/objects" ".git/refs/heads/.*"
             "src/.*" "prod/.*" "env/prod/.*"
             "components/src/.*" 
             "react-native/src" 
@@ -36,10 +41,9 @@ in stdenv.mkDerivation {
           exclude = [
             "resources/fonts/.*"
           ];
-          root = path;
         };
     };
-  buildInputs = [ clojure leiningen nodejs ];
+  buildInputs = [ clojure leiningen nodejs bash git ];
 
   LEIN_OFFLINE = "y";
 

--- a/nix/tools/mkFilter.nix
+++ b/nix/tools/mkFilter.nix
@@ -15,8 +15,11 @@ let
     # primary path under which all files are included, unless excluded
     root,
     # list of regex expressions to match files to include/exclude
-    include ? [ ], exclude ? [ ], # has precedence over include
-    }:
+    include ? [ ],
+    exclude ? [ ], # has precedence over include
+    # by default we ignore Version Control System files
+    ignoreVCS ? true,
+  }:
     let
       # removes superfluous slashes from the path
       cleanRoot = "${toString (/. + root)}/";
@@ -44,13 +47,13 @@ let
       isRootSubdir = hasPrefix cleanRoot path;
       isIncluded = checkRegexes (includeSubdirs include);
       isExcluded = checkRegexes exclude;
-      isSCV = !cleanSourceFilter path type;
+      isVCS = ignoreVCS && !cleanSourceFilter path type;
 
     in
       if !isRootSubdir then
         # everything outside of root is excluded
         false
-      else if isExcluded || isSCV then
+      else if isExcluded || isVCS then
         # isExcluded has precedence over isIncluded
         false
       else

--- a/src/status_im/utils/build.clj
+++ b/src/status_im/utils/build.clj
@@ -28,7 +28,7 @@
 
 (defmacro get-current-sha []
   "fetches the latest commit sha from the current branch"
-  (-> (shell/sh "bash" "-c" "git describe --always")
+  (-> (shell/sh "git" "rev-parse" "--short" "HEAD")
       :out
       (string/replace "\n" "")))
 
@@ -37,6 +37,6 @@
         version-file      (io/file version-file-path)]
     (if (.exists version-file)
       (string/trim (slurp version-file-path))
-      (-> (shell/sh "bash" "-c" "git describe --always")
+      (-> (shell/sh "git" "rev-parse" "--short" "HEAD")
           :out
           (string/replace "\n" "")))))


### PR DESCRIPTION
Changes:
- Includes `VERSION` file in source for `jsbundle` derivation
- Includes `BUILD_NUMBER` file and it's generation scripts
- Includes minimal `.git` files to make `git rev-parse --short HEAD` work
- Implements `ignoreVCS` for `mkFilter` to be able to include `.git` files
- Adds missing `git` and `bash` to `buildInputs` for `jsbundle` derivation
- Dropped `bash -c` from Clojure code calling `git`

Fixes #10265