### PR TITLE
fix(multiaccounts/login): ensure log-level is updated correctly

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -25,6 +25,7 @@
             [status-im.utils.handlers :as handlers]
             [status-im.utils.identicon :as identicon]
             [status-im.utils.keychain.core :as keychain]
+            [status-im.utils.logging.core :as logging]
             [status-im.utils.platform :as platform]
             [status-im.utils.security :as security]
             [status-im.utils.types :as types]
@@ -210,6 +211,7 @@
               (contact/initialize-contacts)
               (stickers/init-stickers-packs)
               (mobile-network/on-network-status-change)
+              (logging/set-log-level multiaccount)
               (multiaccounts/switch-preview-privacy-mode-flag))))
 
 (defn get-new-auth-method [auth-method save-password?]
@@ -270,6 +272,7 @@
                                              :mailserver-topics {}
                                              :default-mailserver true})
               (multiaccounts/switch-preview-privacy-mode-flag)
+              (logging/set-log-level multiaccount)
               (when-not platform/desktop?
                 (initialize-wallet accounts nil)))))
 

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -487,8 +487,7 @@
  :log-level/current-log-level
  :<- [:multiaccount]
  (fn [multiaccount]
-   (or (get multiaccount :log-level)
-       config/log-level-status-go)))
+   (get multiaccount :log-level)))
 
 (re-frame/reg-sub
  :waku/enabled

--- a/src/status_im/utils/logging/core.cljs
+++ b/src/status_im/utils/logging/core.cljs
@@ -42,6 +42,21 @@
     (get-js-logs)
     #(re-frame/dispatch [callback-handler %]))))
 
+(re-frame/reg-fx
+ :logs/set-level
+ (fn [log-level]
+   (log/set-level! log-level)))
+
+(fx/defn set-log-level
+  [{:keys [db]}  multiaccount]
+  (let [log-level (if-let [level (get multiaccount :log-level)]
+                    (if (clojure.string/blank? level) "ERROR" level)
+                    config/log-level-status-go)]
+    {:db (assoc-in db [:multiaccount :log-level] log-level)
+     :logs/set-level (-> log-level
+                         clojure.string/lower-case
+                         keyword)}))
+
 (fx/defn send-logs
   [{:keys [db]}]
   ;; TODO: Add message explaining db export


### PR DESCRIPTION
As reported in #10127 there's an issue that the log level isn't properly
applied when changed through log settings UI.

Turned out that we're setting the log-level only once in the entire
lifetime of the application and that is during bootstrap.
When the log level is changed through the UI, we never actually update
the log level in the logger module.

To fix this, we just need to ensure that, whenever the log-level is changed,
we also call `log/set-level!` with the new level.

It should also be noted that, every time the log level is changed through
the UI, the user is logged out, so one place to update the logger is
after very successful login.

Fixes #10127