### PR TITLE
fix #10058 wrong domain name shown when connecting .eth

### DIFF
--- a/src/status_im/ethereum/stateofus.cljs
+++ b/src/status_im/ethereum/stateofus.cljs
@@ -4,8 +4,21 @@
 
 (def domain "stateofus.eth")
 
-(defn subdomain [username]
+(defn subdomain
+  [username]
   (str username "." domain))
+
+(defn username-with-domain
+  "checks if the username is a status username or a ens name
+  for that we check if there is a dot in the username, which
+  would indicate that there is already a domain name so we don't
+  concatenated stateofus domain to it"
+  [username]
+  (when (and (string? username)
+             (seq username))
+    (if (string/includes? username ".")
+      username
+      (subdomain username))))
 
 (defn username [name]
   (when (and name (string/ends-with? name domain))

--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -361,10 +361,10 @@
   (case state
     :available
     (i18n/label :t/ens-username-registration-confirmation
-                {:username (stateofus/subdomain username)})
+                {:username (stateofus/username-with-domain username)})
     :connected-with-different-key
     (i18n/label :t/ens-username-connection-confirmation
-                {:username (stateofus/subdomain username)})
+                {:username (stateofus/username-with-domain username)})
     :connected
     (i18n/label :t/ens-saved-title)
     ;;NOTE: this state can't be reached atm
@@ -384,7 +384,7 @@
     :connected
     [react/nested-text
      {:style {:font-size 15 :text-align :center}}
-     (stateofus/subdomain username)
+     (stateofus/username-with-domain username)
      [{:style {:color colors/gray}}
       (i18n/label :t/ens-saved)]]
     ;;NOTE: this state can't be reached atm

--- a/test/cljs/status_im/test/ethereum/stateofus.cljs
+++ b/test/cljs/status_im/test/ethereum/stateofus.cljs
@@ -7,3 +7,9 @@
   (is (true? (stateofus/valid-username? "andrey")))
   (is (false? (stateofus/valid-username? "Andrey")))
   (is (true? (stateofus/valid-username? "andrey12"))))
+
+(deftest username-with-domain
+  (is (nil? (stateofus/username-with-domain nil)))
+  (is (= "andrey.stateofus.eth" (stateofus/username-with-domain "andrey")))
+  (is (= "andrey.eth" (stateofus/username-with-domain "andrey.eth")))
+  (is (= "andrey.stateofus.eth" (stateofus/username-with-domain "andrey.stateofus.eth"))))


### PR DESCRIPTION
close #10058 

add a check on the function that adds the stateofus domain to
usernames. if the username already contains a domain, don't
concat stateofus domain to it

# Testing

- add a .eth domain, on the confirmation screen the correct name should be shown instead of currently "domain.eth.stateofus.eth"

status: ready