### PR TITLE
[#10409] Invalid mnemonic on keycard acc creation

### DIFF
--- a/src/status_im/hardwallet/card.cljs
+++ b/src/status_im/hardwallet/card.cljs
@@ -171,26 +171,6 @@
        (re-frame/dispatch
         [:hardwallet.callback/on-pair-error (error-object->map response)]))})))
 
-(defn generate-mnemonic [args]
-  (log/info "[keycard] generate-mnemonic" args)
-  (keycard/generate-mnemonic
-   card
-   (merge
-    args
-    {:on-success
-     (fn [response]
-       (log/info "[keycard response succ] generate-mnemonic"
-                 (js->clj response :keywordize-keys true))
-       (re-frame/dispatch
-        [:hardwallet.callback/on-generate-mnemonic-success response]))
-     :on-failure
-     (fn [response]
-       (log/info "[keycard response fail] generate-mnemonic"
-                 (error-object->map response))
-       (re-frame/dispatch
-        [:hardwallet.callback/on-generate-mnemonic-error
-         (error-object->map response)]))})))
-
 (defn generate-and-load-key [args]
   (log/info "[keycard] generate-and-load-key" args)
   (keycard/generate-and-load-key

--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -62,7 +62,7 @@
                   {:db (update-in db [:hardwallet :secrets] merge pairing-data)}
                   (common/listen-to-hardware-back-button)
                   (when (= flow :create)
-                    (mnemonic/proceed-with-generating-mnemonic))
+                    (mnemonic/set-mnemonic))
                   (when (= flow :recovery)
                     (onboarding/proceed-with-generating-key)))
         (recovery/load-pair-screen cofx)))))
@@ -181,7 +181,6 @@
                                      :hardwallet/generate-and-load-key
                                      :hardwallet/remove-key-with-unpair
                                      :hardwallet/unpair-and-delete
-                                     :hardwallet/generate-mnemonic
                                      :wallet.accounts/generate-new-keycard-account} on-verified)
                 (common/get-application-info pairing nil))
               (when on-verified

--- a/src/status_im/hardwallet/fx.cljs
+++ b/src/status_im/hardwallet/fx.cljs
@@ -43,10 +43,6 @@
  card/pair)
 
 (re-frame/reg-fx
- :hardwallet/generate-mnemonic
- card/generate-mnemonic)
-
-(re-frame/reg-fx
  :hardwallet/generate-and-load-key
  card/generate-and-load-key)
 

--- a/src/status_im/hardwallet/ios_keycard.cljs
+++ b/src/status_im/hardwallet/ios_keycard.cljs
@@ -16,7 +16,6 @@
   (init-card [this args])
   (install-applet-and-init-card [this args])
   (pair [this args])
-  (generate-mnemonic [this args])
   (generate-and-load-key [this args])
   (unblock-pin [this args])
   (verify-pin [this args])

--- a/src/status_im/hardwallet/keycard.cljs
+++ b/src/status_im/hardwallet/keycard.cljs
@@ -15,7 +15,6 @@
   (init-card [this args])
   (install-applet-and-init-card [this args])
   (pair [this args])
-  (generate-mnemonic [this args])
   (generate-and-load-key [this args])
   (unblock-pin [this args])
   (verify-pin [this args])

--- a/src/status_im/hardwallet/mnemonic.cljs
+++ b/src/status_im/hardwallet/mnemonic.cljs
@@ -1,81 +1,27 @@
 (ns status-im.hardwallet.mnemonic
-  (:require [clojure.string :as string]
-            [status-im.ethereum.mnemonic :as mnemonic]
-            [status-im.ui.screens.navigation :as navigation]
+  (:require [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
             [status-im.hardwallet.common :as common]
             status-im.hardwallet.fx))
 
-(fx/defn on-generate-mnemonic-success
-  {:events [:hardwallet.callback/on-generate-mnemonic-success]}
-  [{:keys [db] :as cofx} mnemonic]
-  (fx/merge cofx
-            {:db (-> db
-                     (assoc-in [:hardwallet :setup-step] :recovery-phrase)
-                     (assoc-in [:hardwallet :secrets :mnemonic] mnemonic))}
-            (common/clear-on-card-connected)
-            (navigation/navigate-replace-cofx :keycard-onboarding-recovery-phrase nil)))
-
 (fx/defn set-mnemonic
-  {:events [:test-mnemonic]}
   [{:keys [db] :as cofx}]
+  (log/debug "[hardwallet] set-mnemonic")
   (let [selected-id (get-in db [:intro-wizard :selected-id])
-        accounts    (get-in db [:intro-wizard :multiaccounts])
-        mnemonic    (->> accounts
-                         (filter (fn [{:keys [id]}]
-                                   (= id selected-id)))
-                         first
-                         :mnemonic)]
-    (fx/merge cofx
-              {:db (assoc-in db [:hardwallet :secrets :mnemonic] mnemonic)}
-              (on-generate-mnemonic-success mnemonic))))
-
-(fx/defn generate-mnemonic
-  {:events [:hardwallet/generate-mnemonic]}
-  [cofx]
-  (let [{:keys [pairing]} (get-in cofx [:db :hardwallet :secrets])]
-    {:hardwallet/generate-mnemonic {:pairing pairing
-                                    :words   (string/join "\n" mnemonic/dictionary)}}))
-
-(fx/defn proceed-with-generating-mnemonic
-  [{:keys [db] :as cofx}]
-  (let [pin (or (get-in db [:hardwallet :secrets :pin])
-                (common/vector->string (get-in db [:hardwallet :pin :current])))]
-    (if (empty? pin)
-      (fx/merge cofx
-                {:db (assoc-in db [:hardwallet :pin] {:enter-step  :current
-                                                      :on-verified :hardwallet/generate-mnemonic
-                                                      :current     []})}
-                (navigation/navigate-to-cofx :keycard-onboarding-pin nil))
-      (generate-mnemonic cofx))))
-
-(fx/defn load-generating-mnemonic-screen
-  {:events [:hardwallet/load-generating-mnemonic-screen]}
-  [{:keys [db] :as cofx}]
-  (fx/merge
-   cofx
-   {:db (assoc-in db [:hardwallet :setup-step] :generating-mnemonic)}
-   (common/show-connection-sheet
-    {:on-card-connected :hardwallet/load-generating-mnemonic-screen
-     :handler           (common/dispatch-event :hardwallet/generate-mnemonic)})))
-
-(fx/defn on-generate-mnemonic-error
-  {:events [:hardwallet.callback/on-generate-mnemonic-error]}
-  [{:keys [db] :as cofx} {:keys [error code]}]
-  (log/debug "[hardwallet] generate mnemonic error: " error)
-  (fx/merge cofx
-            {:db (assoc-in db [:hardwallet :setup-error] error)}
-            (common/set-on-card-connected :hardwallet/load-generating-mnemonic-screen)
-            (common/process-error code error)))
-
-(fx/defn proceed-to-generate-mnemonic
-  {:events [:hardwallet/proceed-to-generate-mnemonic]}
-  [{:keys [db] :as cofx}]
-  (log/debug "[hardwallet] proceed-to-generate-mnemonic")
-  (if (= (get-in db [:hardwallet :flow]) :create)
-    (load-generating-mnemonic-screen cofx)
-    {:db (assoc-in db [:hardwallet :setup-step] :recovery-phrase)}))
+        mnemonic (reduce
+                  (fn [_ {:keys [id mnemonic]}]
+                    (when (= selected-id id)
+                      (reduced mnemonic)))
+                  nil
+                  (get-in db [:intro-wizard :multiaccounts]))]
+    (fx/merge
+     cofx
+     {:db (-> db
+              (assoc-in [:hardwallet :setup-step] :recovery-phrase)
+              (assoc-in [:hardwallet :secrets :mnemonic] mnemonic))}
+     (common/clear-on-card-connected)
+     (navigation/navigate-replace-cofx :keycard-onboarding-recovery-phrase nil))))
 
 (fx/defn load-loading-keys-screen
   {:events [:hardwallet.ui/recovery-phrase-confirm-pressed

--- a/src/status_im/hardwallet/onboarding.cljs
+++ b/src/status_im/hardwallet/onboarding.cljs
@@ -215,24 +215,6 @@
         (show-recover-confirmation))
       {:db (assoc-in db [:hardwallet :recovery-phrase :confirm-error] (i18n/label :t/wrong-word))})))
 
-(fx/defn card-ready-next-button-pressed
-  {:events [:hardwallet.ui/card-ready-next-button-pressed]}
-  [{:keys [db] :as cofx}]
-  (log/debug "[hardwallet] card-ready-next-button-pressed")
-  (let [pin (get-in db [:hardwallet :secrets :pin])
-        pin-already-set? (boolean pin)]
-    (if pin-already-set?
-      (if (= (get-in db [:hardwallet :flow]) :create)
-        (mnemonic/load-generating-mnemonic-screen cofx)
-        {:db (assoc-in db [:hardwallet :setup-step] :recovery-phrase)})
-      (fx/merge cofx
-                {:db (-> db
-                         (assoc-in [:hardwallet :setup-step] :pin)
-                         (assoc-in [:hardwallet :pin :enter-step] :current)
-                         (assoc-in [:hardwallet :pin :on-verified] :hardwallet/proceed-to-generate-mnemonic)
-                         (assoc-in [:hardwallet :pin :current] [])
-                         (assoc-in [:hardwallet :pin :original] nil))}))))
-
 (fx/defn recovery-phrase-next-button-pressed
   [{:keys [db] :as cofx}]
   (if (= (get-in db [:hardwallet :flow]) :create)

--- a/src/status_im/hardwallet/real_keycard.cljs
+++ b/src/status_im/hardwallet/real_keycard.cljs
@@ -85,14 +85,6 @@
         (then on-success)
         (catch on-failure))))
 
-(defn generate-mnemonic
-  [{:keys [pairing words on-success on-failure]}]
-  (when pairing
-    (.. status-keycard
-        (generateMnemonic pairing words)
-        (then on-success)
-        (catch on-failure))))
-
 (defn generate-and-load-key
   [{:keys [mnemonic pairing pin on-success on-failure]}]
   (when pairing
@@ -227,8 +219,6 @@
     (install-applet-and-init-card args))
   (keycard/pair [this args]
     (pair args))
-  (keycard/generate-mnemonic [this args]
-    (generate-mnemonic args))
   (keycard/generate-and-load-key [this args]
     (generate-and-load-key args))
   (keycard/unblock-pin [this args]

--- a/src/status_im/hardwallet/simulated_keycard.cljs
+++ b/src/status_im/hardwallet/simulated_keycard.cljs
@@ -86,8 +86,6 @@
   (when (= password kk1-password)
     (later #(on-success kk1-pair))))
 
-(defn generate-mnemonic [args])
-
 (defn generate-and-load-key [{:keys [pin pairing on-success]}]
   (when (and (= pin (get @state :pin))
              (= pairing kk1-pair))
@@ -152,8 +150,6 @@
     (install-applet-and-init-card args))
   (keycard/pair [this args]
     (pair args))
-  (keycard/generate-mnemonic [this args]
-    (generate-mnemonic args))
   (keycard/generate-and-load-key [this args]
     (generate-and-load-key args))
   (keycard/unblock-pin [this args]


### PR DESCRIPTION
Usage of `Keycard.generateMnemonic` is removed from the code as we
always generate new multiaccounts on status-go side. Previously it was
misused and was called with intention of generation of mnemonic for an
existing keycard multiacc.

fixes #10409

status: ready