### PR TITLE
Chat view performance improvements

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -1,68 +1,10 @@
 (ns status-im.chat.db
-  (:require [clojure.set :as clojure.set]
-            [clojure.string :as clojure.string]
-            [status-im.group-chats.db :as group-chats.db]
-            [status-im.mailserver.constants :as mailserver.constants]
-            [status-im.multiaccounts.core :as multiaccounts]
-            [status-im.utils.identicon :as identicon]
-            [status-im.utils.gfycat.core :as gfycat]))
+  (:require [clojure.string :as clojure.string]
+            [status-im.mailserver.constants :as mailserver.constants]))
 
 (defn group-chat-name
   [{:keys [public? name]}]
   (str (when public? "#") name))
-
-(defn enrich-active-chat
-  [contacts {:keys [chat-id
-                    identicon
-                    alias
-                    group-chat] :as chat} current-public-key]
-  (if group-chat
-    (let [pending-invite-inviter-name
-          (group-chats.db/get-pending-invite-inviter-name contacts
-                                                          chat
-                                                          current-public-key)
-          inviter-name
-          (group-chats.db/get-inviter-name contacts
-                                           chat
-                                           current-public-key)]
-      (cond-> chat
-        pending-invite-inviter-name
-        (assoc :pending-invite-inviter-name pending-invite-inviter-name)
-        inviter-name
-        (assoc :inviter-name inviter-name)
-        :always
-        (assoc :chat-name (group-chat-name chat))))
-    (let [photo (if (seq identicon)
-                  identicon
-                  (identicon/identicon chat-id))
-          alias (if (seq alias)
-                  alias
-                  (gfycat/generate-gfy chat-id))
-          {contact-name :name :as contact}
-          (get contacts chat-id
-               {:public-key chat-id
-                :identicon photo
-                :alias alias
-                :name alias
-                :system-tags #{}})]
-      (-> chat
-          (assoc :contact contact
-                 :chat-name (multiaccounts/displayed-name contact)
-                 :name contact-name
-                 :identicon photo
-                 :alias alias)
-          (update :tags clojure.set/union (:tags contact))))))
-
-(defn active-chats
-  [contacts chats {:keys [public-key]}]
-  (reduce-kv (fn [acc chat-id {:keys [is-active] :as chat}]
-               (if is-active
-                 (assoc acc
-                        chat-id
-                        (enrich-active-chat contacts chat public-key))
-                 acc))
-             {}
-             chats))
 
 (defn datemark? [{:keys [type]}]
   (= type :datemark))

--- a/src/status_im/chat/db_test.cljs
+++ b/src/status_im/chat/db_test.cljs
@@ -1,7 +1,5 @@
 (ns status-im.chat.db-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [status-im.utils.gfycat.core :as gfycat]
-            [status-im.utils.identicon :as identicon]
             [status-im.chat.db :as db]))
 
 (deftest group-chat-name
@@ -40,18 +38,6 @@
              (:datemark m4)))
       (is (= {:type :datemark
               :value "Dec 31, 1999"} d2)))))
-
-(deftest active-chats-test
-  (with-redefs [gfycat/generate-gfy (constantly "generated")
-                identicon/identicon (constantly "generated")]
-    (let [active-chat-1 {:is-active true :chat-id "1"}
-          active-chat-2 {:is-active true :chat-id "2"}
-          chats         {"1" active-chat-1
-                         "2" active-chat-2
-                         "3" {:is-active false :chat-id "3"}}]
-      (testing "it returns only chats with is-active"
-        (is (= #{"1" "2"}
-               (set (keys (db/active-chats {} chats {})))))))))
 
 (deftest add-gaps
   (testing "empty state"

--- a/src/status_im/chat/models/message_seen.cljs
+++ b/src/status_im/chat/models/message_seen.cljs
@@ -41,8 +41,7 @@
     (when (seq loaded-unviewed-ids)
       (fx/merge cofx
                 {:db (reduce (fn [acc message-id]
-                               (assoc-in acc [:chats chat-id :messages
-                                              message-id :seen]
+                               (assoc-in acc [:messages chat-id message-id :seen]
                                          true))
                              db
                              loaded-unviewed-ids)}

--- a/src/status_im/chat/models_test.cljs
+++ b/src/status_im/chat/models_test.cljs
@@ -65,15 +65,15 @@
 
 (deftest clear-history-test
   (let [chat-id "1"
-        cofx    {:db {:chats {chat-id {:message-list            [{:something "a"}]
-                                       :last-message            {:clock-value 10}
+        cofx    {:db {:message-lists {chat-id [{:something "a"}]}
+                      :chats {chat-id {:last-message            {:clock-value 10}
                                        :unviewed-messages-count 1}}}}]
     (testing "it deletes all the messages"
       (let [actual (chat/clear-history cofx chat-id)]
-        (is (= {} (get-in actual [:db :chats chat-id :messages])))))
+        (is (= {} (get-in actual [:db :messages chat-id])))))
     (testing "it deletes all the message groups"
       (let [actual (chat/clear-history cofx chat-id)]
-        (is (= nil (get-in actual [:db :chats chat-id :message-list])))))
+        (is (= nil (get-in actual [:db :message-lists chat-id])))))
     (testing "it deletes unviewed messages set"
       (let [actual (chat/clear-history cofx chat-id)]
         (is (= 0 (get-in actual [:db :chats chat-id :unviewed-messages-count])))))
@@ -103,13 +103,13 @@
 
 (deftest remove-chat-test
   (let [chat-id "1"
-        cofx    {:db {:chats {chat-id {:last-message {:clock-value 10}
-                                       :messages {"1" {:clock-value 1}
-                                                  "2" {:clock-value 10}
-                                                  "3" {:clock-value 2}}}}}}]
+        cofx    {:db {:messages {chat-id {"1" {:clock-value 1}
+                                          "2" {:clock-value 10}
+                                          "3" {:clock-value 2}}}
+                      :chats {chat-id {:last-message {:clock-value 10}}}}}]
     (testing "it deletes all the messages"
       (let [actual (chat/remove-chat cofx chat-id)]
-        (is (= {} (get-in actual [:db :chats chat-id :messages])))))
+        (is (= {} (get-in actual [:db :messages chat-id])))))
     (testing "it sets a deleted-at-clock-value equal to the last message clock-value"
       (let [actual (chat/remove-chat cofx chat-id)]
         (is (= 10 (get-in actual [:db :chats chat-id :deleted-at-clock-value])))))
@@ -147,9 +147,10 @@
 
 (def test-db
   {:multiaccount {:public-key "me"}
+
+   :messages {"status" {"4" {} "5" {} "6" {}}}
    :chats {"status" {:public? true
                      :group-chat true
-                     :messages {"4" {} "5" {} "6" {}}
                      :loaded-unviewed-messages-ids #{"6" "5" "4"}}
            "opened" {:loaded-unviewed-messages-ids #{}}
            "1-1"    {:loaded-unviewed-messages-ids #{"6" "5" "4"}}}})

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -16,10 +16,16 @@
                           group-chat private-group-chat-type
                           :else one-to-one-chat-type)))
 
-(defn rpc->type [{:keys [chatType] :as chat}]
+(defn rpc->type [{:keys [chatType name] :as chat}]
   (cond
-    (= public-chat-type chatType) (assoc chat :public? true :group-chat true)
-    (= private-group-chat-type chatType) (assoc chat :public? false :group-chat true)
+    (= public-chat-type chatType) (assoc chat
+                                         :chat-name (str "#" name)
+                                         :public? true
+                                         :group-chat true)
+    (= private-group-chat-type chatType) (assoc chat
+                                                :chat-name name
+                                                :public? false
+                                                :group-chat true)
     :else (assoc chat :public? false :group-chat false)))
 
 (defn- marshal-members [{:keys [admins contacts members-joined chatType] :as chat}]
@@ -68,11 +74,10 @@
                                 :deleted-at-clock-value :deletedAtClockValue
                                 :is-active :active
                                 :last-clock-value :lastClockValue})
-      (dissoc :message-list :gaps-loaded? :pagination-info
-              :public? :group-chat :messages
+      (dissoc :public? :group-chat :messages
               :might-have-join-time-messages?
               :loaded-unviewed-messages-ids
-              :messages-initialized? :contacts :admins :members-joined)))
+              :contacts :admins :members-joined)))
 
 (defn <-rpc [chat]
   (-> chat

--- a/src/status_im/data_store/chats_test.cljs
+++ b/src/status_im/data_store/chats_test.cljs
@@ -5,7 +5,6 @@
 (deftest ->to-rpc
   (let [chat {:public? false
               :group-chat true
-              :message-list []
               :color "color"
               :contacts #{"a" "b" "c" "d"}
               :last-clock-value 10
@@ -13,15 +12,11 @@
               :members-joined #{"a" "c"}
               :name "name"
               :membership-update-events :events
-              :gaps-loaded? true
               :unviewed-messages-count 2
               :is-active true
-              :messages {}
-              :pagination-info {}
               :chat-id "chat-id"
               :loaded-unviewed-messages-ids []
-              :timestamp 2
-              :messages-initialized? true}
+              :timestamp 2}
         expected-chat {:id "chat-id"
                        :color "color"
                        :name "name"
@@ -73,6 +68,7 @@
         expected-chat {:public? false
                        :group-chat true
                        :color "color"
+                       :chat-name "name"
                        :contacts #{"a" "b" "c" "d"}
                        :last-clock-value 10
                        :last-message nil

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -519,7 +519,7 @@
 (handlers/register-handler-fx
  :chat.ui/resend-message
  (fn [{:keys [db] :as cofx} [_ chat-id message-id]]
-   (let [message (get-in db [:chats chat-id :messages message-id])]
+   (let [message (get-in db [:messages chat-id message-id])]
      (fx/merge
       cofx
       (transport.message/set-message-envelope-hash chat-id message-id (:message-type message) 1)

--- a/src/status_im/group_chats/db.cljs
+++ b/src/status_im/group_chats/db.cljs
@@ -1,5 +1,4 @@
-(ns status-im.group-chats.db
-  (:require [status-im.multiaccounts.core :as multiaccounts]))
+(ns status-im.group-chats.db)
 
 (def members-added-type 3)
 
@@ -23,21 +22,3 @@
 
 (defn group-chat? [chat]
   (and (:group-chat chat) (not (:public? chat))))
-
-(defn get-pending-invite-inviter-name
-  "when the chat is a private group chat in which the user has been
-  invited and didn't accept the invitation yet, return inviter-name"
-  [contacts chat my-public-key]
-  (when (and (group-chat? chat)
-             (invited? my-public-key chat)
-             (not (joined? my-public-key chat)))
-    (let [inviter-pk (get-inviter-pk my-public-key chat)]
-      (multiaccounts/displayed-name (or (get contacts inviter-pk) {:public-key inviter-pk})))))
-
-(defn get-inviter-name
-  "when the chat is a private group chat in which the user has been
-  invited and didn't accept the invitation yet, return inviter-name"
-  [contacts chat my-public-key]
-  (when (group-chat? chat)
-    (let [inviter-pk (get-inviter-pk my-public-key chat)]
-      (multiaccounts/displayed-name (or (get contacts inviter-pk) {:public-key inviter-pk})))))

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -1171,7 +1171,7 @@
      {})))
 
 (fx/defn load-gaps-fx [{:keys [db] :as cofx} chat-id]
-  (when-not (get-in db [:chats chat-id :gaps-loaded?])
+  (when-not (get-in db [:gaps-loaded? chat-id])
     (let [success-fn #(re-frame/dispatch [::gaps-loaded %1 %2])]
       (data-store.mailservers/load-gaps cofx chat-id success-fn))))
 
@@ -1190,7 +1190,7 @@
      cofx
      {:db
       (-> db
-          (assoc-in [:chats chat-id :gaps-loaded?] true)
+          (assoc-in [:gaps-loaded? chat-id] true)
           (assoc-in [:mailserver/gaps chat-id] gaps))}
 
      (data-store.mailservers/delete-gaps outdated-gaps))))

--- a/src/status_im/mailserver/core_test.cljs
+++ b/src/status_im/mailserver/core_test.cljs
@@ -389,13 +389,11 @@
    {:multiaccount {:public-key "me"}
     :chats
     {"chat-id-1" {:is-active                      true
-                  :messages                       {}
                   :might-have-join-time-messages? true
                   :group-chat                     true
                   :public?                        true
                   :chat-id                        "chat-id-1"}
      "chat-id-2" {:is-active  true
-                  :messages   {}
                   :group-chat true
                   :public?    true
                   :chat-id    "chat-id-2"}}}})
@@ -405,14 +403,12 @@
    {:multiaccount {:public-key "me"}
     :chats
     {"chat-id-1" {:is-active                      true
-                  :messages                       {}
                   :join-time-mail-request-id      "a"
                   :might-have-join-time-messages? true
                   :group-chat                     true
                   :public?                        true
                   :chat-id                        "chat-id-1"}
      "chat-id-2" {:is-active  true
-                  :messages   {}
                   :group-chat true
                   :public?    true
                   :chat-id    "chat-id-2"}}}})
@@ -422,26 +418,22 @@
    {:multiaccount {:public-key "me"}
     :chats
     {"chat-id-1" {:is-active                      true
-                  :messages                       {}
                   :join-time-mail-request-id      "a"
                   :might-have-join-time-messages? true
                   :group-chat                     true
                   :public?                        true
                   :chat-id                        "chat-id-1"}
      "chat-id-2" {:is-active                      true
-                  :messages                       {}
                   :join-time-mail-request-id      "a"
                   :might-have-join-time-messages? true
                   :group-chat                     true
                   :public?                        true
                   :chat-id                        "chat-id-2"}
      "chat-id-3" {:is-active  true
-                  :messages   {}
                   :group-chat true
                   :public?    true
                   :chat-id    "chat-id-3"}
      "chat-id-4" {:is-active                      true
-                  :messages                       {}
                   :join-time-mail-request-id      "a"
                   :might-have-join-time-messages? true
                   :group-chat                     true

--- a/src/status_im/transport/core_test.cljs
+++ b/src/status_im/transport/core_test.cljs
@@ -60,7 +60,8 @@
   (let [chat-id "chat-id"
         from "from"
         message-id "message-id"
-        initial-cofx {:db {:chats {chat-id {:messages {message-id {:from from}}}}}}]
+        initial-cofx {:db {:messages {chat-id {message-id {:from from}}}
+                           :chats {chat-id {}}}}]
 
     (testing "a single envelope message"
       (let [cofx (message/set-message-envelope-hash initial-cofx chat-id message-id :message-type 1)]
@@ -72,12 +73,12 @@
           (is (= :sent
                  (get-in
                   (message/update-envelope-status cofx message-id :sent)
-                  [:db :chats chat-id :messages message-id :outgoing-status]))))
+                  [:db :messages chat-id message-id :outgoing-status]))))
         (testing "the message is not sent"
           (is (= :not-sent
                  (get-in
                   (message/update-envelope-status cofx message-id :not-sent)
-                  [:db :chats chat-id :messages message-id :outgoing-status]))))))
+                  [:db :messages chat-id message-id :outgoing-status]))))))
     (testing "multi envelope message"
       (testing "only inserts"
         (let [cofx (fx/merge
@@ -103,7 +104,7 @@
             (is (= :sent
                    (get-in
                     cofx
-                    [:db :chats chat-id :messages message-id :outgoing-status]))))))
+                    [:db :messages chat-id message-id :outgoing-status]))))))
       (testing "order of events is reversed"
         (let [cofx (fx/merge
                     initial-cofx
@@ -119,7 +120,7 @@
             (is (= :sent
                    (get-in
                     cofx
-                    [:db :chats chat-id :messages message-id :outgoing-status]))))))
+                    [:db :messages chat-id message-id :outgoing-status]))))))
       (testing "message not sent"
         (let [cofx (fx/merge
                     initial-cofx
@@ -135,4 +136,4 @@
             (is (= :not-sent
                    (get-in
                     cofx
-                    [:db :chats chat-id :messages message-id :outgoing-status])))))))))
+                    [:db :messages chat-id message-id :outgoing-status])))))))))

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -91,7 +91,7 @@
   [{:keys [db] :as cofx} message-id status]
   (if-let [{:keys [chat-id]}
            (get-in db [:transport/message-envelopes message-id])]
-    (when-let [{:keys [from]} (get-in db [:chats chat-id :messages message-id])]
+    (when-let [{:keys [from]} (get-in db [:messages chat-id message-id])]
       (check-confirmations cofx status chat-id message-id))
     ;; We don't have a message-envelope for this, might be that the confirmation
     ;; came too early

--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -8,8 +8,6 @@
             [status-im.ui.screens.chat.photos :as photos]
             [status-im.utils.platform :as platform]))
 
-;;TODO REWORK THIS NAMESPACE
-
 (defn default-chat-icon [name styles]
   (when-not (string/blank? name)
     [react/view (:default-chat-icon styles)
@@ -32,15 +30,16 @@
      [react/view online-dot-right]]]])
 
 (defn chat-icon-view
-  [contact group-chat name _online styles]
+  [chat-id group-chat name styles]
   [react/view (:container styles)
-   (if-not group-chat
-     [photos/photo (multiaccounts/displayed-photo contact) styles]
-     [default-chat-icon name styles])])
+   (if group-chat
+     [default-chat-icon name styles]
+     (let [photo-path @(re-frame.core/subscribe [:chats/photo-path chat-id])]
+       [photos/photo photo-path styles]))])
 
 (defn chat-icon-view-toolbar
-  [contact group-chat name color online]
-  [chat-icon-view contact group-chat name online
+  [chat-id group-chat name color]
+  [chat-icon-view chat-id group-chat name
    {:container              styles/container-chat-toolbar
     :online-view-wrapper    styles/online-view-wrapper
     :online-view            styles/online-view
@@ -52,8 +51,8 @@
     :default-chat-icon-text (styles/default-chat-icon-text 36)}])
 
 (defn chat-icon-view-chat-list
-  [contact group-chat name color online]
-  [chat-icon-view contact group-chat name online
+  [chat-id group-chat name color]
+  [chat-icon-view chat-id group-chat name
    {:container              styles/container-chat-list
     :online-view-wrapper    styles/online-view-wrapper
     :online-view            styles/online-view
@@ -65,8 +64,8 @@
     :default-chat-icon-text (styles/default-chat-icon-text 40)}])
 
 (defn chat-icon-view-chat-sheet
-  [contact group-chat name color online]
-  [chat-icon-view contact group-chat name online
+  [chat-id group-chat name color]
+  [chat-icon-view chat-id group-chat name
    {:container              styles/container-chat-list
     :online-view-wrapper    styles/online-view-wrapper
     :online-view            styles/online-view
@@ -116,11 +115,12 @@
     :default-chat-icon      (styles/default-chat-icon-profile colors/default-chat-color size)
     :default-chat-icon-text (styles/default-chat-icon-text size)}])
 
-(defn chat-intro-icon-view [icon-text chat-id styles]
-  (let [photo-path (re-frame.core/subscribe [:contacts/chat-photo chat-id])]
-    (if-not (string/blank? @photo-path)
-      [photos/photo @photo-path styles]
-      [default-chat-icon icon-text styles])))
+(defn chat-intro-icon-view [icon-text chat-id group-chat styles]
+  (if group-chat
+    [default-chat-icon icon-text styles]
+    (let [photo-path @(re-frame.core/subscribe [:chats/photo-path chat-id])]
+      (if-not (string/blank? photo-path)
+        [photos/photo photo-path styles]))))
 
 (defn profile-icon-view [photo-path name color edit? size override-styles]
   (let [styles (merge {:container              {:width size :height size}

--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -8,6 +8,8 @@
             [status-im.ui.screens.chat.photos :as photos]
             [status-im.utils.platform :as platform]))
 
+;;TODO REWORK THIS NAMESPACE
+
 (defn default-chat-icon [name styles]
   (when-not (string/blank? name)
     [react/view (:default-chat-icon styles)

--- a/src/status_im/ui/components/topbar.cljs
+++ b/src/status_im/ui/components/topbar.cljs
@@ -33,9 +33,10 @@
         [react/text {:style {:color colors/blue}}
          (utils.label/stringify label)])]]))
 
+(def default-title-padding 16)
 ;; TODO(Ferossgp): Tobbar should handle safe area
-(defn topbar [_]
-  (let [title-padding (reagent/atom 16)]
+(defn topbar [{:keys [initial-title-padding]}]
+  (let [title-padding (reagent/atom (or initial-title-padding default-title-padding))]
     (fn [& [{:keys [title navigation accessories show-border? modal? content]}]]
       (let [navigation (or navigation (default-navigation modal?))]
         [react/view (cond-> {:height 56 :align-items :center :flex-direction :row}

--- a/src/status_im/ui/screens/chat/message/gap.cljs
+++ b/src/status_im/ui/screens/chat/message/gap.cljs
@@ -21,15 +21,15 @@
 
 (views/defview gap
   [{:keys [gaps first-gap?]} idx list-ref]
-  (views/letsubs [{:keys [range intro-status]} [:chats/current-chat]
+  (views/letsubs [range [:chats/range]
+                  {:keys [might-have-join-time-messages?]} [:chats/current-raw-chat]
                   in-progress? [:chats/fetching-gap-in-progress?
                                 (if first-gap?
                                   [:first-gap]
                                   (:ids gaps))]
                   connected?   [:mailserver/connected?]]
-    (let [ids            (:ids gaps)
-          intro-loading? (= intro-status :loading)]
-      (when-not (and first-gap? intro-loading?)
+    (let [ids            (:ids gaps)]
+      (when-not (and first-gap? might-have-join-time-messages?)
         [react/view {:style style/gap-container}
          [react/touchable-highlight
           {:on-press (when (and connected? (not in-progress?))

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -38,7 +38,7 @@
    appender])
 
 (defview quoted-message
-  [_ {:keys [from text]} outgoing current-public-key public?]
+  [_ {:keys [from text image]} outgoing current-public-key public?]
   (letsubs [contact-name [:contacts/contact-name-by-identity from]]
     [react/view {:style (style/quoted-message-container outgoing)}
      [react/view {:style style/quoted-message-author-container}

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -18,8 +18,8 @@
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defview mention-element [from]
-  (letsubs [{:keys [ens-name alias]} [:contacts/contact-name-by-identity from]]
-    (if ens-name (str "@" ens-name) alias)))
+  (letsubs [contact-name [:contacts/contact-name-by-identity from]]
+    contact-name))
 
 (defn message-timestamp
   ([message]
@@ -38,14 +38,13 @@
    appender])
 
 (defview quoted-message
-  [_ {:keys [from text image]} outgoing current-public-key public?]
-  (letsubs [{:keys [ens-name alias]} [:contacts/contact-name-by-identity from]]
+  [_ {:keys [from text]} outgoing current-public-key public?]
+  (letsubs [contact-name [:contacts/contact-name-by-identity from]]
     [react/view {:style (style/quoted-message-container outgoing)}
      [react/view {:style style/quoted-message-author-container}
       [chat.utils/format-reply-author
        from
-       alias
-       ens-name
+       contact-name
        current-public-key
        (partial style/quoted-message-author outgoing)]]
      (if (and image
@@ -239,8 +238,8 @@
       nil)))
 
 (defview message-author-name [from alias]
-  (letsubs [{:keys [ens-name]} [:contacts/contact-name-by-identity from]]
-    (chat.utils/format-author alias style/message-author-name-container ens-name)))
+  (letsubs [contact-name [:contacts/raw-contact-name-by-identity from]]
+    (chat.utils/format-author (or contact-name alias) style/message-author-name-container)))
 
 (defn message-content-wrapper
   "Author, userpic and delivery wrapper"
@@ -261,7 +260,6 @@
      (when display-username?
        [react/touchable-opacity {:style    style/message-author-touchable
                                  :on-press #(re-frame/dispatch [:chat.ui/show-profile from])}
-        ;;TODO (perf) move to event
         [message-author-name from alias]])
      ;;MESSAGE CONTENT
      content]]

--- a/src/status_im/ui/screens/chat/sheets.cljs
+++ b/src/status_im/ui/screens/chat/sheets.cljs
@@ -6,6 +6,7 @@
             [status-im.utils.universal-links.core :as universal-links]
             [status-im.ui.components.chat-icon.screen :as chat-icon]
             [status-im.ui.components.colors :as colors]
+            [status-im.multiaccounts.core :as multiaccounts]
             [status-im.utils.platform :as platform]
             [status-im.ui.screens.chat.styles.message.sheets :as sheets.styles]
             [status-im.ui.components.list-item.views :as list-item]))

--- a/src/status_im/ui/screens/chat/styles/main.cljs
+++ b/src/status_im/ui/screens/chat/styles/main.cljs
@@ -47,8 +47,8 @@
    :margin-right     6})
 
 (defn intro-header-container
-  [status no-messages]
-  (if (or no-messages (= status (or :loading :empty)))
+  [loading-messages? no-messages?]
+  (if (or loading-messages? no-messages?)
     {:flex               1
      :flex-direction     :column
      :justify-content    :center

--- a/src/status_im/ui/screens/chat/toolbar_content.cljs
+++ b/src/status_im/ui/screens/chat/toolbar_content.cljs
@@ -5,64 +5,48 @@
             [status-im.ui.screens.chat.styles.main :as st])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
-(defn- in-progress-text [{:keys [highestBlock currentBlock startBlock]}]
-  (let [total      (- highestBlock startBlock)
-        ready      (- currentBlock startBlock)
-        percentage (if (zero? ready)
-                     0
-                     (->> (/ ready total)
-                          (* 100)
-                          (.round js/Math)))]
-
-    (str (i18n/label :t/sync-in-progress) " " percentage "% " currentBlock)))
-
-(defview last-activity [{:keys [sync-state accessibility-label]}]
-  (letsubs [state [:sync-data]]
-    [react/text {:style               st/last-activity-text
-                 :accessibility-label accessibility-label}
-     (case sync-state
-       :in-progress (in-progress-text state)
-       :synced      (i18n/label :t/sync-synced))]))
-
-(defn- group-last-activity [{:keys [contacts sync-state public?]}]
-  (if (or (= sync-state :in-progress)
-          (= sync-state :synced))
-    [last-activity {:sync-state sync-state}]
-    [react/view {:flex-direction :row}
-     [react/text {:style st/toolbar-subtitle}
-      (if public?
-        (i18n/label :t/public-group-status)
-        (let [cnt (count contacts)]
-          (if (zero? cnt)
-            (i18n/label :members-active-none)
-            (i18n/label-pluralize cnt :t/members-active))))]]))
-
-(defn- contact-indicator [{:keys [added?]}]
+(defn- group-last-activity [{:keys [contacts public?]}]
   [react/view {:flex-direction :row}
    [react/text {:style st/toolbar-subtitle}
-    (if added?
-      (i18n/label :chat-is-a-contact)
-      (i18n/label :chat-is-not-a-contact))]])
+    (if public?
+      (i18n/label :t/public-group-status)
+      (let [cnt (count contacts)]
+        (if (zero? cnt)
+          (i18n/label :members-active-none)
+          (i18n/label-pluralize cnt :t/members-active))))]])
+
+(defview one-to-one-name [from]
+  (letsubs [contact-name [:contacts/contact-name-by-identity from]]
+    contact-name))
+
+(defview contact-indicator [contact-id]
+  (letsubs [added? [:contacts/contact-added? contact-id]]
+    [react/view {:flex-direction :row}
+     [react/text {:style st/toolbar-subtitle}
+      (if added?
+        (i18n/label :chat-is-a-contact)
+        (i18n/label :chat-is-not-a-contact))]]))
 
 (defview toolbar-content-view []
-  (letsubs [{:keys [group-chat color online contacts chat-name contact public?]}
-            [:chats/current-chat]
-            sync-state [:sync-state]]
-    (let [has-subtitle? (or group-chat (not= :done sync-state))]
-      [react/view {:style st/toolbar-container}
-       [react/view {:margin-right 10}
-        [chat-icon.screen/chat-icon-view-toolbar contact group-chat chat-name color online]]
-       [react/view {:style st/chat-name-view}
-        [react/text {:style               st/chat-name-text
-                     :number-of-lines     1
-                     :accessibility-label :chat-name-text}
-         chat-name]
-        (when contact
-          [contact-indicator contact])
-        (if group-chat
-          [group-last-activity {:contacts   contacts
-                                :public?    public?
-                                :sync-state sync-state}]
-          (when has-subtitle?
-            [last-activity {:sync-state          sync-state
-                            :accessibility-label :last-seen-text}]))]])))
+  (letsubs [{:keys [group-chat
+                    color
+                    chat-id
+                    contacts
+                    chat-name
+                    public?]}
+            [:chats/current-chat]]
+    [react/view {:style st/toolbar-container}
+     [react/view {:margin-right 10}
+      [chat-icon.screen/chat-icon-view-toolbar chat-id group-chat chat-name color]]
+     [react/view {:style st/chat-name-view}
+      [react/text {:style               st/chat-name-text
+                   :number-of-lines     1
+                   :accessibility-label :chat-name-text}
+       (if group-chat
+         chat-name
+         [one-to-one-name chat-id])]
+      (when-not group-chat
+        [contact-indicator chat-id])
+      (when group-chat
+        [group-last-activity {:contacts   contacts
+                              :public?    public?}])]]))

--- a/src/status_im/ui/screens/chat/utils.cljs
+++ b/src/status_im/ui/screens/chat/utils.cljs
@@ -4,30 +4,26 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.components.colors :as colors]))
 
-(defn format-author [alias style name]
+(defn format-author [contact-name style]
   (let [additional-styles (style false)]
-    (if name
-      (let [name (subs name 0 80)]
+    (if (= (aget contact-name 0) "@")
+      (let [trimmed-name (subs contact-name 0 81)]
         [react/text {:number-of-lines 2
                      :style (merge {:color       colors/blue
                                     :font-size   13
                                     :line-height 18
                                     :font-weight "500"} additional-styles)}
-         (str "@" (or (stateofus/username name) name))])
+         (or (stateofus/username trimmed-name) trimmed-name)])
       [react/text {:style (merge {:color       colors/gray
                                   :font-size   12
                                   :line-height 18
                                   :font-weight "400"} additional-styles)}
-       alias])))
+       contact-name])))
 
 (def ^:private reply-symbol "↪ ")
 
-(defn format-reply-author [from alias username current-public-key style]
-  (let [reply-name (or (some->> username
-                                (str "@")
-                                (str reply-symbol))
-                       (str reply-symbol alias))]
-    (or (and (= from current-public-key)
-             [react/text {:style (style true)}
-              (str reply-symbol (i18n/label :t/You))])
-        (format-author (subs reply-name 0 80) style false))))
+(defn format-reply-author [from username current-public-key style]
+  (or (and (= from current-public-key)
+           [react/text {:style (style true)}
+            (str reply-symbol (i18n/label :t/You))])
+      (format-author username style)))

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -27,6 +27,7 @@
   [topbar/topbar
    {:content      [toolbar-content/toolbar-content-view]
     :show-border? true
+    :initial-title-padding 56
     :navigation   {:icon                :main-icons/back
                    :accessibility-label :back-button
                    :handler

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -1,8 +1,6 @@
 (ns status-im.ui.screens.chat.views
   (:require [re-frame.core :as re-frame]
-            [status-im.contact.db :as contact.db]
             [status-im.i18n :as i18n]
-            [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.connectivity.view :as connectivity]
@@ -41,56 +39,86 @@
                                                      [sheets/actions current-chat])
                                           :height  256}])}]}])
 
-(defn add-contact-bar
-  [public-key]
-  [react/touchable-highlight
-   {:on-press
-    #(re-frame/dispatch [:contact.ui/add-to-contact-pressed public-key])
-    :accessibility-label :add-to-contacts-button}
-   [react/view {:style (style/add-contact)}
-    [vector-icons/icon :main-icons/add
-     {:color colors/blue}]
-    [react/i18n-text {:style style/add-contact-text :key :add-to-contacts}]]])
+(defview add-contact-bar [public-key]
+  (letsubs [added? [:contacts/contact-added? public-key]]
+    (when-not added?
+      [react/touchable-highlight
+       {:on-press
+        #(re-frame/dispatch [:contact.ui/add-to-contact-pressed public-key])
+        :accessibility-label :add-to-contacts-button}
+       [react/view {:style (style/add-contact)}
+        [vector-icons/icon :main-icons/add
+         {:color colors/blue}]
+        [react/i18n-text {:style style/add-contact-text :key :add-to-contacts}]]])))
 
-(defn intro-header
-  [contact]
+(defn intro-header [name]
   [react/text {:style (assoc style/intro-header-description
                              :margin-bottom 32)}
    (str
     (i18n/label :t/empty-chat-description-one-to-one)
-    (multiaccounts/displayed-name contact))])
+    name)])
+
+(defn chat-intro [{:keys [chat-id
+                          chat-name
+                          group-chat
+                          contact-name
+                          public?
+                          color
+                          loading-messages?
+                          no-messages?]}]
+  [react/view (style/intro-header-container loading-messages? no-messages?)
+   ;; Icon section
+   [react/view {:style {:margin-top    42
+                        :margin-bottom 24}}
+    [chat-icon.screen/chat-intro-icon-view
+     chat-name chat-id group-chat
+     {:default-chat-icon      (style/intro-header-icon 120 color)
+      :default-chat-icon-text style/intro-header-icon-text
+      :size                   120}]]
+   ;; Chat title section
+   [react/text {:style (style/intro-header-chat-name)} (if group-chat chat-name contact-name)]
+   ;; Description section
+   (if group-chat
+     [chat.group/group-chat-description-container {:chat-id chat-id
+                                                   :loading-messages? loading-messages?
+                                                   :chat-name chat-name
+                                                   :public? public?
+                                                   :no-messages? no-messages?}]
+     [react/text {:style (assoc style/intro-header-description
+                                :margin-bottom 32)}
+
+      (str
+       (i18n/label :t/empty-chat-description-one-to-one)
+       contact-name)])])
+
+(defview chat-intro-one-to-one [{:keys [chat-id] :as opts}]
+  (letsubs [contact-name [:contacts/contact-name-by-identity chat-id]]
+    (chat-intro (assoc opts :contact-name contact-name))))
 
 (defn chat-intro-header-container
-  [{:keys [group-chat name pending-invite-inviter-name color chat-id chat-name
-           public? contact intro-status] :as chat}
+  [{:keys [group-chat
+           might-have-join-time-messages?
+           color chat-id chat-name
+           public?]}
    no-messages]
-  (let [icon-text  (if public? chat-id name)
-        intro-name (if public? chat-name (multiaccounts/displayed-name contact))]
-    (when (or pending-invite-inviter-name
-              (not= (get-in contact [:tribute-to-talk :snt-amount]) 0))
-      [react/touchable-without-feedback
-       {:style    {:flex        1
-                   :align-items :flex-start}
-        :on-press (fn [_]
-                    (re-frame/dispatch
-                     [:chat.ui/set-chat-ui-props {:input-bottom-sheet nil}])
-                    (react/dismiss-keyboard!))}
-       [react/view (style/intro-header-container intro-status no-messages)
-        ;; Icon section
-        [react/view {:style {:margin-top    42
-                             :margin-bottom 24}}
-         [chat-icon.screen/chat-intro-icon-view
-          icon-text chat-id
-          {:default-chat-icon      (style/intro-header-icon 120 color)
-           :default-chat-icon-text style/intro-header-icon-text
-           :size                   120}]]
-        ;; Chat title section
-        [react/text {:style (style/intro-header-chat-name)}
-         (if group-chat chat-name intro-name)]
-        ;; Description section
-        (if group-chat
-          [chat.group/group-chat-description-container chat]
-          [intro-header contact])]])))
+  [react/touchable-without-feedback
+   {:style    {:flex        1
+               :align-items :flex-start}
+    :on-press (fn [_]
+                (re-frame/dispatch
+                 [:chat.ui/set-chat-ui-props {:input-bottom-sheet nil}])
+                (react/dismiss-keyboard!))}
+   (let [opts
+         {:chat-id chat-id
+          :group-chat group-chat
+          :chat-name chat-name
+          :public? public?
+          :color color
+          :loading-messages? might-have-join-time-messages?
+          :no-messages? no-messages}]
+     (if group-chat
+       [chat-intro opts]
+       [chat-intro-one-to-one opts]))])
 
 (defonce messages-list-ref (atom nil))
 
@@ -110,15 +138,16 @@
   (debounce/debounce-and-dispatch [:chat.ui/message-visibility-changed e] 5000))
 
 (defview messages-view
-  [{:keys [public? group-chat chat-id pending-invite-inviter-name] :as chat}]
+  [{:keys [group-chat chat-id public?] :as chat}]
   (letsubs [messages           [:chats/current-chat-messages-stream]
+            no-messages?       [:chats/current-chat-no-messages?]
             current-public-key [:multiaccount/public-key]]
     [list/flat-list
      {:key-fn                       #(or (:message-id %) (:value %))
       :ref                          #(reset! messages-list-ref %)
-      :header                       (when pending-invite-inviter-name
+      :header                       (when (and group-chat (not public?))
                                       [chat.group/group-chat-footer chat-id])
-      :footer                       [chat-intro-header-container chat (empty? messages)]
+      :footer                       [chat-intro-header-container chat no-messages?]
       :data                         messages
       :inverted                     true
       :render-fn                    (fn [{:keys [outgoing type] :as message} idx]
@@ -154,14 +183,13 @@
       [empty-bottom-sheet])))
 
 (defview chat []
-  (letsubs [{:keys [chat-id show-input? group-chat contact] :as current-chat}
+  (letsubs [{:keys [chat-id show-input? group-chat] :as current-chat}
             [:chats/current-chat]]
     [react/view {:style {:flex 1}}
      [connectivity/connectivity
       [topbar current-chat]
       [react/view {:style {:flex 1}}
-       ;;TODO contact.db/added? looks weird here, move to events
-       (when (and (not group-chat) (not (contact.db/added? contact)))
+       (when-not group-chat
          [add-contact-bar chat-id])
        [messages-view current-chat]]]
      (when show-input?

--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -18,7 +18,9 @@
             [status-im.ui.components.radio :as radio]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.topbar :as topbar]
+            [status-im.ui.screens.chat.utils :as chat.utils]
             [status-im.ui.screens.chat.message.message :as message]
+            [status-im.ui.screens.chat.styles.message.message :as message.style]
             [status-im.ui.screens.chat.photos :as photos]
             [status-im.ui.screens.profile.components.views :as profile.components]
             [status-im.utils.debounce :as debounce])
@@ -624,7 +626,11 @@
              [name-item {:name name :hide-chevron? true :action action}]]
             [radio/radio (= name preferred-name)]]]))]]]])
 
-(defn- registered [names {:keys [preferred-name public-key] :as account} _]
+(views/defview my-name []
+  (views/letsubs [contact-name [:multiaccount/my-name]]
+    (chat.utils/format-author contact-name message.style/message-author-name-container)))
+
+(defn- registered [names {:keys [preferred-name] :as account} _]
   [react/view {:style {:flex 1}}
    [react/scroll-view
     [react/view {:style {:margin-top 8}}
@@ -663,7 +669,7 @@
                    :timestamp-str "9:41 AM"}]
       [react/view
        [react/view {:padding-left 72}
-        [message/message-author-name public-key]]
+        [my-name]]
        [react/view {:flex-direction :row}
         [react/view {:padding-left 16 :padding-right 8 :padding-top 4}
          [photos/photo (multiaccounts/displayed-photo account) {:size 36}]]

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -121,6 +121,9 @@
                                    :else nil)
       :title                     (if group-chat
                                    (utils/truncate-str chat-name 30)
+                                   ;; This looks a bit odd, but I would like only to subscribe
+                                   ;; if it's a one-to-one. If wrapped in a component styling
+                                   ;; won't be applied correctly.
                                    @(re-frame/subscribe [:contacts/contact-name-by-identity chat-id]))
       :title-accessibility-label :chat-name-text
       :title-row-accessory       [message-timestamp (if (pos? (:whisper-timestamp last-message))


### PR DESCRIPTION
Improve chat loading performance
    
This commit does a few things:
    
##    Move collections top level
    
Move `messages`,`message-lists`,`pagination-info` from nested in
    `chats` to top level at the db.
    The reason for this change is that if any of the `messages` fields
    change, any `sub` that relies on `chat` will be recomputed, which is
    unnecessary.
    
## Move chat-name to events
    
`chat-name` was computed dynamically, while it is now only calculated
    when loading chat the first time around.
    
## Remove `enrich-chats`
    
Enrich chats was doing a lot of work, and many subscriptions were
    relying on it.
    Not all the computations were necessary, for example it would always
    calculate the name of who invited the user to a group chat, regardless
    of whether it was actually used in the view.
    This commit changes that behavior so that we use smaller subscriptions
    to calculate such fields.
    In general we should move computations to events, if that's not
    desirable (there are some cases where we might not want to do that), we
    should have "bottom/leaf heavy" subscriptions as opposed to "top heavy",
    especially if they are to be shared, so only when (and if) we load that
    particular view, the subscription is triggered, while others can be
    re-used.
    
I have compared performance with current release, and there's a
    noticeable difference. Opening a chat is faster (messages are loaded
    faster), and clicking on the home view on a chat is more responsing
    (the animation on-press is much quicker).

Sorry for the big PR but changing one thing lead to another. I can split it off for easier reviewing if necessary.

I have left subscriptions names as they are, using `raw` for those that do not do any calculation or don't fallback on defaults, probably it would be good to revisit to have a consistent naming, I would also separate `subs.cljs` in multiple files (under a single directory), `subs/chats.cljs` `subs/contacts.cljs` etc , as sometimes is difficult to find what can be re-used (or any other scheme is good), but that's for a separate PR pending discussion.

## Testing

No functional changes, just performance improvement. Performance can be tested if necessary, I have included a video that shows the difference, mind as well that current develop parses markdown so it does a bit more, but pr seems to be faster despite of that.
Areas that are impacted is main chat view, chat view mostly.
Receiving messages is also faster it looks (significantly), although haven't looked much into it as wasn't optimizing that particular part.

![release](https://user-images.githubusercontent.com/1017008/83036514-fbb96500-a03a-11ea-9afd-48f3e108e8b2.gif)
![pr](https://user-images.githubusercontent.com/1017008/83036521-fcea9200-a03a-11ea-956b-a3c3d63cf011.gif)

status: ready