### PR TITLE
fix Nix garbage collection

### DIFF
--- a/nix/DETAILS.md
+++ b/nix/DETAILS.md
@@ -89,3 +89,11 @@ Some of those are required which is why just calling:
 nix-build --attr targets.mobile.android.release
 ```
 Would fail.
+
+# Garbage Collection
+
+The `make nix-gc` target calls `nix-store --gc` and normally would remove almost everything, but to prevent that we place symlinks to protected derivations in `/nix/var/nix/gcroots` subfolder. Specifically:
+```sh
+_NIX_GCROOTS="${_NIX_GCROOTS:-/nix/var/nix/gcroots/per-user/${USER}/status-react}"
+```
+Whenever `nix/scripts/build.sh` or `nix/scripts/shell.sh` are called they update symlinks named after given targets in that folder. This in combination with `keep-outputs = true` set in `nix/nix.conf` prevents garbage collection from removing too much.

--- a/nix/KNOWN_ISSUES.md
+++ b/nix/KNOWN_ISSUES.md
@@ -45,3 +45,10 @@ When building Android on NixOS you might encounter the following error:
 ignoring the user-specified setting 'extra-sandbox-paths', because it is a restricted setting and you are not a trusted user
 ```
 You can mitigate this by setting the [`nix.trustedUsers`](https://nixos.org/nixos/options.html#nix.trustedusers) property.
+
+## NixOS Prioritizes System Config
+
+Currently on NixOS `NIX_CONF_DIR` is being ignored in favor of the default `/etc/nix/nix.conf`.
+This will be possible to fix once Nix `2.4` comes out with support for `NIX_USER_CONF_FILES`.
+
+For more details see https://github.com/NixOS/nix/issues/3723.

--- a/nix/README.md
+++ b/nix/README.md
@@ -6,7 +6,7 @@ This folder contains configuration for [Nix](https://nixos.org/), a purely funct
 
 The main config file is [`nix/nix.conf`](/nix/nix.conf) and its main purpose is defining the [binary caches](https://nixos.org/nix/manual/#ch-basic-package-mgmt) which allow download of packages to avoid having to compile them yourself locally.
 
-__NOTE:__ If you are in Asia you might want to add the `https://nix-cache-cn.status.im/` to be first in order of `substituters`. Removing `cache.nixos.org` could also help.
+__NOTE:__ If you are in Asia you might want to add the `https://nix-cache-cn.status.im/` to be first in order of `extra-substituters`. Removing `cache.nixos.org` could also help.
 
 ## Build arguments
 

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,7 +1,11 @@
-# NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to substituters
-substituters = https://nix-cache.status.im/ https://cache.nixos.org/
+# NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to extra-substituters
+extra-substituters = https://nix-cache.status.im/
+substituters = https://cache.nixos.org/
 trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-cache-cn.status.im:WUiOoTQQurm+rEL/yuAuU/a3TViDtMM9DCMgMx/KkOw= 
 # Some downloads are multiple GB, default is 5 minutes
 stalled-download-timeout = 600
 connect-timeout = 10
 max-jobs = auto
+# Helps avoid removing currently used dependencies via garbage collection
+keep-derivations = true
+keep-outputs = true

--- a/nix/scripts/build.sh
+++ b/nix/scripts/build.sh
@@ -36,10 +36,10 @@ function extractResults() {
   chmod -R u+w "${resultPath}"
 }
 
-targetAttr="${1}"
+TARGET="${1}"
 shift
 
-if [[ -z "${targetAttr}" ]]; then
+if [[ -z "${TARGET}" ]]; then
   echo -e "${RED}First argument is mandatory and has to specify the Nix attribute!${RST}"
   exit 1
 fi
@@ -51,8 +51,11 @@ nixOpts=(
   "--fallback"
   "--no-out-link"
   "--show-trace"
-  "--attr" "${targetAttr}"
+  "--attr" "${TARGET}"
 )
+
+# Save derivation from being garbage collected
+${GIT_ROOT}/nix/scripts/gcroots.sh "${TARGET}"
 
 # Run the actual build
 echo "Running: nix-build "${nixOpts[@]}" "${@}" default.nix"

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -3,7 +3,7 @@
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/scripts/colors.sh"
 
-NIX_VERSION="2.3.4"
+NIX_VERSION="2.3.6"
 NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
 
 function install_nix() {

--- a/nix/scripts/shell.sh
+++ b/nix/scripts/shell.sh
@@ -23,6 +23,12 @@ if [[ -z "${TARGET}" ]]; then
     TARGET="default"
     echo -e "${YLW}Missing TARGET, assuming default target.${RST} See nix/README.md for more details." 1>&2
 fi
+# Minimal shell with just Nix sourced, useful for `make nix-gc`.
+if [[ "${TARGET}" == "nix" ]]; then
+    eval $@
+    exit
+fi
+
 entryPoint="default.nix"
 nixArgs+=("--attr shells.${TARGET}")
 
@@ -60,6 +66,9 @@ if [[ -n "${_NIX_PURE}" ]]; then
 fi
 
 echo -e "${GRN}Configuring ${pureDesc}Nix shell for target '${TARGET}'...${RST}" 1>&2
+
+# Save derivation from being garbage collected
+${GIT_ROOT}/nix/scripts/gcroots.sh "shells.${TARGET}"
 
 # ENTER_NIX_SHELL is the fake command used when `make shell` is run.
 # It is just a special string, not a variable, and a marker to not use `--run`.

--- a/nix/scripts/source.sh
+++ b/nix/scripts/source.sh
@@ -5,7 +5,7 @@
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 
 # Location of profile script for Nix that adjusts PATH
-NIX_PROFILE_SH="${HOME}/.nix-profile/etc/profile.d/nix.sh"
+export NIX_PROFILE_SH="${HOME}/.nix-profile/etc/profile.d/nix.sh"
 
 function source_nix() {
   # Just stop if Nix is already available

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -37,14 +37,19 @@ config+="status-im.android.abi-split=\"$(must_get_env ANDROID_ABI_SPLIT)\";"
 config+="status-im.android.abi-include=\"$(must_get_env ANDROID_ABI_INCLUDE)\";"
 nixOpts=()
 
-# Secrets like this can't be passed via args or they end up in derivation
-SECRETS_FILE_PATH=$(mktemp)
-chmod 644 ${SECRETS_FILE_PATH}
-trap "rm -f ${SECRETS_FILE_PATH}" EXIT
-append_env_export 'KEYSTORE_PASSWORD'
-append_env_export 'KEYSTORE_ALIAS'
-append_env_export 'KEYSTORE_KEY_PASSWORD'
-nixOpts+=("--argstr" "secretsFile" "${SECRETS_FILE_PATH}")
+# If no secrets were passed there's no need to pass the 'secretsFile'
+if [[ -n "${KEYSTORE_ALIAS}${KEYSTORE_ALIAS}${KEYSTORE_ALIAS}" ]]; then
+  # Secrets like this can't be passed via args or they end up in derivation
+  SECRETS_FILE_PATH=$(mktemp)
+  trap "rm -f ${SECRETS_FILE_PATH}" EXIT ERR INT QUIT
+  chmod 644 ${SECRETS_FILE_PATH}
+  append_env_export 'KEYSTORE_PASSWORD'
+  append_env_export 'KEYSTORE_ALIAS'
+  append_env_export 'KEYSTORE_KEY_PASSWORD'
+  nixOpts+=("--argstr" "secretsFile" "${SECRETS_FILE_PATH}")
+fi
+
+# Used by Clojure at compile time to include JS modules
 nixOpts+=("--argstr" "buildEnv" "$(must_get_env BUILD_ENV)")
 
 if [[ "$(uname -s)" =~ Darwin ]]; then


### PR DESCRIPTION
In order to prevent `nix-store --gc` from removing too much I've:

- Added the `keep-outputs = true` setting to `nix/nix.conf`
- Fixed `nix/scripts/gcroots.sh` to make symlinks in `/nix/var/nix/gcroots`
- Made `nix/scripts/build.sh` and `nix/scripts/shell.sh` use it

This way when running `make nix-gc` most recently used shells and built
derivations won't be removed along with their dependencies.

It also upgrade Nix from `2.3.4` to `2.3.6` and improves Android builds when no secrets are specified.