### PR TITLE
Chat api

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -257,7 +257,7 @@ PODS:
     - React
   - react-native-splash-screen (3.2.0):
     - React
-  - react-native-webview (9.4.0):
+  - react-native-webview (10.3.1):
     - React
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
@@ -588,7 +588,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 60f654e00b6cc416573f6d5dbfce3839958eb57a
   react-native-shake: de052eaa3eadc4a326b8ddd7ac80c06e8d84528c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
-  react-native-webview: cf5527893252b3b036eea024a1da6996f7344c74
+  react-native-webview: 40bbeb6d011226f34cb83f845aeb0fdf515cfc5f
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -32,7 +32,7 @@ in {
   gradlePropParser = callPackage ./tools/gradlePropParser.nix { };
 
   # Package version adjustments
-  xcodeWrapper = super.xcodeenv.composeXcodeWrapper { version = "11.4.1"; };
+  xcodeWrapper = super.xcodeenv.composeXcodeWrapper { version = "11.5"; };
   openjdk = super.pkgs.openjdk8_headless;
   nodejs = super.pkgs.nodejs-12_x;
 

--- a/resources/js/provider.js
+++ b/resources/js/provider.js
@@ -151,6 +151,10 @@
         return sendAPIrequest('send-to-public-chat', params);
     }
 
+    StatusAPI.prototype.getChatMessages = function() {
+      return sendAPIrequest('get-chat-messages');
+    }
+
     var EthereumProvider = function () {};
 
     EthereumProvider.prototype.isStatus = true;

--- a/resources/js/provider.js
+++ b/resources/js/provider.js
@@ -146,6 +146,11 @@
         return sendAPIrequest('contact-code');
     };
 
+    StatusAPI.prototype.sendToPublicChat = function(topic, message) {
+        const params = { topic, message };
+        return sendAPIrequest('send-to-public-chat', params);
+    }
+
     var EthereumProvider = function () {};
 
     EthereumProvider.prototype.isStatus = true;

--- a/resources/js/provider.js
+++ b/resources/js/provider.js
@@ -151,6 +151,11 @@
         return sendAPIrequest('send-to-public-chat', params);
     }
 
+    StatusAPI.prototype.gotoPublicChat = function(topic) {
+      const params = { topic }
+      return sendAPIrequest('goto-public-chat', params);
+    }
+
     StatusAPI.prototype.getChatMessages = function() {
       return sendAPIrequest('get-chat-messages');
     }

--- a/src/status_im/browser/permissions.cljs
+++ b/src/status_im/browser/permissions.cljs
@@ -77,7 +77,7 @@
                   :dapp-name            dapp-name
                   :yield-control?       yield-control?})})
 
-(defn get-permission-data [cofx allowed-permission & [{:keys [start] :as params}]]
+(defn get-permission-data [cofx allowed-permission]
   (let [multiaccount (get-in cofx [:db :multiaccount])
         messages (get-in cofx [:db :messages])]
     (get {constants/dapp-permission-contact-code (:public-key multiaccount)
@@ -152,7 +152,7 @@
             (send-response-to-bridge requested-permission
                                      message-id
                                      true
-                                     (get-permission-data cofx requested-permission params))
+                                     (get-permission-data cofx requested-permission))
             (process-next-permission dapp-name)))
 
 (fx/defn allow-permission
@@ -190,7 +190,7 @@
       (send-response-to-bridge cofx permission message-id false nil)
 
       (and (or permission-allowed? (:allowed? supported-permission)) (not (:yield-control? supported-permission)))
-      (send-response-to-bridge cofx permission message-id true (get-permission-data cofx permission params))
+      (send-response-to-bridge cofx permission message-id true (get-permission-data cofx permission))
 
       :else
       (process-next-permission (update-in cofx [:db :browser/options :pending-permissions]

--- a/src/status_im/browser/permissions.cljs
+++ b/src/status_im/browser/permissions.cljs
@@ -14,6 +14,11 @@
 (def supported-permissions
   {constants/dapp-permission-qr-code           {:yield-control? true
                                                 :allowed?       true}
+   constants/dapp-permission-goto-public-chat  {:type           :chat
+                                                :yield-control? true
+                                                :title          "Wants to go to"
+                                                :description    "To a public chat"
+                                                :icon           :main-icons/public-chat}
    constants/dapp-permission-send-to-public-chat {:type       :chat
                                                   :yield-control? true
                                                   :title       "Wants to send a message"
@@ -38,6 +43,11 @@
   (re-frame/dispatch [:chat.ui/set-chat-input-text message])
   (send-response-to-bridge cofx permission message-id true params))
 
+(fx/defn dapp-goto-to-topic
+  [{:keys [db] :as cofx} permission message-id {:keys [topic] :as params}]
+  (re-frame/dispatch [:chat.ui/start-public-chat topic {:navigation-reset? true}])
+  (send-response-to-bridge cofx permission message-id true params))
+
 (fx/defn get-current-messages
   [{:keys [db] :as cofx} permission message-id {:keys [topic message] :as params}]
   (send-response-to-bridge cofx permission message-id true params))
@@ -55,6 +65,9 @@
 
     (= permission constants/dapp-permission-send-to-public-chat)
     (dapp-message-to-topic cofx permission message-id params)
+
+    (= permission constants/dapp-permission-goto-public-chat)
+    (dapp-goto-to-topic cofx permission message-id params)
     ))
 
 (fx/defn permission-show-permission

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -272,6 +272,7 @@
 (def desktop-msg-chars-hard-limit 10000)
 
 (def dapp-permission-contact-code "contact-code")
+(def dapp-permission-send-to-public-chat "send-to-public-chat")
 (def dapp-permission-web3 "web3")
 (def dapp-permission-qr-code "qr-code")
 (def api-response "api-response")

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -274,6 +274,7 @@
 (def dapp-permission-contact-code "contact-code")
 (def dapp-permission-get-chat-messages "get-chat-messages")
 (def dapp-permission-send-to-public-chat "send-to-public-chat")
+(def dapp-permission-goto-public-chat "goto-public-chat")
 (def dapp-permission-web3 "web3")
 (def dapp-permission-qr-code "qr-code")
 (def api-response "api-response")

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -272,6 +272,7 @@
 (def desktop-msg-chars-hard-limit 10000)
 
 (def dapp-permission-contact-code "contact-code")
+(def dapp-permission-get-chat-messages "get-chat-messages")
 (def dapp-permission-send-to-public-chat "send-to-public-chat")
 (def dapp-permission-web3 "web3")
 (def dapp-permission-qr-code "qr-code")

--- a/src/status_im/utils/messages.cljs
+++ b/src/status_im/utils/messages.cljs
@@ -1,6 +1,7 @@
 (ns status-im.utils.messages
   (:require [clojure.string :as string]
             [status-im.utils.types :as util-types]
+            [clojure.set :as clj-set]
             [status-im.browser.webview-ref :as webview-ref]))
 
 (defn replace-several [content & replacements]
@@ -23,9 +24,9 @@
                    #"\'" ""))
 
 (defn format-message-client
-  [[message-id, {:keys [content] :as message}]]
+  [{:keys [content] :as message}]
   (let [reduced-message (select-keys message [:timestamp :from :alias :message-id])
-        js-formatted (clojure.set/rename-keys reduced-message {:message-id :messageId})]
+        js-formatted (clj-set/rename-keys reduced-message {:message-id :messageId})]
     (merge {:text (:text content)} js-formatted)))
 
 (defn messages-format-js
@@ -33,7 +34,7 @@
   (let [chat-keys (keys messages)
         chat-content (mapcat #(get messages %) chat-keys)
         chat-id (first chat-keys)
-        flat-messages (map format-message-client chat-content)
+        flat-messages (map (comp format-message-client second) chat-content)
         payload {:chat chat-id :messages flat-messages}]
     payload))
 

--- a/src/status_im/utils/messages.cljs
+++ b/src/status_im/utils/messages.cljs
@@ -1,0 +1,27 @@
+(ns status-im.utils.messages
+  (:require [clojure.string :as string]))
+
+(defn replace-several [content & replacements]
+  (let [replacement-list (partition 2 replacements)]
+    (reduce #(apply string/replace %1 %2) content replacement-list)))
+
+(defn sanitize-text-for-parse
+  "These characters cause JSON payloads to fail being sent over the bridge without proper scrubbing"
+  [text]
+  (replace-several text
+                   #"\n" "\\n"
+                   #"\r" "\\r"
+                   #"\t" "\\t"
+                   #"\'" ""))
+
+(defn format-message-client
+  [[message-id, {:keys [content] :as message}]]
+  (let [reduced-message (select-keys message [:timestamp :from :alias :message-id])]
+    (merge {:text (sanitize-text-for-parse (:text content))} reduced-message)))
+
+(defn messages-format-js
+  [messages]
+  (let [chat-keys (keys messages)
+        chat-content (mapcat #(get messages %) chat-keys)
+        reduced-content (map format-message-client chat-content)]
+    reduced-content))

--- a/src/status_im/utils/messages.cljs
+++ b/src/status_im/utils/messages.cljs
@@ -1,5 +1,7 @@
 (ns status-im.utils.messages
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [status-im.utils.types :as util-types]
+            [status-im.browser.webview-ref :as webview-ref]))
 
 (defn replace-several [content & replacements]
   (let [replacement-list (partition 2 replacements)]
@@ -9,19 +11,38 @@
   "These characters cause JSON payloads to fail being sent over the bridge without proper scrubbing"
   [text]
   (replace-several text
-                   #"\n" "\\n"
+                   #"\"\{" "{"
+                   #"\"\"\{" "{"
+                   #"\"\}" "}"
+                   #":\"\{" ":{"
+                   #"\}\"" "}"
+                   #"\\\"" "\""
+                   #"\n" ""
                    #"\r" "\\r"
                    #"\t" "\\t"
                    #"\'" ""))
 
 (defn format-message-client
   [[message-id, {:keys [content] :as message}]]
-  (let [reduced-message (select-keys message [:timestamp :from :alias :message-id])]
-    (merge {:text (sanitize-text-for-parse (:text content))} reduced-message)))
+  (let [reduced-message (select-keys message [:timestamp :from :alias :message-id])
+        js-formatted (clojure.set/rename-keys reduced-message {:message-id :messageId})]
+    (merge {:text (:text content)} js-formatted)))
 
 (defn messages-format-js
   [messages]
   (let [chat-keys (keys messages)
         chat-content (mapcat #(get messages %) chat-keys)
-        reduced-content (map format-message-client chat-content)]
-    reduced-content))
+        chat-id (first chat-keys)
+        flat-messages (map format-message-client chat-content)
+        payload {:chat chat-id :messages flat-messages}]
+    payload))
+
+(defn dapp-post-message
+  [message]
+  (let [^js webview @webview-ref/webview-ref
+        msg (str "window.postMessage("
+                 (str (util-types/serialize message))
+                 ");"
+                 newline "true;")]
+    (when (and message webview)
+      (.injectJavaScript webview msg))))


### PR DESCRIPTION
### Summary
Implements DApp Chat api as per: https://github.com/status-im/specs/issues/117

### Review notes
This is my first PR on this code base, wondering how these changes should be organized and if these state mutation are idiomatic? 

There are 3 functions in `permissions.cljs` that dispatch re-frame events, I'm wondering if they should live elsewhere? Are they inline with convention to dispatch re-frame events if the action is coming from the browser API?

#### Outstanding bugs

Looking for guidance on how to resolve these issues:
- The first time a permission is invoked to send a message or join a room it causes a crash upon approval. 
- When grabbing messages and sending over the bridge on iOS the json payload can not be parsed if the message contains the character `'`. I have not found a way to escape it so for now it is removed.

### Testing notes
There is a test dapp which makes calls to the api, it can be run locally and use in the webview. It can be found here: https://github.com/status-im/status-api-tester.git
#### Platforms

- Android
- iOS

#### Areas that maybe impacted
Security? Two of the calls have the permission `:yield-control? true` I don't know the full impact of this.

##### Functional

- public chats
- dapps / app browsing

### Steps to test

After running npm install in the `status-api-test` directory one can start the dapp using `embark run`. It should be accessible from `http://localhost:8000/`. Open it in the dapp browser and use the Status api tab to test calls. Keep the localhost console open as some function currently just log to console. 

status: wip