### PR TITLE
fix: carousel image height on narrow devices

### DIFF
--- a/src/status_im/ui/screens/intro/styles.cljs
+++ b/src/status_im/ui/screens/intro/styles.cljs
@@ -29,9 +29,11 @@
    :text-align    :center
    :margin-bottom 16})
 
-(def wizard-text
-  {:color       colors/gray
-   :text-align  :center})
+(defn wizard-text [height]
+  (merge {:color      colors/gray
+          :text-align :center}
+         (when-not (zero? height)
+           {:height height})))
 
 (def welcome-text-bottom-note
   {:typography  :caption


### PR DESCRIPTION
Fixes #10427

### Summary
Narrow devices were causing text in the intro carousel to grow to two lines on *the first* slide but not others, causing the height to be recalculated incorrectly on the last slide (that only had one line of text).

Create a vector of atoms that can individually track the heights required for each slide independently.

#### Screenshots during testing
iPhone SE (2nd gen)
![iPhone SE (2nd gen)](https://imgur.com/pfEScXS.png)
iPhone 11
![iPhone 11](https://imgur.com/NxENAdi.png)
Nexus One
![Nexus One](https://imgur.com/jgEL7mw.png)
Pixel 2
![Pixel 2](https://imgur.com/oNC96pw.png)

### Testing notes
#### Areas that maybe impacted
- Intro screen

status: ready