### PR TITLE
Use a single in-progress? flag for signing

### DIFF
--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -164,7 +164,6 @@
 (spec/def :stickers/recent (spec/nilable vector?))
 (spec/def :wallet/custom-token-screen (spec/nilable map?))
 
-(spec/def :signing/in-progress? (spec/nilable boolean?))
 (spec/def :signing/queue (spec/nilable any?))
 (spec/def :signing/tx (spec/nilable map?))
 (spec/def :signing/sign (spec/nilable map?))
@@ -239,7 +238,6 @@
                                 :bottom-sheet/options
                                 :wallet/custom-token-screen
                                 :wallet/prepare-transaction
-                                :signing/in-progress?
                                 :signing/queue
                                 :signing/sign
                                 :signing/tx

--- a/test/cljs/status_im/test/signing/core.cljs
+++ b/test/cljs/status_im/test/signing/core.cljs
@@ -20,7 +20,7 @@
           sign-second (signing/sign sign-first second-tx)]
       (testing "after fist transaction"
         (testing "signing in progress"
-          (is (get-in sign-first [:db :signing/in-progress?])))
+          (is (get-in sign-first [:db :signing/tx])))
         (testing "qieue is empty"
           (is (= (get-in sign-first [:db :signing/queue]) '())))
         (testing "first tx object is parsed"
@@ -37,15 +37,15 @@
                          :amount  "10"})))))
       (testing "after second transaction"
         (testing "signing still in progress"
-          (is (get-in sign-second [:db :signing/in-progress?])))
+          (is (get-in sign-second [:db :signing/tx])))
         (testing "queue is not empty, second tx in queue"
           (is (= (get-in sign-second [:db :signing/queue]) (list second-tx))))
         (testing "check queue does nothing"
           (is (not (signing/check-queue sign-second))))
-        (let [first-discarded (signing/check-queue (update sign-second :db dissoc :signing/in-progress? :signing/tx))]
+        (let [first-discarded (signing/check-queue (update sign-second :db dissoc :signing/tx))]
           (testing "after first transaction discarded"
             (testing "signing still in progress"
-              (is (get-in first-discarded [:db :signing/in-progress?])))
+              (is (get-in first-discarded [:db :signing/tx])))
             (testing "qieue is empty"
               (is (= (get-in first-discarded [:db :signing/queue]) '())))
             (testing "second tx object is parsed"


### PR DESCRIPTION
We currently use 2 different locations for `in-progress?` flag during signing: under `:signing/in-progress?` and under `[:signing/sign :in-progress?]`. This could cause bugs.

This PR removes the former one in favour of the latter.