### PR TITLE
fix #10039

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -88,6 +88,7 @@
          ;; in onWillBlur navigation event handler
          :preserve-input?     true
          :accessibility-label :enter-contact-code-input
+         :auto-capitalize :none
          :return-key-type     :go}]]
       [react/view {:width 16}]
       [input-icon state]]


### PR DESCRIPTION
close #10039 

- wasn't able to reproduce the issue as it seems that all inputs are already
properly turned to lower case
- added :auto-capitalize :none property to the input field though to ensure
the keyboard doesn't force the user to start with an uppercase later

status: ready <!-- Can be ready or wip -->