### PR TITLE
Denormalize message on replying

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -75,11 +75,11 @@
 
 (fx/defn reply-to-message
   "Sets reference to previous chat message and focuses on input"
-  [{:keys [db] :as cofx} message-id]
+  [{:keys [db] :as cofx} message]
   (let [current-chat-id (:current-chat-id db)]
     (fx/merge cofx
               {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message]
-                             {:message-id     message-id})}
+                             message)}
               (chat-input-focus :input-ref))))
 
 (fx/defn cancel-message-reply

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -546,8 +546,8 @@
 
 (handlers/register-handler-fx
  :chat.ui/reply-to-message
- (fn [cofx [_ message-id]]
-   (chat.input/reply-to-message cofx message-id)))
+ (fn [cofx [_ message]]
+   (chat.input/reply-to-message cofx message)))
 
 (handlers/register-handler-fx
  :chat.ui/send-current-message

--- a/src/status_im/i18n_resources.cljs
+++ b/src/status_im/i18n_resources.cljs
@@ -13,8 +13,7 @@
    (conj #{:en} default-device-language)))
 
 (def translations
-  {
-   :ar         (js/require "../translations/ar.json")
+  {:ar         (js/require "../translations/ar.json")
    :en         (js/require "../translations/en.json")
    :es         (js/require "../translations/es.json")
    :es_419     (js/require "../translations/es_419.json")
@@ -47,7 +46,7 @@
 ;; translations
 (def translations-by-locale
   (cond->
-      {:en (require-translation :en)}
+   {:en (require-translation :en)}
     (not= :en default-device-language)
     (assoc default-device-language
            (require-translation (-> (name default-device-language)

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -834,8 +834,8 @@
 (re-frame/reg-sub
  :chats/reply-message
  :<- [:chats/current-chat]
- (fn [{:keys [metadata messages]}]
-   (get messages (get-in metadata [:responding-to-message :message-id]))))
+ (fn [{:keys [metadata]}]
+   (:responding-to-message metadata)))
 
 (re-frame/reg-sub
  :public-chat.new/topic-error-message

--- a/src/status_im/ui/screens/chat/sheets.cljs
+++ b/src/status_im/ui/screens/chat/sheets.cljs
@@ -162,7 +162,7 @@
        :accessibility-label :delete-transaction-button
        :on-press            #(hide-sheet-and-dispatch [:chat.ui/delete-message chat-id message-id])}]]))
 
-(defn message-long-press [{:keys [message-id content identicon from outgoing]}]
+(defn message-long-press [{:keys [content identicon from outgoing] :as message}]
   (fn []
     (let [{:keys [ens-name alias]} @(re-frame/subscribe [:contacts/contact-name-by-identity from])]
       [react/view
@@ -180,7 +180,7 @@
         {:theme    :action
          :title    :t/message-reply
          :icon     :main-icons/reply
-         :on-press #(hide-sheet-and-dispatch [:chat.ui/reply-to-message message-id])}]
+         :on-press #(hide-sheet-and-dispatch [:chat.ui/reply-to-message message])}]
        [list-item/list-item
         {:theme    :action
          :title    :t/sharing-copy-to-clipboard


### PR DESCRIPTION
Before we stored only the message-id and had a subscription pulling the
message from the database when replying to the message.
This broke once we implemented offloading of messages, as the message
might not be in the database anymore.
This commit fixes the issue by storing the full message in the database,
so in the event of it being offloaded it is still shown.

status: ready