### PR TITLE
Fix searching name of ens contacts

### DIFF
--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -99,24 +99,26 @@
 
 (views/defview chats-list []
   (views/letsubs [loading? [:chats/loading?]
-                  {:keys [chats all-home-items search-filter]} [:home-items]
+                  {:keys [chats search-filter]} [:home-items]
                   {:keys [hide-home-tooltip?]} [:multiaccount]]
     (if loading?
       [react/view {:flex 1 :align-items :center :justify-content :center}
        [react/activity-indicator {:animating true}]]
-      (if (and (empty? all-home-items) hide-home-tooltip? (not @search-active?))
+      (if (and (empty? chats)
+               (empty? search-filter)
+               hide-home-tooltip?
+               (not @search-active?))
         [welcome-blank-page]
-        (let [data (if @search-active? chats all-home-items)]
-          [list/flat-list
-           {:key-fn                         first
-            :keyboard-should-persist-taps   :always
-            :data                           data
-            :render-fn                      inner-item/home-list-item
-            :header                         (when (or (not-empty data) @search-active?)
-                                              [search-input-wrapper search-filter])
-            :footer                         (if (and (not hide-home-tooltip?) (not @search-active?))
-                                              [home-tooltip-view]
-                                              [react/view {:height 68}])}])))))
+        [list/flat-list
+         {:key-fn                         :chat-id
+          :keyboard-should-persist-taps   :always
+          :data                           chats
+          :render-fn                      inner-item/home-list-item
+          :header                         (when (or (seq chats) @search-active?)
+                                            [search-input-wrapper search-filter])
+          :footer                         (if (and (not hide-home-tooltip?) (not @search-active?))
+                                            [home-tooltip-view]
+                                            [react/view {:height 68}])}]))))
 
 (views/defview plus-button []
   (views/letsubs [logging-in? [:multiaccounts/login]]

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -106,7 +106,7 @@
                    :accessibility-label :unviewed-messages-public}]
       [badge/message-counter unviewed-messages-count])))
 
-(defn home-list-item [[_ home-item]]
+(defn home-list-item [home-item]
   (let [{:keys [chat-id chat-name color online group-chat
                 public? timestamp last-message]}
         home-item


### PR DESCRIPTION
We stopped searching for ENS names in home view. This commit restores the old behavior and simplify the `home-item` subscription.

status: ready