### PR TITLE
unify multiple Makefile targets

### DIFF
--- a/STARTING_GUIDE.md
+++ b/STARTING_GUIDE.md
@@ -21,11 +21,11 @@ For more `make` targets run `make help`.
 
 There are three steps necessary to start development, in this case for Android:
 
-1. `make startdev-android-real` - Compiles Clojure into JavaScript for real device
-2. `make react-native-android` - Watches JavaScript code and updates the App
+1. `make run-clojure` - Compiles Clojure into JavaScript, watches for changes on cljs files, and hot-reloads code in the app
+2. `make run-metro` - Starts metro bundler and watches JavaScript code
 3. `make run-android` - Builds the Android app and starts it on the device
 
-The first two will continue watching for changes and keep re-building the app.
+The first two will continue watching for changes and keep re-building the app. They need to be ready first.
 The last one will exit once the app is up and ready.
 
 # Manual Steps

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -51,7 +51,7 @@ Developer updates `package.json` file with a new dependency using a GitHub URL. 
 ```
   "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#feature/exportKeyWithPath",
 ```
-Afterwards, when running e.g. `make react-native-android`, they might see the following confusing error:
+Afterwards, when running e.g. `make run-metro`, they might see the following confusing error:
 ```
 # macOS
 fatal: unable to access 'https://github.com/siphiuel/react-native-status-keycard.git/': SSL certificate problem: unable to get local issuer certificate

--- a/nix/mobile/android/jsbundle/default.nix
+++ b/nix/mobile/android/jsbundle/default.nix
@@ -2,11 +2,10 @@
 # This Nix expression builds the js files for the current repository given a node modules Nix expression
 #
 
-{ target ? "android"
-, stdenv, lib, deps, pkgs }:
+{ stdenv, lib, deps, pkgs }:
 
 stdenv.mkDerivation {
-  name = "status-react-build-jsbundle-${target}";
+  name = "status-react-build-jsbundle-android";
   src =
     let path = ./../../../..;
     in builtins.path { # We use builtins.path so that we can name the resulting derivation, otherwise the name would be taken from the checkout directory, which is outside of our control
@@ -55,10 +54,12 @@ stdenv.mkDerivation {
   buildPhase = ''
     # Assemble CLASSPATH from available clojure dependencies.
     # We append 'src' so it can find the local sources.
-    export CLASS_PATH="$(find ${deps.clojure} -iname '*.jar' | tr '\n' ':')src"
+    export CLASS_PATH="$(find ${deps.clojure} \
+      -iname '*.jar' | tr '\n' ':')src"
 
     # target must be one of the builds defined in shadow-cljs.edn
-    java -cp "$CLASS_PATH" clojure.main -m shadow.cljs.devtools.cli release ${target}
+    java -cp "$CLASS_PATH" clojure.main \
+      -m shadow.cljs.devtools.cli release mobile
   '';
   installPhase = ''
     mkdir -p $out

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -20,6 +20,7 @@ let
       # core utilities that should always be present in a shell
       bash curl wget file unzip flock rsync
       git gnumake jq ncurses gnugrep parallel
+      lsof # used in start-react-native.sh
       # build specific utilities
       clojure maven watchman
       # other nice to have stuff

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -32,10 +32,10 @@
 
  :cache-blockers #{status-im.utils.js-resources}
 
- :builds {:android
+ :builds {:mobile
           {:target :react-native
            :output-dir "app"
-           :init-fn status-im.android.core/init
+           :init-fn status-im.core/init
            :dev {:devtools {:after-load status-im.reloader/reload
                             :preloads [re-frisk-remote.preload]}
                  :compiler-options {:closure-defines
@@ -50,27 +50,6 @@
                                         ;;disable for android build as there
                                         ;;is an intermittent warning with deftype
                                         :warnings-as-errors false
-                                        :infer-externs :auto
-                                        :static-fns true
-                                        :fn-invoke-direct true
-                                        :optimizations :advanced
-                                        :js-options {:js-provider :closure}}}}
-          :ios
-          {:target :react-native
-           :output-dir "app"
-           :init-fn status-im.ios.core/init
-           :dev {:devtools {:after-load status-im.reloader/reload
-                            :preloads [re-frisk-remote.preload]}
-                 :compiler-options {:closure-defines
-                                    {re-frame.trace/trace-enabled? true}
-                                    :source-map false}
-                 ;; if you want to use a real device, set your local ip
-                 ;; in the SHADOW_HOST env variable to make sure that
-                 ;; it will use the right interface
-                 :local-ip #shadow/env "SHADOW_HOST"}
-           :chunks {:fleets status-im.default-fleet/default-fleets}
-           :release {:compiler-options {:output-feature-set :es6
-                                        :warnings-as-errors true
                                         :infer-externs :auto
                                         :static-fns true
                                         :fn-invoke-direct true

--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -1,7 +1,0 @@
-(ns status-im.android.core
-  (:require [status-im.native-module.core :as status]
-            [status-im.core :as core]))
-
-(defn init []
-  (status/set-soft-input-mode status/adjust-resize)
-  (core/init core/root))

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -11,6 +11,7 @@
             [reagent.core :as reagent]
             [reagent.impl.batching :as batching]
             [status-im.i18n :as i18n]
+            [status-im.native-module.core :as status]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.views :as views]
             [status-im.utils.error-handler :as error-handler]
@@ -77,10 +78,12 @@
     :display-name "root"
     :reagent-render views/main}))
 
-(defn init [app-root]
+(defn init []
   (utils.logs/init-logs)
   (error-handler/register-exception-handler!)
   (enableScreens)
   (re-frame/dispatch-sync [:init/app-started])
-  (.registerComponent ^js app-registry "StatusIm" #(reagent/reactify-component app-root))
+  (when platform/android?
+    (status/set-soft-input-mode status/adjust-resize))
+  (.registerComponent ^js app-registry "StatusIm" #(reagent/reactify-component root))
   (snoopy/subscribe!))

--- a/src/status_im/desktop/core.cljs
+++ b/src/status_im/desktop/core.cljs
@@ -1,14 +1,19 @@
 (ns status-im.desktop.core
   (:require [reagent.core :as reagent]
             [re-frame.core :as re-frame]
+            ["react-native" :as rn]
             status-im.utils.db
             status-im.subs
             [status-im.ui.screens.views :as views]
             [status-im.ui.components.react :as react]
-            [status-im.core :as core]
+            [status-im.utils.snoopy :as snoopy]
+            [status-im.utils.error-handler :as error-handler]
+            [status-im.utils.logging.core :as utils.logs]
             [status-im.ui.screens.desktop.views :as desktop-views]
             [status-im.desktop.deep-links :as deep-links]
             [status-im.utils.config :as config]))
+
+(def app-registry (.-AppRegistry rn))
 
 (defn app-state-change-handler [state]
   (re-frame/dispatch [:app-state-change state]))
@@ -34,4 +39,8 @@
                              desktop-views/main)})))
 
 (defn init []
-  (core/init app-root))
+  (utils.logs/init-logs)
+  (error-handler/register-exception-handler!)
+  (re-frame/dispatch-sync [:init/app-started])
+  (.registerComponent ^js app-registry "StatusIm" #(reagent/reactify-component app-root))
+  (snoopy/subscribe!))

--- a/src/status_im/ios/core.cljs
+++ b/src/status_im/ios/core.cljs
@@ -1,5 +1,0 @@
-(ns status-im.ios.core
-  (:require [status-im.core :as core]))
-
-(defn init []
-  (core/init core/root))


### PR DESCRIPTION
Simplifies `Makefile` target by getting rid of a bunch of platform-dependent ones in favor of mobile-wide ones like `run-clojure` or `run-metro`. Done with Clojure help from @Ferossgp.

Changes:
- Drop a bunch of `watch-{android,ios}-*` tagets
- Replace them with one `run-clojure`
- Drop a bunch of `react-native-*` targets
- Replace them with one `run-metro`
- Replace `run-{android,ios}` with `run-{android,ios}`
- Drop `startdev-{android,ios,desktop}*` targets
- Drop `prod-build-{android,ios}` as deprecated
- Drop `src/status_im/android/core.cljs`
- Drop `src/status_im/ios/core.cljs`
- Move `lsof` tool to `default` shell
- Replace them with one `init` from `src/status_im/core.cljs`
- Use `init` in one `shadow-cljs.edn` target `mobile`
- Use `mobile` target in `nix/mobile/android/jsbundle`
- Update instructions in `STARTING_GUIDE.md`

And here's a matching website docs update: https://github.com/status-im/status.im/pull/508