### PR TITLE
[keycard] Remove unnecessary parameter from generate-and-load-key

### DIFF
--- a/src/status_im/hardwallet/onboarding.cljs
+++ b/src/status_im/hardwallet/onboarding.cljs
@@ -273,8 +273,7 @@
               {:hardwallet/generate-and-load-key
                {:mnemonic     mnemonic
                 :pairing      pairing
-                :pin          pin'
-                :multiaccount multiaccount}})))
+                :pin          pin'}})))
 
 (fx/defn begin-setup-pressed
   {:events [:keycard.onboarding.intro.ui/begin-setup-pressed]}

--- a/src/status_im/hardwallet/simulated_keycard.cljs
+++ b/src/status_im/hardwallet/simulated_keycard.cljs
@@ -112,11 +112,18 @@
     (later #(on-success kk1-pair))))
 
 (defn generate-and-load-key
-  [{:keys [pin pairing on-success multiaccount]}]
+  [{:keys [pin pairing on-success]}]
   (when (and (= pin (get @state :pin))
              (= pairing kk1-pair))
-    (let [{:keys [id address public-key derived key-uid]}
-          multiaccount
+    (let [{:keys [selected-id multiaccounts root-key derived]}
+          (:intro-wizard @re-frame.db/app-db)
+
+          {:keys [id address public-key derived key-uid]}
+          (or (->> multiaccounts
+                   (filter #(= (:id %) selected-id))
+                   first)
+              (assoc root-key :derived derived))
+
           whisper     (get derived constants/path-whisper-keyword)
           wallet      (get derived constants/path-default-wallet-keyword)
           wallet-root (get derived constants/path-wallet-root-keyword)


### PR DESCRIPTION
`multiaccount` was used only by simulated keycard, so it is removed
and will be retreived by accessing app-db directly. This is done because
simulated kk implementation should be compatible with real keycard and
thus can't require extra parameters.

status: ready