### PR TITLE
[#10369] App freezes on transaction signing after entering wrong pass…

### DIFF
--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -335,7 +335,9 @@
   {:events       [:signing/transaction-completed]
    :interceptors [(re-frame/inject-cofx :random-id-generator)]}
   [cofx response tx-obj hashed-password]
-  (let [cofx-in-progress-false (assoc-in cofx [:db :signing/in-progress?] false)
+  (let [cofx-in-progress-false (-> cofx
+                                   (assoc-in [:db :signing/in-progress?] false)
+                                   (assoc-in [:db :signing/sign :in-progress?] false))
         {:keys [result error]} (types/json->clj response)]
     (log/debug "transaction-completed" error tx-obj)
     (if error


### PR DESCRIPTION


fixes #10369