### PR TITLE
signals processing performance improvements [#10287]

### DIFF
--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -60,10 +60,13 @@
               (multiaccounts.update/multiaccount-update :last-updated last-updated {:dont-sync? true})
               (multiaccounts.update/multiaccount-update :photo-path photo-path {:dont-sync? true}))))
 
-(fx/defn ensure-contact
-  [{:keys [db]}
-   {:keys [public-key] :as contact}]
-  {:db (update-in db [:contacts/contacts public-key] merge contact)})
+(fx/defn ensure-contacts
+  [{:keys [db]} contacts]
+  {:db (update db :contacts/contacts
+               #(reduce (fn [acc {:keys [public-key] :as contact}]
+                          (update acc public-key merge contact))
+                        %
+                        contacts))})
 
 (fx/defn upsert-contact
   [{:keys [db] :as cofx}

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -167,18 +167,28 @@
   ([db public-key]
    (active? (get-in db [:contacts/contacts public-key]))))
 
+;;TODO TTT
+#_(defn enrich-ttt-contact
+    [{:keys [system-tags tribute-to-talk] :as contact}]
+    (let [tribute (:snt-amount tribute-to-talk)
+          tribute-status (tribute-to-talk.db/tribute-status contact)
+          tribute-label (tribute-to-talk.db/status-label tribute-status tribute)]
+      (-> contact
+          (assoc-in [:tribute-to-talk :tribute-status] tribute-status)
+          (assoc-in [:tribute-to-talk :tribute-label] tribute-label)
+          (assoc :pending? (pending? contact)
+                 :blocked? (blocked? contact)
+                 :active? (active? contact)
+                 :added? (contains? system-tags :contact/added)))))
+
 (defn enrich-contact
-  [{:keys [system-tags tribute-to-talk] :as contact}]
-  (let [tribute (:snt-amount tribute-to-talk)
-        tribute-status (tribute-to-talk.db/tribute-status contact)
-        tribute-label (tribute-to-talk.db/status-label tribute-status tribute)]
-    (-> contact
-        (assoc-in [:tribute-to-talk :tribute-status] tribute-status)
-        (assoc-in [:tribute-to-talk :tribute-label] tribute-label)
-        (assoc :pending? (pending? contact)
-               :blocked? (blocked? contact)
-               :active? (active? contact)
-               :added? (contains? system-tags :contact/added)))))
+  [{:keys [system-tags] :as contact}]
+  (-> contact
+      (dissoc :ens-verified-at :ens-verification-retries)
+      (assoc :pending? (pending? contact)
+             :blocked? (blocked? contact)
+             :active? (active? contact)
+             :added? (contains? system-tags :contact/added))))
 
 (defn enrich-contacts
   [contacts]

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -216,8 +216,12 @@
                   :name (:name metadata)
                   :device-type (:deviceType metadata))})
 
-(fx/defn handle-installation [{:keys [db]} {:keys [id] :as i}]
-  {:db (assoc-in db [:pairing/installations id] (installation<-rpc i))})
+(fx/defn handle-installations [{:keys [db]} installations]
+  {:db (update db :pairing/installations #(reduce
+                                           (fn [acc {:keys [id] :as i}]
+                                             (update acc id merge (installation<-rpc i)))
+                                           %
+                                           installations))})
 
 (fx/defn load-installations [{:keys [db]} installations]
   {:db (assoc db :pairing/installations (reduce

--- a/src/status_im/transport/filters/core.cljs
+++ b/src/status_im/transport/filters/core.cljs
@@ -273,6 +273,13 @@
     (let [chat (get-in db [:chats chat-id])]
       (load-filter-fx (waku/enabled? cofx) (->filter-request chat)))))
 
+(fx/defn load-chats
+  "Check if a filter already exists for that chat, otherw load the filter"
+  [{:keys [db] :as cofx} chats]
+  (let [chats (filter #(chat-loaded? db (:chat-id %)) chats)]
+    (when (and (filters-initialized? db) (seq chats))
+      (load-filter-fx (waku/enabled? cofx) (chats->filter-requests chats)))))
+
 (fx/defn load-contact
   "Check if we already have a filter for that contact, otherwise load the filter
   if the contact has been added"


### PR DESCRIPTION
partially addresses #10287

we split all items from a signal by `dispatch-later [{:ms 20` this leads to performance issues because each item cause all subscriptions and views recomputation and re-rendrering, we need this only for messages, but still, we don't want to dispatch every message, we could split them by small batches 

tested on top on release app on my Android device, app much faster and responsive 

QA: test ens names resolution in chats, new messages, sync device with new chats