### PR TITLE
nix: add missing Gradle repo path in gradle shell

### DIFF
--- a/android/gradlew
+++ b/android/gradlew
@@ -17,8 +17,8 @@ if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
 fi
 
 # Map mavenLocal() to the Nix maven repo we set up in nix/mobile/android/maven-and-npm-deps/default.nix
-if [ -n "$STATUSREACT_NIX_MAVEN_REPO" ]; then
-  repoOpts="-Dmaven.repo.local=${STATUSREACT_NIX_MAVEN_REPO}"
+if [ -n "${STATUS_NIX_MAVEN_REPO}" ]; then
+  repoOpts="-Dmaven.repo.local=${STATUS_NIX_MAVEN_REPO}"
 else
   repoOpts=''
 fi

--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -34,7 +34,7 @@ in {
       export ANDROID_SDK_ROOT="${androidPkgs}"
       export ANDROID_NDK_ROOT="${androidPkgs}/ndk-bundle"
 
-      export STATUSREACT_NIX_MAVEN_REPO="${deps.gradle}"
+      export STATUS_NIX_MAVEN_REPO="${deps.gradle}"
 
       # required by some makefile targets
       export STATUS_GO_ANDROID_LIBDIR=${status-go}

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -77,6 +77,7 @@ let
       inputsFrom = [ node-sh ];
       shellHook = ''
         export STATUS_GO_ANDROID_LIBDIR="DUMMY"
+        export STATUS_NIX_MAVEN_REPO="${pkgs.deps.gradle}"
         export ANDROID_SDK_ROOT="${pkgs.androidPkgs}"
         export ANDROID_NDK_ROOT="${pkgs.androidPkgs}/ndk-bundle"
       '';


### PR DESCRIPTION
The 0bec573eb36841d0ebdc5080b8b635d313ef5939 change cause issues when running `make nix-update-gradle`:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-community_clipboard'.
> Could not resolve all artifacts for configuration ':react-native-community_clipboard:classpath'.
   > Could not find com.android.tools.build:gradle:3.2.1.
```
The `android/gradlew` wrapper needs the path to Gradle repo to be set in the env.

Also renamed `STATUSREACT_NIX_MAVEN_REPO` to `STATUS_NIX_MAVEN_REPO`.