### PR TITLE
fix: strip leading and trailing whitespace from QR Code data

### DIFF
--- a/src/status_im/ui/components/camera.cljs
+++ b/src/status_im/ui/components/camera.cljs
@@ -1,6 +1,7 @@
 (ns status-im.ui.components.camera
   (:require [goog.object :as object]
             [reagent.core :as reagent]
+            [clojure.string :as string]
             [clojure.walk :as walk]
             [status-im.react-native.js-dependencies :as js-dependencies]
             [status-im.utils.platform :as platform]))
@@ -34,4 +35,5 @@
   (reagent/create-element default-camera (clj->js (merge {:inverted true} props))))
 
 (defn get-qr-code-data [code]
-  (.-data code))
+  (when-let [data (.-data code)]
+    (string/trim data)))

--- a/src/status_im/ui/screens/qr_scanner/views.cljs
+++ b/src/status_im/ui/screens/qr_scanner/views.cljs
@@ -1,6 +1,7 @@
 (ns status-im.ui.screens.qr-scanner.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [re-frame.core :as re-frame]
+            [clojure.string :as string]
             [status-im.i18n :as i18n]
             [status-im.ui.components.camera :as camera]
             [status-im.ui.components.react :as react]
@@ -42,7 +43,7 @@
          :on-press #(re-frame/dispatch [:qr-scanner.callback/scan-qr-code-cancel opts])}]
        [button/button
         {:label    "OK"
-         :on-press #(re-frame/dispatch [:qr-scanner.callback/scan-qr-code-success opts @text-value])}]]]]))
+         :on-press #(re-frame/dispatch [:qr-scanner.callback/scan-qr-code-success opts (when-let [text @text-value] (string/trim text))])}]]]]))
 
 (defn corner [border1 border2 corner]
   [react/view (assoc {:border-color colors/white-persist :width 60 :height 60} border1 5 border2 5 corner 32)])


### PR DESCRIPTION
fixes #10306.

see also https://github.com/status-im/status-react/pull/10280#issuecomment-611374756.

### Summary

All leading and trailing whitespace is now removed from strings derived from QR codes, both in the case of `get-qr-code-data` (real camera) and `qr-test-view` (mock camera).

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- mailservers

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Use a QR code generator that will preserve leading and trailing whitespace in the text to be encoded, and generate a QR code that has e.g. leading and/or trailing spaces and new lines. On macOS you can use `qrencode` (`brew install qrencode`).
- Open Status
- Navigate to Profile -> Sync settings -> Mailserver
- Click the `+` in the top-right of the screen.
- Click the QR code button-icon in the second field that's titled *Mailserver address*.
- Depending on the `QR_READ_TEST_MENU` flag in your development setup, either enter some text that has leading/trailing whitespace, or take a picture of the QR code you generated in the first step.
- When you are returned to the *Add mailserver* screen notice that the leading/trailing whitespace has been stripped away.

status: ready