### PR TITLE
Update webview to 10.2.3

### DIFF
--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -55,7 +55,7 @@
     "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.23",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
-    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v9.4.0_1",
+    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v10.2.3_1",
     "web3-utils": "^1.2.1"
   },
   "devDependencies": {

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -6603,9 +6603,9 @@ react-native-touch-id@^4.4.1:
   resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz#8b1bb2d04c30bac36bb9696d2d723e719c4a8b08"
   integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
 
-"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v9.4.0_1":
-  version "9.4.0"
-  resolved "git+https://github.com/status-im/react-native-webview.git#2e2d03e03fb299b19aafc6f34c88df2b30896dcf"
+"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v10.2.3_1":
+  version "10.2.3"
+  resolved "git+https://github.com/status-im/react-native-webview.git#23ff0900c9eb2f741c95321fdc733124d6934f4c"
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
Also includes ssl error handling fix from https://github.com/react-native-community/react-native-webview/pull/1450

Partially addresses #10630 (url-spoof vulnerability will now show an error page).