### PR TITLE
fix: add debounce to "Done" button in the recipient selection dialog

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -8,7 +8,8 @@
             [status-im.ui.components.toolbar.view :as topbar]
             [status-im.ui.screens.wallet.components.styles :as styles]
             [status-im.ui.components.text-input.view :as text-input]
-            [status-im.ui.components.colors :as colors])
+            [status-im.ui.components.colors :as colors]
+            [status-im.utils.debounce :as debounce])
   (:require-macros [status-im.utils.views :as views]))
 
 (defn separator []
@@ -27,7 +28,7 @@
    [topbar/text-action
     {:disabled? (string/blank? content)
      :style     {:margin-right 16}
-     :handler   #(re-frame/dispatch [:wallet.send/set-recipient content])}
+     :handler   #(debounce/dispatch-and-chill [:wallet.send/set-recipient content] 3000)}
     (i18n/label :t/done)]])
 
 (views/defview contact-code []


### PR DESCRIPTION
fixes #9562

### Summary

Prevents tapping the "Done" button multiple times when choosing a recipient by adding a debounce of 3 seconds

#### Platforms
- Android
- iOS