### PR TITLE
fix: change amount-input field keyboard type and autocapitalization to display decimal separator

### DIFF
--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -104,7 +104,7 @@
          {:style               {:font-size (if small-screen? 24 38)
                                 :color (if amount-error colors/red colors/black)
                                 :flex-shrink 1}
-          :keyboard-type       :numeric
+          :keyboard-type       :decimal-pad
           :accessibility-label :amount-input
           :default-value       amount-text
           :editable            (not request?)
@@ -163,7 +163,7 @@
          {:style               {:font-size (if small-screen? 24 38)
                                 :color (when amount-error colors/red)
                                 :flex-shrink 1}
-          :keyboard-type       :numeric
+          :keyboard-type       :decimal-pad
           :accessibility-label :amount-input
           :default-value       amount-text
           :auto-focus          true

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -105,6 +105,7 @@
                                 :color (if amount-error colors/red colors/black)
                                 :flex-shrink 1}
           :keyboard-type       :decimal-pad
+          :auto-capitalize     :words
           :accessibility-label :amount-input
           :default-value       amount-text
           :editable            (not request?)
@@ -164,6 +165,7 @@
                                 :color (when amount-error colors/red)
                                 :flex-shrink 1}
           :keyboard-type       :decimal-pad
+          :auto-capitalize     :words
           :accessibility-label :amount-input
           :default-value       amount-text
           :auto-focus          true


### PR DESCRIPTION
fixes #2681

### Summary

This PR is an attempt to fix the issue with not displaying the dot/comma in the keyboard when typing in the input field for setting the amount to send in a transaction. I could not replicate this issue locally (S9+ and Android 6.0 / R), as it seems to happen on specific devices / OS versions.

The solution is based on these comments:
https://github.com/facebook/react-native/issues/22005#issuecomment-560495530
https://github.com/facebook/react-native/issues/12988#issuecomment-407550185

#### Platforms
- Android
- iOS

status: WIP