### PR TITLE
fix: display the value to sign as a bytes32 hex string if the data is 66 chars long

### DIFF
--- a/src/status_im/ethereum/core.cljs
+++ b/src/status_im/ethereum/core.cljs
@@ -138,3 +138,13 @@
                          nil)]
     (when normalized-key
       (subs (sha3 normalized-key) 26))))
+
+(def ^:const bytes32-length 66) ; length of '0x' + 64 hex values. (a 32bytes value has 64 nibbles)
+
+(defn hex->text
+  "Converts a hexstring to UTF8 text. If the data received is 32 bytes long, 
+   return the value unconverted"
+  [data]
+  (if (= bytes32-length (count (normalized-hex data)))
+    data ; Assume it's a bytes32
+    (hex-to-utf8 data)))

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -195,7 +195,7 @@
                    :signing/sign {:type           (cond pinless? :pinless
                                                         keycard-multiaccount? :keycard
                                                         :else :password)
-                                  :formatted-data (if typed? (types/json->clj data) (ethereum/hex-to-utf8 data))
+                                  :formatted-data (if typed? (types/json->clj data) (ethereum/hex->text data))
                                   :keycard-step (when pinless? :connect)})}
        (when pinless?
          (signing.keycard/hash-message {:data data


### PR DESCRIPTION
fixes #8590

### Summary

If the value to sign is a bytes32 hexadecimal string, like `0x1122334455667788112233445566778811223344556677881122334455667788`, it will be displayed as such in the Signature screen, otherwise, it will do the transformation to a UTF8 String as usual.

![Screenshot from 2020-04-22 13-54-06](https://user-images.githubusercontent.com/1106587/80016524-3a3e8b80-84a1-11ea-8f7d-9e8341750db3.png)

![Screenshot from 2020-04-22 13-53-23](https://user-images.githubusercontent.com/1106587/80016531-3ca0e580-84a1-11ea-8c72-2594eff5f152.png)


In the issue I had mentioned before that any hexadecimal string should be displayed as such, but after reviewing this behavior in other web3 browsers, t**he hexadecimal string is shown only for bytes32 values.**

##### Functional

- dapps / app browsing


### Steps to test
- Open Status
- Open Dapp Browser
- Go to https://status-im.github.io/dapp
- Select the tab "Transaction"
- Change the message to sign, either use a normal string or a bytes32 value.
- Click on "Sign message"

status: ready