### PR TITLE
Log level copy update

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -110,7 +110,7 @@
     "card-reseted": "Card has been reseted",
     "card-unpaired": "Card has been unpaired from current device",
     "change-fleet": "Change fleet to {{fleet}}",
-    "change-log-level": "Change log level to {{log-level}}",
+    "change-log-level": "Confirm and restart the app to change log level to {{log-level}}",
     "change-logging-enabled": "Are you sure you want to {{enable}} logging?",
     "change-passcode": "Change Passcode",
     "change-password": "Change Password",


### PR DESCRIPTION
fixes #10888 

Communicates that restart is required for log change to take effect.

### Summary
Mitigates the issue, doesn't resolve the issue that restart is required for log level changes to take effect

### Review notes
- Open Status
- Create new account
- Change log level 
- View dialog

### Testing notes

#### Platforms
- Android
- iOS



##### Functional
Settings > Advanced > Log level

