### PR TITLE
Show correct error message when signing typed data

### DIFF
--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -301,7 +301,9 @@
   (let [{:keys [result error]} (types/json->clj result)
         on-result (get-in db [:signing/tx :on-result])]
     (if error
-      {:db (update db :signing/sign assoc :error (i18n/label :t/wrong-password) :in-progress? false)}
+      {:db (update db :signing/sign assoc
+                   :error (if (= 5 (:code error)) (i18n/label :t/wrong-password) (:message error))
+                   :in-progress? false)}
       (fx/merge cofx
                 {:db (dissoc db :signing/tx :signing/in-progress? :signing/sign)}
                 (check-queue)


### PR DESCRIPTION
Prior to this commit `sign-message-completed` effect would always use
the `wrong-password` label for error handling. We now ensure that `wrong-password`
is only used in case the error in question has a code `5`, which is
associated to unmatching passwords.

In any other case we'll use the `message` attached to the `error`.

Fixes #8275
