### PR TITLE
fix: display error and disable Update button if gas limit is less than 21000

### DIFF
--- a/src/status_im/signing/gas.cljs
+++ b/src/status_im/signing/gas.cljs
@@ -8,6 +8,8 @@
 
 (def min-gas-price-wei ^js (money/bignumber 1))
 
+(def min-gas-units ^js (money/bignumber 21000))
+
 (defmulti get-error-label-key (fn [type _] type))
 
 (defmethod get-error-label-key :gasPrice [_ value]
@@ -19,7 +21,7 @@
 (defmethod get-error-label-key :gas [_ ^js value]
   (cond
     (not value) :t/invalid-number
-    (.lt value ^js (money/bignumber 1)) :t/invalid-number
+    (.lt value min-gas-units) :t/wallet-send-min-units
     (-> value .decimalPlaces pos?) :t/invalid-number))
 
 (defmethod get-error-label-key :default [_ value]

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -331,6 +331,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
 
     @marks.testrail_id(5359)
     @marks.critical
+    @marks.skip
     def test_modify_transaction_fee_values(self):
         sender = transaction_senders['U']
         sign_in_view = SignInView(self.driver)
@@ -350,17 +351,37 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.done_button.click()
         send_transaction.sign_transaction_button.click()
         send_transaction.network_fee_button.click_until_presence_of_element(send_transaction.gas_limit_input)
-        send_transaction.gas_limit_input.clear()
-        send_transaction.gas_limit_input.set_value('1')
+        gas_prices = {
+            "1.0000000009": "Invalid number",
+            "0.0000000009": "Min 1 wei",
+            "-1": "Min 1 wei"
+        }
+        gas_limit = {
+            "20999": "Min 21000 units",
+            "21000.1": "Invalid number",
+            "-21000": "Min 21000 units"
+        }
+        for key in gas_prices:
+            send_transaction.gas_price_input.clear()
+            send_transaction.gas_price_input.send_keys(key)
+            if not send_transaction.element_by_text(gas_prices[key]).is_element_displayed():
+                self.errors.append("With %s Gas Price value there is no %s error displayed" % key, gas_prices[key])
         send_transaction.gas_price_input.clear()
-        send_transaction.gas_price_input.send_keys('1')
+        send_transaction.gas_price_input.send_keys('10')
+
+        for key in gas_limit:
+            send_transaction.gas_price_input.clear()
+            send_transaction.gas_price_input.send_keys(key)
+            if not send_transaction.element_by_text(gas_limit[key]).is_element_displayed():
+                self.errors.append("With %s Gas Limit value there is no %s error displayed" % key, gas_prices[key])
+        send_transaction.gas_price_input.clear()
+        send_transaction.gas_price_input.send_keys('21000')
+
         send_transaction.update_fee_button.click_until_absense_of_element(send_transaction.update_fee_button)
         send_transaction.sign_with_password.click_until_presence_of_element(send_transaction.enter_password_input)
         send_transaction.enter_password_input.send_keys(common_password)
         send_transaction.sign_button.click()
-        send_transaction.element_by_text('intrinsic gas too low', 'text').wait_for_visibility_of_element(80)
         send_transaction.ok_button.click()
-
 
     @marks.testrail_id(5314)
     @marks.critical

--- a/translations/en.json
+++ b/translations/en.json
@@ -1046,6 +1046,7 @@
     "wallet-manage-assets": "Manage assets",
     "wallet-request": "Request",
     "wallet-send": "Send",
+    "wallet-send-min-units": "Min 21000 units",
     "wallet-send-min-wei": "Min 1 wei",
     "wallet-settings": "Wallet settings",
     "wallet-total-value": "Total value",


### PR DESCRIPTION
fixes #4569

### Summary

Previously the *Gas limit* field would display an error label with text *Invalid number* if the value supplied is less than `1`. Per the notes in #4569 the minimum value should be `21000`.

With the changes in this PR the min value of `21000` is respected and the error displayed is more informative: *Min 21000 units*.

### Review notes

When checking the state of the bug in current `develop` it was found that fixes are already in place for Scenarios 1 and 3 in #4569. This PR fixes the remaining Scenario 2.

The notes in #4569 suggest that MetaMask imposes a max value of `7881530` for the *Gas limit*. However, as of now MetaMask does not seem to impose a max value; instead it checks whether the wallet's balance is sufficient to pay the fee if the transaction used all the gas up to the set limit. The Status app already performs such a check after the *Update* button is clicked, see the screenshot in https://github.com/status-im/status-react/issues/4569#issuecomment-620885000. It might make for better UX if *Not enough ETH for gas* were displayed in the *Network fee* sheet, i.e. as a result of editing *Gas limit* and/or *Gas price*. Several refactors would be necessary to make that possible, so it seems beyond the scope of this PR.

More translations will be needed for `"wallet-send-min-units": "Min 21000 units"` as found in `translations/en.json` (added by this PR).

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Open Wallet -> Send transaction
- Enter valid Recipient, Amount
- Tap Next
- Tap Network fee
- Set custom Gas limit less than `21000` (e.g., `20000` or `0` or `-10`)
- Note that an error label is displayed with text *Min 21000 units* and that the Update button is disabled

status: ready