### PR TITLE
Use ms instead of seconds

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -106,21 +106,23 @@
                                   120000)]
     (reduce
      (fn [acc {:keys [from to id]}]
-       (if (and next-message
-                (not ignore-next-message?)
-                (or
-                 (and (nil? previous-timestamp)
-                      (< from next-whisper-timestamp))
-                 (and
-                  (< previous-timestamp from)
-                  (< to next-whisper-timestamp))
-                 (and
-                  (< from previous-timestamp)
-                  (< to next-whisper-timestamp))))
-         (-> acc
-             (update :gaps-number inc)
-             (update-in [:gap :ids] conj id))
-         (reduced acc)))
+       (let [from-ms (* from 1000)
+             to-ms (* to 1000)]
+         (if (and next-message
+                  (not ignore-next-message?)
+                  (or
+                   (and (nil? previous-timestamp)
+                        (< from-ms next-whisper-timestamp))
+                   (and
+                    (< previous-timestamp from-ms)
+                    (< to-ms next-whisper-timestamp))
+                   (and
+                    (< from-ms previous-timestamp)
+                    (< to-ms next-whisper-timestamp))))
+           (-> acc
+               (update :gaps-number inc)
+               (update-in [:gap :ids] conj id))
+           (reduced acc))))
      {:gaps-number 0
       :gap         nil}
      gaps)))

--- a/test/cljs/status_im/test/chat/db.cljs
+++ b/test/cljs/status_im/test/chat/db.cljs
@@ -75,50 +75,50 @@
           true
           true))))
   (testing "simple case with gap"
-    (is (= '({:whisper-timestamp 40
+    (is (= '({:whisper-timestamp 40000
               :message-id        :m4
-              :timestamp         40}
+              :timestamp         40000}
              {:type  :gap
               :value ":gapid1"
               :gaps  {:ids [:gapid1]}}
-             {:whisper-timestamp 30
-              :timestamp         30
+             {:whisper-timestamp 30000
+              :timestamp         30000
               :message-id        :m3}
              {:value             "today"
               :type              :datemark
-              :whisper-timestamp 30
-              :timestamp         30}
-             {:whisper-timestamp 20
-              :timestamp         20
+              :whisper-timestamp 30000
+              :timestamp         30000}
+             {:whisper-timestamp 20000
+              :timestamp         20000
               :message-id        :m2}
-             {:whisper-timestamp 10
-              :timestamp         10
+             {:whisper-timestamp 10000
+              :timestamp         10000
               :message-id        :m1}
              {:value             "yesterday"
               :type              :datemark
-              :whisper-timestamp 10
-              :timestamp         10})
+              :whisper-timestamp 10000
+              :timestamp         10000})
            (db/add-gaps
             [{:message-id        :m4
-              :whisper-timestamp 40
-              :timestamp         40}
+              :whisper-timestamp 40000
+              :timestamp         40000}
              {:message-id        :m3
-              :whisper-timestamp 30
-              :timestamp         30}
+              :whisper-timestamp 30000
+              :timestamp         30000}
              {:type :datemark
               :value "today"
-              :whisper-timestamp 30
-              :timestamp 30}
+              :whisper-timestamp 30000
+              :timestamp 30000}
              {:message-id        :m2
-              :whisper-timestamp 20
-              :timestamp         20}
+              :whisper-timestamp 20000
+              :timestamp         20000}
              {:message-id        :m1
-              :whisper-timestamp 10
-              :timestamp         10}
+              :whisper-timestamp 10000
+              :timestamp         10000}
              {:type :datemark
               :value "yesterday"
-              :whisper-timestamp 10
-              :timestamp 10}]
+              :whisper-timestamp 10000
+              :timestamp 10000}]
             [{:from 25
               :to   30
               :id   :gapid1}]
@@ -129,47 +129,47 @@
     (is (= '({:type  :gap
               :value ":gapid1"
               :gaps  {:ids (:gapid1)}}
-             {:whisper-timestamp 40
+             {:whisper-timestamp 40000
               :message-id        :m4
-              :timestamp         40}
-             {:whisper-timestamp 30
+              :timestamp         40000}
+             {:whisper-timestamp 30000
               :message-id        :m3
-              :timestamp         30}
+              :timestamp         30000}
              {:value             "today"
               :type              :datemark
-              :whisper-timestamp 30
-              :timestamp         30}
-             {:whisper-timestamp 20
+              :whisper-timestamp 30000
+              :timestamp         30000}
+             {:whisper-timestamp 20000
               :message-id        :m2
-              :timestamp         20}
-             {:whisper-timestamp 10
+              :timestamp         20000}
+             {:whisper-timestamp 10000
               :message-id        :m1
-              :timestamp         10}
+              :timestamp         10000}
              {:value             "yesterday"
               :type              :datemark
-              :whisper-timestamp 10
-              :timestamp         10})
+              :whisper-timestamp 10000
+              :timestamp         10000})
            (db/add-gaps
             [{:message-id        :m4
-              :whisper-timestamp 40
-              :timestamp         40}
+              :whisper-timestamp 40000
+              :timestamp         40000}
              {:message-id        :m3
-              :whisper-timestamp 30
-              :timestamp         30}
+              :whisper-timestamp 30000
+              :timestamp         30000}
              {:type :datemark
               :value "today"
-              :whisper-timestamp 30
-              :timestamp         30}
+              :whisper-timestamp 30000
+              :timestamp         30000}
              {:message-id        :m2
-              :whisper-timestamp 20
-              :timestamp         20}
+              :whisper-timestamp 20000
+              :timestamp         20000}
              {:message-id        :m1
-              :whisper-timestamp 10
-              :timestamp         10}
+              :whisper-timestamp 10000
+              :timestamp         10000}
              {:type :datemark
               :value "yesterday"
-              :whisper-timestamp 10
-              :timestamp         10}]
+              :whisper-timestamp 10000
+              :timestamp         10000}]
             [{:from 100
               :to   110
               :id   :gapid1}]


### PR DESCRIPTION
Fixes: #10249

We were using seconds instead of seconds (changed when we moved to status-go), therefore the gap would always end up as last.

status: ready