### PR TITLE
fix android build on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ export TARGET ?= $(TARGET_OS)
 endif
 
 # Useful for checking if we are on NixOS
-OS_NAME := $(shell awk -F= '/^NAME/{print $2}' /etc/os-release)
+OS_NAME := $(shell [ -f /etc/os-release ] && awk -F= '/^NAME/{print $2}' /etc/os-release)
 
 # Useful for Andoird release builds
 TMP_BUILD_NUMBER := $(shell ./scripts/version/gen_build_no.sh | cut -c1-10)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -313,22 +313,34 @@ dependencies {
     implementation 'com.facebook.fresco:animated-gif:2.0.0'
 }
 
-// Run this once to be able to run the application with BUCK
-// puts all compile dependencies into folder libs for BUCK to use
-
-task hemroidBuild(type: Exec) {
+def getLocalNDKDir = { ->
     def rootDir = project.rootDir
     def localProperties = new File(rootDir, "local.properties")
-
-    def ndkDir = System.env.ANDROID_NDK
-    if (localProperties.exists()) {
-        Properties properties = new Properties()
-        localProperties.withInputStream { instr ->
-            properties.load(instr)
-        }
-        ndkDir = properties.getProperty('ndk.dir')
+    if (!localProperties.exists()) {
+        return null
     }
-    executable "$ndkDir/ndk-build"
+    Properties properties = new Properties()
+    localProperties.withInputStream { instr ->
+        properties.load(instr)
+    }
+    return properties.getProperty('ndk.dir')
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task hemroidBuild(type: Exec) {
+    def localNdkDir = getLocalNDKDir()
+    def ndkDir = System.env.ANDROID_NDK
+    if (localNdkDir != null) {
+        ndkDir = localNdkDir 
+    }
+
+    def execPath = "$ndkDir/ndk-build"
+    def exec = new File(execPath)
+    if (!exec.exists()) {
+        throw new GradleException("No ndk-build binary found!")
+    }
+    executable execPath
 }
 
 preBuild.dependsOn hemroidBuild

--- a/scripts/generate-keystore.sh
+++ b/scripts/generate-keystore.sh
@@ -31,7 +31,7 @@ KEYSTORE_PATH=$(env_var_or_gradle_prop 'KEYSTORE_PATH')
 KEYSTORE_PATH=${KEYSTORE_PATH/#\~/$HOME}
 
 if [[ -e "${KEYSTORE_PATH}" ]]; then
-    echo -e "${YLW}Keystore file already exists:${RST} ${KEYSTORE_PATH}" > /dev/stderr
+    echo -e "${YLW}Keystore file already exists:${RST} ${KEYSTORE_PATH}" >&2
     echo "${KEYSTORE_PATH}"
     exit 0
 fi
@@ -39,7 +39,7 @@ fi
 KEYSTORE_DIR=$(dirname "${KEYSTORE_PATH}")
 [[ -d $KEYSTORE_DIR ]] || mkdir -p $KEYSTORE_DIR
 
-echo -e "${GRN}Generating keystore...${RST}" > /dev/stderr
+echo -e "${GRN}Generating keystore...${RST}" >&2
 
 keytool -genkey -v \
     -keyalg RSA \

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -46,14 +46,14 @@ nixOpts+=(
   "--argstr" "secrets-file" "${SECRETS_FILE_PATH}"
 )
 
-if [[ "$OS" =~ Darwin ]]; then
+if [[ "$(uname -s)" =~ Darwin ]]; then
   # Start a watchman instance if not started already and store its socket path.
   # In order to get access to the right versions of watchman and jq,
   # we start an ad-hoc nix-shell that imports the packages from nix/nixpkgs-bootstrap.
   WATCHMAN_SOCKFILE=$(watchman get-sockname --no-pretty | jq -r .sockname)
   nixOpts+=(
-    " --argstr" "watchmanSockPath" "${WATCHMAN_SOCKFILE}"
-    " --option" "extra-sandbox-paths" "${KEYSTORE_PATH} ${SECRETS_FILE_PATH} ${WATCHMAN_SOCKFILE}"
+    "--argstr" "watchmanSockPath" "${WATCHMAN_SOCKFILE}"
+    "--option" "extra-sandbox-paths" "${KEYSTORE_PATH} ${SECRETS_FILE_PATH} ${WATCHMAN_SOCKFILE}"
   )
 else
   nixOpts+=(


### PR DESCRIPTION
Changes:

* Explicit error when `ndk-build` executable does not exist
* Fixes OS checking by use of `uname -s` instead of `OS` variable
* Replaces use of `> /dev/stderr` with `>&2` to make it work on MacOS
* Removes unnecessary leading whitespace in Nix arguments
* Checks if `/etc/os-release` exists before reading it