### PR TITLE
Do not use signer arg for keycard_signTypedData

### DIFF
--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -325,7 +325,11 @@
   (let [message?      (constants/web3-sign-message? method)
         dapps-address (get-in cofx [:db :multiaccount :dapps-address])]
     (if (or message? (= constants/web3-send-transaction method))
-      (let [[address data] (when message? (normalize-sign-message-params params))]
+      (let [[address data] (cond (= method constants/web3-keycard-sign-typed-data)
+                                 ;; We don't use signer argument for keycard sign-typed-data
+                                 ["0x0" params]
+                                 message? (normalize-sign-message-params params)
+                                 :else [nil nil])]
         (when (or (not message?) (and address data))
           (signing/sign cofx (merge
                               (if message?

--- a/src/status_im/ui/screens/signing/views.cljs
+++ b/src/status_im/ui/screens/signing/views.cljs
@@ -148,7 +148,7 @@
                    :signing :t/try-keeping-the-card-still
                    :error :t/tap-card-again
                    :success :t/transaction-signed)]
-    [react/view (assoc styles/message :padding-vertical 16 :align-items :center)
+    [react/view (assoc (styles/message) :padding-vertical 16 :align-items :center)
      [react/view {:style {:align-self :flex-start :padding-left 16 :margin-bottom 24}}
       [react/text {:style {:font-size (if small-screen? 15 17) :font-weight "700"}}
        (i18n/label :t/confirmation-request)]]


### PR DESCRIPTION
Fixes #10245 

The signature for `keycard_signTypedData` is changed from
```
ethereum.send("keycard_signTypedData", [account, JSON.stringify(params(chainId))]);
```
to
```
ethereum.send("keycard_signTypedData", JSON.stringify(params(chainId)));
```