### PR TITLE
[#10255] Keycard is not optimized for Dark mode 

### DIFF
--- a/src/status_im/signing/keycard.cljs
+++ b/src/status_im/signing/keycard.cljs
@@ -85,6 +85,6 @@
               (assoc-in [:hardwallet :pin :enter-step] :sign)
               (assoc-in [:signing/sign :type] :keycard)
               (assoc-in [:signing/sign :keycard-step] :pin))}
-     (if message
-       (hash-message message nil)
-       (hash-transaction)))))
+     #(if message
+        (hash-message % message)
+        (hash-transaction %)))))

--- a/src/status_im/ui/screens/keycard/styles.cljs
+++ b/src/status_im/ui/screens/keycard/styles.cljs
@@ -3,5 +3,4 @@
 
 (def container
   {:flex             1
-   :justify-content  :space-between
-   :background-color colors/white})
+   :justify-content  :space-between})

--- a/src/status_im/ui/screens/signing/views.cljs
+++ b/src/status_im/ui/screens/signing/views.cljs
@@ -126,7 +126,7 @@
 
 (defn- keycard-view
   [{:keys [keycard-step]} phrase]
-  [react/view {:height 520}
+  [react/view
    [signing-phrase-view phrase]
    (case keycard-step
      :pin     [keycard-pin-view]


### PR DESCRIPTION

fixes #10255

also fixed keycard crash on message signing and fixed height of bottom sheet