### PR TITLE
Shrink left side in toolbar to not overflow

### DIFF
--- a/src/status_im/ui/components/toolbar.cljs
+++ b/src/status_im/ui/components/toolbar.cljs
@@ -6,7 +6,8 @@
                           :or   {size :default}}]
   (merge {:align-items        :center
           :padding-horizontal 8
-          :flex-direction     :row}
+          :flex-direction     :row
+          :justify-content    :space-between}
          (when center?
            {:justify-content :center})
          (when show-border?
@@ -26,6 +27,7 @@
     [react/view {:style (toolbar-container {:show-border? show-border?
                                             :center?      false
                                             :size         size})}
-     (when left left)
-     [react/view {:flex 1}]
-     (when right right)]))
+     [react/view {:flex-shrink 1}
+      (when left left)]
+     [react/view
+      (when right right)]]))


### PR DESCRIPTION
Fixes 
![image0](https://user-images.githubusercontent.com/5794620/88372205-1c353f80-cd9e-11ea-809e-a215e68918fe.png)

For a better fix we should check strings which are too long and replace by their shorter version.