### PR TITLE
fix: make token icons consistent

### DIFF
--- a/src/status_im/ui/components/list/styles.cljs
+++ b/src/status_im/ui/components/list/styles.cljs
@@ -39,6 +39,11 @@
   {:width         image-size
    :height        image-size})
 
+(def item-token-icon
+  {:border-radius 50
+   :border-color  "rgba(0,0,0,0.1)"
+   :border-width  1})
+
 (def big-item-image
   {:width         image-size
    :height        image-size

--- a/src/status_im/ui/components/list/views.cljs
+++ b/src/status_im/ui/components/list/views.cljs
@@ -67,6 +67,11 @@
   [react/view {:style style}
    [react/image {:source (if (fn? source) (source) source)
                  :style  (merge styles/item-image image-style)}]])
+(defn item-token-icon
+  [{:keys [source style image-style]}]
+  (item-image {:source      source
+               :style       style
+               :image-style (merge image-style styles/item-token-icon)}))
 ;;TODO DEPRECATED, use status-im.ui.components.list-item.views
 (defn item-primary
   ([s] (item-primary nil s))

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -82,7 +82,7 @@
                                        [react/text {:style {:color colors/gray}} (if value value 0)])
                                      [react/text {:style {:color colors/gray}} (str " " currency)]]
               :icon                 (if icon
-                                      [list/item-image icon]
+                                      [list/item-token-icon icon]
                                       [chat-icon/custom-icon-view-list (:name token) color])}
        on-press
        (assoc :on-press #(on-press token)))]))

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -44,8 +44,8 @@
                                         :margin-left    16}
                   :accessibility-label :choose-asset-button}
       (if icon
-        [list/item-image (assoc icon :style {:background-color colors/gray-lighter
-                                             :border-radius    50} :image-style {:width 32 :height 32})]
+        [list/item-token-icon (assoc icon :style {:background-color colors/gray-lighter
+                                                  :border-radius    50} :image-style {:width 32 :height 32})]
         [chat-icon/custom-icon-view-list name color 32])
       [react/text {:style {:margin-left 8}}
        (wallet.utils/display-symbol token)]


### PR DESCRIPTION
Fixes #9832

### Summary
Ensure token icons are consistent across the app, by adding a 1px 10% opacity #000000 inner border to all token icons.

### Testing notes
#### Platforms
- all

#### Areas that maybe impacted
- Wallet screens

status: ready