### PR TITLE
Update react-native-webview to 9.4.0

### DIFF
--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -53,7 +53,7 @@
     "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.21",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
-    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v8.0.7_6",
+    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v9.4.0_1",
     "web3-utils": "^1.2.1"
   },
   "devDependencies": {

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -6594,9 +6594,9 @@ react-native-touch-id@^4.4.1:
   resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz#8b1bb2d04c30bac36bb9696d2d723e719c4a8b08"
   integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
 
-"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v8.0.7_6":
-  version "8.0.7"
-  resolved "git+https://github.com/status-im/react-native-webview.git#5578e63fc609b770408ddbdead5a4a211c45218b"
+"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v9.4.0_1":
+  version "9.4.0"
+  resolved "git+https://github.com/status-im/react-native-webview.git#2e2d03e03fb299b19aafc6f34c88df2b30896dcf"
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
Fixes #10556 

Updated react-native-webview with incorrect URL processing fixes ported from react-native-webview-bridge: https://github.com/status-im/react-native-webview/commit/2e2d03e03fb299b19aafc6f34c88df2b30896dcf. Also rebased it with latest upstream version (9.4.0)