### PR TITLE
Refactor delete account algorithm to properly remove deleted account

### DIFF
--- a/src/status_im/wallet/accounts/core.cljs
+++ b/src/status_im/wallet/accounts/core.cljs
@@ -274,7 +274,7 @@
                                  :on-success #()}]
                :db (-> db
                        (assoc :multiaccount/accounts new-accounts)
-                       (assoc-in [:wallet :accounts deleted-address] nil))}
+                       (update-in [:wallet :accounts] dissoc deleted-address))}
               (navigation/navigate-to-cofx :wallet nil))))
 
 (fx/defn view-only-qr-scanner-result


### PR DESCRIPTION
Prior to this commit, deleted accounts would stay in the database but
set to `nil`. With this change accounts are properly removed from the database
when scheduled for deletion.