### PR TITLE
nix: use clojure shells for run-clojure and run-metro

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -15,15 +15,3 @@ automated-tests:
 
 github-team:
   slug: 'clojure'
-
-prchecklist:
-  title: Pull Request Checklist
-  checklist:
-    - '**Docs**: Updated the [documentation](https://status.im/build_status/), if affected'
-    - '**Docs**: Added or updated inline comments explaining intention of the code'
-    - '**Tests**: Ensured that all new UI elements have been assigned accessibility IDs'
-    - '**Tests**: Signaled need for E2E tests with label, if applicable'
-    - '**Tests**: Briefly described what was tested and what platforms were used'
-    - '**UI**: In case of UI changes, ensured that UI matches [Figma](https://www.figma.com/)'
-    - '**UI**: In case of UI changes, requested review from a Core UI designer'
-    - '**UI**: In case of UI changes, included screenshots of implementation'

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ status-go-desktop: ##@status-go Compile status-go for desktop app
 # Watch, Build & Review changes
 #--------------
 
-run-clojure: export TARGET := default
+run-clojure: export TARGET := clojure
 run-clojure: ##@run Watch for and build Clojure changes for mobile
 	yarn shadow-cljs watch mobile
 
@@ -221,7 +221,7 @@ run-clojure-desktop: export TARGET ?= $(HOST_OS)
 run-clojure-desktop: #@run Watch for and build Clojure changes for desktop
 	clj -R:dev build.clj watch --platform desktop
 
-run-metro: export TARGET := default
+run-metro: export TARGET := clojure
 run-metro: ##@run Start Metro to build React Native changes
 	@scripts/start-react-native.sh
 


### PR DESCRIPTION
Otherwise we get issues with missing node modules.
```
 $ make run-clojure
yarn shadow-cljs watch mobile
Configuring Nix shell for target 'default'...
yarn run v1.22.4
error Command "shadow-cljs" not found.
```
This fixes it because `clojure` shell is merged with `node-sh`:
https://github.com/status-im/status-react/blob/5851fb0882d19f4033131eb6c93f53e7cefbc4e8/nix/shells.nix#L48-L54

EDIT: Also added removal of `prchecklist` from `.github/github-bot.yml`.