### PR TITLE
Set status bar style with theme

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainActivity.java
+++ b/android/app/src/main/java/im/status/ethereum/MainActivity.java
@@ -127,7 +127,7 @@ public class MainActivity extends ReactFragmentActivity
         Log.v("RNBootstrap", "Available system memory "+getAvailableMemory(activityManager).availMem + ", maximum usable application memory " + activityManager.getLargeMemoryClass()+"M");
 
         setSecureFlag();
-        SplashScreen.show(this, true);
+        SplashScreen.show(this, R.style.AppTheme);
         // NOTE: Try to not restore the state https://github.com/software-mansion/react-native-screens/issues/17
         super.onCreate(null);
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,15 +6,19 @@
         <item name="android:windowBackground">?attr/backgroundColor</item>
         <item name="android:textColor">?attr/textColor</item>
         <item name="android:forceDarkAllowed">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="LightTheme" parent="AppTheme">
         <item name="textColor">#000000</item>
         <item name="backgroundColor">#ffffff</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
     <style name="DarkTheme" parent="AppTheme">
         <item name="textColor">#ffffff</item>
         <item name="backgroundColor">#000000</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>


### PR DESCRIPTION
Instead of making the app full screen then changing it on js start, we can use the same theme as in the app for the Status Bar. Fixes the resize of the screen, and missing color for status bar on the app start without required login.