### PR TITLE
F-Droid build enabling changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ release-android: export BUILD_ENV ?= prod
 release-android: export BUILD_TYPE ?= nightly
 release-android: export BUILD_NUMBER ?= $(TMP_BUILD_NUMBER)
 release-android: export KEYSTORE_PATH ?= $(HOME)/.gradle/status-im.keystore
+release-android: export ANDROID_APK_SIGNED ?= true
 release-android: export ANDROID_ABI_SPLIT ?= false
 release-android: export ANDROID_ABI_INCLUDE ?= armeabi-v7a;arm64-v8a;x86
 release-android: keystore ##@build build release for Android

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -228,6 +228,8 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        /* Caution! In production, you need to generate your own keystore file.
+         * See: https://facebook.github.io/react-native/docs/signed-apk-android */
         release {
             /* environment variables take precedence over gradle.properties file */
             storeFile     file(getEnvOrConfig('KEYSTORE_PATH').replaceAll("~", System.properties['user.home']))
@@ -253,11 +255,11 @@ android {
             resValue "string", "build_config_package", "im.status.ethereum"
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://facebook.github.io/react-native/docs/signed-apk-android.
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            signingConfig signingConfigs.release
+            if (getEnvOrConfig('ANDROID_APK_SIGNED').toBoolean()) {
+                signingConfig signingConfigs.release
+            }
         }
         pr {
             initWith release

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -42,6 +42,8 @@ KEYSTORE_KEY_PASSWORD=password
 ANDROID_ABI_SPLIT=false
 # Some platforms are excluded though
 ANDROID_ABI_INCLUDE=armeabi-v7a;arm64-v8a;x86
+# F-Droid builds need to be unsigned
+ANDROID_APK_SIGNED=true
 
 org.gradle.jvmargs=-Xmx8704M
 

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -7,6 +7,7 @@
     android = {
       gradle-opts = null;    # Gradle options passed for Android builds
       keystore-path = null;  # Path to keystore for signing the APK
+      apk-signed = true;     # F-Droid builds aren't signed by us
       abi-split = false;     # If APKs should be split based on architectures
       abi-include = "armeabi-v7a;arm64-v8a;x86"; # Android architectures to build for
     };

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -143,6 +143,7 @@ in stdenv.mkDerivation rec {
     ${adhocEnvVars} ${pkgs.gradle}/bin/gradle \
       ${toString gradleOpts} \
       --offline --stacktrace \
+      -Dorg.gradle.daemon=false \
       -Dmaven.repo.local='${deps.gradle}' \
       -PversionCode=${toString buildNumber} \
       assemble${gradleBuildType} \

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -28,7 +28,7 @@ let
   # If it is not we use an ad-hoc one generated with default password.
   keystorePath = getConfig "android.keystore-path" keystore;
 
-  baseName = "release-android";
+  baseName = "${buildType}-android";
   name = "status-react-build-${baseName}";
 
   envFileName = 
@@ -72,6 +72,7 @@ in stdenv.mkDerivation rec {
 
   # custom env variables derived from config
   STATUS_GO_SRC_OVERRIDE = getConfig "nimbus.src-override" null;
+  ANDROID_APK_SIGNED = getConfig "android.apk-unsigned" "true";
   ANDROID_ABI_SPLIT = getConfig "android.abi-split" "false";
   ANDROID_ABI_INCLUDE = androidAbiInclude;
 

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -136,6 +136,9 @@ in stdenv.mkDerivation rec {
     assert ANDROID_ABI_SPLIT != null && ANDROID_ABI_SPLIT != "";
     assert stringLength ANDROID_ABI_INCLUDE > 0;
   ''
+    # Fixes issue with failing to load libnative-platform.so
+    export GRADLE_USER_HOME=$(mktemp -d)
+
     pushd ./android
     ${adhocEnvVars} ${pkgs.gradle}/bin/gradle \
       ${toString gradleOpts} \

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -9,3 +9,5 @@ max-jobs = auto
 # Helps avoid removing currently used dependencies via garbage collection
 keep-derivations = true
 keep-outputs = true
+# Extra isolation for network and filesystem, doesn't work on MacOS
+build-use-sandbox = false

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -63,6 +63,7 @@ if [[ "$(uname -s)" =~ Darwin ]]; then
   )
 else
   nixOpts+=(
+    "--option" "build-use-sandbox" "true"
     "--option" "extra-sandbox-paths" "${KEYSTORE_PATH} ${SECRETS_FILE_PATH}"
   )
 fi

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -33,6 +33,7 @@ fi
 config+="status-im.build-type=\"$(must_get_env BUILD_TYPE)\";"
 config+="status-im.build-number=\"$(must_get_env BUILD_NUMBER)\";"
 config+="status-im.android.keystore-path=\"$(must_get_env KEYSTORE_PATH)\";"
+config+="status-im.android.apk-signed=\"$(must_get_env ANDROID_APK_SIGNED)\";"
 config+="status-im.android.abi-split=\"$(must_get_env ANDROID_ABI_SPLIT)\";"
 config+="status-im.android.abi-include=\"$(must_get_env ANDROID_ABI_INCLUDE)\";"
 nixOpts=()


### PR DESCRIPTION
After a lot of research in #8512 I finally have a working F-Droid build using this branch.

Changes:
- Set GRADLE_USER_HOME to a temp dir
- Enable `build-use-sandbox = true` for Android Nix builds
- Use `org.gradle.daemon=false` for Nix Android builds
- Add `ANDROID_APK_SIGNED` to make unsigned builds for F-Droid

I think we should be able to release `1.5.0` on F-Droid.
It should be also doable to release `1.4.1` with these changes.