### PR TITLE
fix #10591 error when scrolling account view

### DIFF
--- a/src/status_im/ui/screens/wallet/account/styles.cljs
+++ b/src/status_im/ui/screens/wallet/account/styles.cljs
@@ -32,7 +32,7 @@
    anim-y
    {:toValue 0
     :duration 200
-    :easing (.-ease ^js (animation/easing))
+    :easing (.-ease ^js animation/easing)
     :useNativeDriver true}))
 
 (defn bottom-send-recv-buttons-lower [anim-y y]
@@ -40,5 +40,5 @@
    anim-y
    {:toValue y
     :duration 200
-    :easing (.-ease ^js (animation/easing))
+    :easing (.-ease ^js animation/easing)
     :useNativeDriver true}))


### PR DESCRIPTION
fixes #10591 

### Summary

Steps:

- create new multiaccount
- open wallet > manage assets > add several different assets (>5)
- open Status account
- scroll