### PR TITLE
Disable by default list item animations on android

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -164,6 +164,7 @@
                                        :PureNativeButton         #js {}
                                        :TapGestureHandler        #js {}
                                        :PanGestureHandler        #js {}
+                                       :TouchableHighlight       #js {}
                                        :LongPressGestureHandler  #js {}
                                        :TouchableWithoutFeedback #js {}
                                        :createNativeWrapper      identity})

--- a/src/quo/components/list/item.cljs
+++ b/src/quo/components/list/item.cljs
@@ -2,6 +2,7 @@
   (:require [quo.react-native :as rn]
             [quo.platform :as platform]
             [quo.haptic :as haptic]
+            [quo.gesture-handler :as gh]
             [quo.design-system.spacing :as spacing]
             [quo.design-system.colors :as colors]
             [quo.components.text :as text]
@@ -153,7 +154,7 @@
     :or   {subtitle-max-lines 1
            theme              :main
            haptic-feedback    true
-           animated           true
+           animated           platform/ios?
            haptic-type        :selection}}]
   (let [theme           (if disabled :disabled theme)
         {:keys [icon-color text-color icon-bg-color
@@ -167,7 +168,7 @@
                                (not on-long-press))
                           rn/view
                           animated animated/pressable
-                          :else    rn/touchable-opacity)]
+                          :else    gh/touchable-hightlight)]
     [rn/view {:background-color (if (and (= accessory :radio) active)
                                   active-background
                                   passive-background)}

--- a/src/quo/gesture_handler.cljs
+++ b/src/quo/gesture_handler.cljs
@@ -2,9 +2,11 @@
   (:require [oops.core :refer [oget]]
             ["react-native-reanimated" :default animated]
             [reagent.core :as reagent]
+            [quo.design-system.colors :as colors]
             ["react-native-gesture-handler"
              :refer (TapGestureHandler PanGestureHandler LongPressGestureHandler
                                        PureNativeButton TouchableWithoutFeedback
+                                       TouchableHighlight
                                        createNativeWrapper State)]))
 
 (def tap-gesture-handler
@@ -22,6 +24,13 @@
 
 (def touchable-without-feedback
   (reagent/adapt-react-class touchable-without-feedback-class))
+
+(def touchable-hightlight-class (reagent/adapt-react-class TouchableHighlight))
+
+(defn touchable-hightlight [props & children]
+  (into [touchable-hightlight-class (merge {:underlay-color (:interactive-02 @colors/theme)}
+                                           props)]
+        children))
 
 (def raw-button
   (reagent/adapt-react-class


### PR DESCRIPTION
Because performance on android is worse, disable till will find a solution to improve