### PR TITLE
fix: show message when loading new transactions instead of no tx msg

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -113,7 +113,9 @@
        :render-fn    #(render-transaction %)
        :empty-component
        [react/i18n-text {:style styles/empty-text
-                         :key   :transactions-history-empty}]
+                         :key   (if (or fetching-recent-history? fetching-more-history?)
+                                  :transactions-history-loading
+                                  :transactions-history-empty)}]
        :refreshing   false}]
      (when (and (not fetching-recent-history?)
                 (not all-fetched?))

--- a/translations/en.json
+++ b/translations/en.json
@@ -957,6 +957,7 @@
     "type": "Type",
     "transactions-history": "Transaction history",
     "transactions-history-empty": "No transactions in your history yet",
+    "transactions-history-loading": "Loading transaction history. This might take a while.",
     "transactions-sign": "Sign",
     "tribute-required-by-multiaccount": "{{multiaccount-name}} requires SNT to start a chat.",
     "tribute-state-paid": "Tribute paid",


### PR DESCRIPTION
### Summary

Fixes #10301 by showing the loading message when loading and the no trandsactions when there is none and there is no TX.

status: ready