### PR TITLE
makefile: add missing TARGET for android-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,9 +327,10 @@ geth-connect: ##@other Connect to Geth on the device
 	adb forward tcp:8545 tcp:8545 && \
 	build/bin/geth attach http://localhost:8545
 
+android-clean: export TARGET := android
 android-clean: ##@prepare Clean Gradle state
 	git clean -dxf -f ./android/app/build
-	[ -d android/.gradle ] && cd android && ./gradlew clean
+	[[ -d android/.gradle ]] && cd android && ./gradlew clean
 
 android-ports: export TARGET := android-env
 android-ports: ##@other Add proxies to Android Device/Simulator
@@ -348,7 +349,7 @@ android-logcat: ##@other Read status-react logs from Android phone using adb
 
 android-install: export TARGET := android-env
 android-install: export BUILD_TYPE ?= release
-android-install:
+android-install: ##@other Install APK on device using adb
 	adb install result/app-$(BUILD_TYPE).apk
 
 _list: SHELL := /bin/sh

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,6 @@ export REACT_SERVER_PORT ?= 5001
 export NIX_CONF_DIR = $(PWD)/nix
 # Defines which variables will be kept for Nix pure shell, use semicolon as divider
 export _NIX_KEEP ?= TMPDIR,BUILD_ENV,STATUS_GO_SRC_OVERRIDE,NIMBUS_SRC_OVERRIDE
-# legacy TARGET_OS variable support
-ifdef TARGET_OS
-export TARGET ?= $(TARGET_OS)
-endif
 
 # Useful for Andoird release builds
 TMP_BUILD_NUMBER := $(shell ./scripts/version/gen_build_no.sh | cut -c1-10)

--- a/nix/scripts/purge.sh
+++ b/nix/scripts/purge.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+source "${GIT_ROOT}/scripts/colors.sh"
+
+# Purging /nix on NixOS would be disasterous
+if [[ -f "/etc/os-release" ]]; then
+    OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
+    if [[ "$OS_NAME" == "NixOS" ]]; then
+        echo -e "${RED}You should not purge Nix files on NixOS!${RST}" >&2
+        exit
+    fi
+fi
+
+NIX_ROOT="/nix"
+if [[ $(uname -s) == "Darwin" ]]; then
+    # Special case due to read-only root on MacOS Catalina
+    NIX_ROOT="/opt/nix"
+fi
+
+sudo rm -rf ${NIX_ROOT}/* ~/.nix-profile ~/.nix-defexpr ~/.nix-channels ~/.cache/nix ~/.status .nix-gcroots
+echo -e "${GRN}Purged all Nix files from your system.${RST}" >&2

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -15,14 +15,14 @@ function install_nix() {
   if [ $? -eq 0 ]; then
     echo -e "${GRN}The Nix package manager was successfully installed.${RST}"
   else
-    echo -e "${RED}Failed to install Nix package manager!${RST}" > /dev/stderr
-    echo "Please see: https://nixos.org/nix/manual/#chap-installation" > /dev/stderr
+    echo -e "${RED}Failed to install Nix package manager!${RST}" >&2
+    echo "Please see: https://nixos.org/nix/manual/#chap-installation" >&2
     exit 1
   fi
 }
 
 if [[ ! -x "$(command -v git)" ]]; then
-  echo -e "${RED}The 'curl' utility is required for Nix installation.${RST}" > /dev/stderr
+  echo -e "${RED}The 'curl' utility is required for Nix installation.${RST}" >&2
   exit 1
 fi
 

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -2,6 +2,6 @@ const blacklist = require('metro').createBlacklist;
 
 module.exports = {
     getBlacklistRE: function() {
-        return blacklist([/desktop\/js_files\/.*/]);
+        return blacklist([/(desktop|mobile)\/js_files\/.*/]);
     }
 };


### PR DESCRIPTION
Changes:
* Fixed `make android-clean` target failing due to lack of Gradle
* Included small change that moves `make nix-purge` to `nix/scripts/purge.sh` for simplicity
* Fixed Haste warnings about mode name collisions by changing blacklist in `rn-cli.config.js`
* Got rid of the old `TARGET_OS` variable from `Makefile`