### PR TITLE
Handle when message confirmations arrive out of order.

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -813,15 +813,12 @@
 (handlers/register-handler-fx
  :transport/message-sent
  (fn [cofx [_ response messages-count]]
-   (let [{:keys [localChatId id messageType]} (-> response :messages first)]
-     (fx/merge cofx
-               (handle-update response)
-               (transport.message/set-message-envelope-hash localChatId id messageType messages-count)))))
-
-(handlers/register-handler-fx
- :transport/contact-message-sent
- (fn [cofx [_ chat-id envelope-hash]]
-   (transport.message/set-contact-message-envelope-hash cofx chat-id envelope-hash)))
+   (let [set-hash-fxs (map (fn [{:keys [localChatId id messageType]}]
+                             (transport.message/set-message-envelope-hash localChatId id messageType messages-count))
+                           (:messages response))]
+     (apply fx/merge cofx
+            (conj set-hash-fxs
+                  (handle-update response))))))
 
 (handlers/register-handler-fx
  :transport.callback/node-info-fetched


### PR DESCRIPTION
Fixes: #10389 

In some cases message confirmations might arrive out of order, before
status-go calls the callback for a sent message.

This commit changes the behavior so that confirmations out of order are
not ignored and they are checked when the callback for sending message
is called.

Please test with replies and non reply messages. It might fix the issue we had with confirmations in general (it might also be partially due to this).

status: ready