### PR TITLE
Use RN's OkHttp in webview lib

### DIFF
--- a/mobile/js_files/package.json
+++ b/mobile/js_files/package.json
@@ -56,7 +56,7 @@
     "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.23",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
-    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v10.2.3_1",
+    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v10.2.3_5",
     "web3-utils": "^1.2.1"
   },
   "devDependencies": {

--- a/mobile/js_files/yarn.lock
+++ b/mobile/js_files/yarn.lock
@@ -6608,9 +6608,9 @@ react-native-touch-id@^4.4.1:
   resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz#8b1bb2d04c30bac36bb9696d2d723e719c4a8b08"
   integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
 
-"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v10.2.3_1":
-  version "10.2.3"
-  resolved "git+https://github.com/status-im/react-native-webview.git#23ff0900c9eb2f741c95321fdc733124d6934f4c"
+"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v10.2.3_5":
+  version "10.3.1"
+  resolved "git+https://github.com/status-im/react-native-webview.git#3bef57fcf8243c2b52b5ab668630d8c92d400de4"
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
Test using RN's OkHttpClient instance in react-native-webview.

The fix is in this commit: https://github.com/status-im/react-native-webview/commit/3bef57fcf8243c2b52b5ab668630d8c92d400de4

Instead of initialising `httpClient` instance in `RNCWebViewManager`'s constructor, we do it on-demand in `shouldInterceptRequest()`.

Related to #10844 