### PR TITLE
ci: fix what version is set for iOS PR builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ Statusgo.framework
 /ios/Pods/
 /ios/StatusIm.xcworkspace
 /ios/react-native-xcode.log
+/ios/set_xcode_version.log
 .ruby-version
 status-e2e/
 

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.1.8'
+library 'status-react-jenkins@v1.1.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -678,7 +678,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "#!/usr/bin/env bash\n\nsource \"${PROJECT_DIR}/scripts/set_xcode_version.sh\"";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./set_xcode_version.log 2>&1";
 		};
 		3AAD2AD824A3A60E0075D594 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -754,7 +754,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "#!/usr/bin/env bash\n\nsource \"${PROJECT_DIR}/scripts/set_xcode_version.sh\"";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./set_xcode_version.log 2>&1";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/scripts/set_xcode_version.sh
+++ b/ios/scripts/set_xcode_version.sh
@@ -6,29 +6,29 @@
 # To use this script in Xcode, add the script's path to a "Run Script" build
 # phase for your application target.
 
+set -x
 set -o errexit
 set -o nounset
 
 # First, check for git in $PATH
 hash git 2>/dev/null || { echo >&2 "Git required, not installed.  Aborting build number update script."; exit 0; }
 
-# Alternatively, we could use Xcode's copy of the Git binary,
-# but old Xcodes don't have this.
-#GIT=$(xcrun -find git)
-
-# Run Script build phases that operate on product files of the target that defines them should use the value of this build setting [TARGET_BUILD_DIR]. But Run Script build phases that operate on product files of other targets should use ?BUILT_PRODUCTS_DIR? instead.
+# Run Script build phases that operate on product files of the target
+# that defines them should use the value of this build setting [TARGET_BUILD_DIR].
+# But Run Script build phases that operate on product files of other targets should use ?BUILT_PRODUCTS_DIR? instead.
 INFO_PLIST="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
 
 if [[ $(git ls-files -m "StatusIm/Info.plist") = *"Info.plist"* ]]; then
     echo "version was set in Info.plist"
-else
-    RELEASE_VERSION=$(cat ../../VERSION)
-    BUILD_NO=$(bash ../scripts/version/build_no.sh)
-
-    # For debugging:
-    echo "SHORT VERSION: $RELEASE_VERSION"
-    echo "BUILD NO: $BUILD_NO"
-
-    /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $BUILD_NO" "$INFO_PLIST" 2>/dev/null || /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NO" "$INFO_PLIST"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $RELEASE_VERSION" "$INFO_PLIST"
+    exit 0
 fi
+
+RELEASE_VERSION=$(cat ../VERSION)
+BUILD_NO=$(bash ../scripts/version/build_no.sh)
+
+# For debugging:
+echo "SHORT VERSION: ${RELEASE_VERSION}"
+echo "BUILD NO: ${BUILD_NO}"
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${BUILD_NO}" "${INFO_PLIST}"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${RELEASE_VERSION}" "${INFO_PLIST}"


### PR DESCRIPTION
Related to #10904. Testing if using the right version might fix the iOS PR builds.

Also changes `ios/scripts/set_xcode_version.sh` to fix an issue with:
```
cat: ../../VERSION: No such file or directory
```
Not sure how that was caused, so I'd prefer if someone from Core tested the iOS build locally.

Related: https://github.com/status-im/status-react-jenkins/pull/10