### PR TITLE
disable hermes warnings that dump translations to stdout

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,7 +79,12 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.Copy
 project.ext.react = [
     nodeExecutableAndArgs: ["node", "--max-old-space-size=16384"],
     entryFile: "index.js",
-    enableHermes: true,     // clean and rebuild if changing. NOTE: Hermes engine is required for Android 64-bit builds running on 64 devices, to guard against a hang in the UI thread after invoking status-go
+    /* NOTE: Hermes engine is required for Android 64-bit builds running on 64 devices,
+     *       to guard against a hang in the UI thread after invoking status-go.
+     * Also a clean and rebuild is required when changing this. */
+    enableHermes: true,
+    /* Disable 'The first definition was here.' warnings */
+    hermesFlagsRelease: ["-w"],
     bundleInPr: true,
     inputExcludes: ["android/**", "ios/**", "react-native/**", "src/**", "test/**"]
 ]


### PR DESCRIPTION
These kinds of warnings dump minified translation files to stdout:
```
/build/android/app/build/generated/assets/react/pr/index.android.bundle:943:1256:
    warning: The first definition was here.
__d(function(e,t,a,n,o,r,s){o.exports={"about-app":"About","about-key-storage-content":"Status will never access your private key. Be sure to backup your seed phrase. If you lose your phone it is the only way to access your keys.","about-key-storage-title":"About key storage","about-names-content":"No one can pretend to be you! You\u2019re anonymous by default and never have to reveal your real name. You can register a custom name for a small fee."...
```

Details: https://github.com/facebook/hermes/issues/216

Also, long comments that go beyond reasonable 80-90 characters are literally cancer.