### PR TITLE
fix: display value decimals instead of using exp notation

### DIFF
--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -157,7 +157,7 @@
          (if (nil? to)
            {:contact {:name (i18n/label :t/new-contract)}}
            (let [eth-value  (when value (money/bignumber value))
-                 eth-amount (when eth-value (money/to-number (money/wei->ether eth-value)))
+                 eth-amount (when eth-value (money/to-fixed (money/wei->ether eth-value)))
                  token      (get-transfer-token db to data)]
              (cond
                (and eth-amount (or (not (zero? eth-amount)) (nil? data)))

--- a/src/status_im/ui/screens/chat/message/command.cljs
+++ b/src/status_im/ui/screens/chat/message/command.cljs
@@ -174,7 +174,7 @@
       [react/text {:style {:margin-bottom 2
                            :font-size 20
                            :line-height 24}}
-       (str amount " " (name symbol))]
+       (str (money/to-fixed amount) " " (name symbol))]
       [react/text {:style {:font-size 12
                            :line-height 16
                            :color colors/gray}}


### PR DESCRIPTION
fixes #9389

### Summary
Displays the amounts in wallet and chat with decimal values instead of using exponential notation

##### Functional

- 1-1 chats
- wallet / transactions

status: ready