### PR TITLE
fix(signing/views): allow discarding signing popup when tx in progress

### DIFF
--- a/src/status_im/ui/screens/signing/views.cljs
+++ b/src/status_im/ui/screens/signing/views.cljs
@@ -84,10 +84,10 @@
        [{:style {:color colors/black}} (displayed-name contact)]]
       [react/text {:style {:margin-top 6 :color colors/gray}}
        (str fee " " fee-display-symbol " " (string/lower-case (i18n/label :t/network-fee)))])]
-   [button/button (merge {:type :secondary
-                          :container-style {:padding-horizontal 24}
-                          :label (i18n/label :t/cancel)}
-                         (when-not in-progress? {:on-press #(re-frame/dispatch [:signing.ui/cancel-is-pressed])}))]])
+   [button/button {:type :secondary
+                   :container-style {:padding-horizontal 24}
+                   :label (i18n/label :t/cancel)
+                   :on-press #(re-frame/dispatch [:signing.ui/cancel-is-pressed])}]])
 
 (views/defview keycard-pin-view []
   (views/letsubs [pin [:hardwallet/pin]


### PR DESCRIPTION


### Summary

As discussed in #9977, there's an issue that the signing view popup cannot
be cancelled/discarded when a transaction is in progress.
This is because the `cancel-is-pressed` event is only conditionally applied to
the cancel button, rendering it non-functional for the time-being.

This commit changes that behaviour to always attach the event handler to
the cancel button, so that the popup can be closed even when a transaction
has been sent.

Fixes #9977

### Review notes

One thing to keep in mind:
Once the transaction has been signed and is in progress, there's no way to "cancel" it, so hitting the "Cancel" button in the UI really just "discards" it. One could consider changing the label to "Discard", but it probably won't work well because the UI is used in a context where cancelling makes sense.

### Testing notes

Best way to test this is to turn off the `signing/transaction-completed` event so the app thinks the transaction is in progress forever.

#### Platforms

- Android
- iOS
- macOS
- Linux
- Windows

