### PR TITLE
fix: prevent multiple taps on Register button from opening several tx during ENS registration

### DIFF
--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -295,7 +295,7 @@
        (i18n/label :t/ens-deposit)]]]
     [button {:disabled?    (not @checked?)
              :label-style  (when (not @checked?) {:color colors/gray})
-             :on-press     #(re-frame/dispatch [::ens/register-name-pressed])}
+             :on-press     #(debounce/dispatch-and-chill [::ens/register-name-pressed] 2000)}
      (i18n/label :t/ens-register)]]])
 
 (defn- registration


### PR DESCRIPTION
fixes #9566

### Summary

To prevent multiple taps from opening several transactions, the `::ens/register-name-pressed` event is debounced (via `status-im.utils.debounce/dispatch-and-chill`).

### Review notes

I set the "chill" time to 2 seconds — too long or short? I'm not sure.

### Testing notes

If you tap on the Cancel button quickly to do a repeat test of the `dispatch-and-chill` effect, keep in mind the 2 second chill-time must expire before tapping Register again will have an effect.

#### Platforms

- Android
- iOS

##### Functional

- user profile updates

### Steps to test

- Open Status
- Navigate through Profile -> ENS usernames -> Your username *(requires some input)*
- Check the *"Agree..."* box
- Tap the Register button multiple times quickly; note that only one transaction is opened.

status: ready