### PR TITLE
Fix GitHub releases

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.0'
+library 'status-react-jenkins@v1.2.1'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.0'
+library 'status-react-jenkins@v1.2.1'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.0'
+library 'status-react-jenkins@v1.2.1'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.0'
+library 'status-react-jenkins@v1.2.1'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.0'
+library 'status-react-jenkins@v1.2.1'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.0'
+library 'status-react-jenkins@v1.2.1'
 
 pipeline {
   agent { label 'linux' }

--- a/nix/pkgs/gomobile/default.nix
+++ b/nix/pkgs/gomobile/default.nix
@@ -36,33 +36,18 @@ in buildGoPackage rec {
       --replace \
         'tmpdir, err = ioutil.TempDir(gomobilepath, "work-")' \
         "tmpdir = filepath.Join(os.Getenv(\"NIX_BUILD_TOP\"), \"work\")"
-
-    echo "Creating $dev"
-    mkdir -p $dev/src/$goPackagePath
-    echo "Copying from $src"
-    cp -a $src/. $dev/src/$goPackagePath
   '';
 
   preBuild = ''
     mkdir $NIX_BUILD_TOP/gomobile-work $NIX_BUILD_TOP/work
   '';
 
-  postInstall =
-    let
-      inherit (stdenv.lib) makeBinPath makeLibraryPath;
-    in ''
-    mkdir -p $out $bin/lib
-
-    ln -s ${ncurses5}/lib/libncursesw.so.5 $bin/lib/libtinfo.so.5
-    ${if isDarwin then ''
-    wrapProgram $bin/bin/gomobile \
-      --prefix "PATH" : "${makeBinPath [ xcodeWrapper ]}" \
-      --prefix "LD_LIBRARY_PATH" : "${makeLibraryPath [ ncurses5 zlib ]}:$bin/lib"
-  '' else ''
-    wrapProgram $bin/bin/gomobile \
-      --prefix "LD_LIBRARY_PATH" : "${makeLibraryPath [ ncurses5 zlib ]}:$bin/lib"
-  ''}
-    $bin/bin/gomobile init
+  # Necessary for GOPATH when using gomobile.
+  postInstall = ''
+    echo "Creating $out"
+    mkdir -p $out/src/$goPackagePath
+    echo "Copying from $src"
+    cp -a $src/. $out/src/$goPackagePath
   '';
 
   src = fetchgit {
@@ -70,8 +55,6 @@ in buildGoPackage rec {
     name = "gomobile";
     url = "https://go.googlesource.com/mobile";
   };
-
-  outputs = [ "bin" "dev" "out" ];
 
   meta = with stdenv.lib; {
     description = "A tool for building and running mobile apps written in Go.";

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -45,7 +45,7 @@ in buildGoPackage {
     mkdir ${NIX_GOWORKDIR}
 
     export GO111MODULE=off
-    export GOPATH=${gomobile.dev}:$GOPATH
+    export GOPATH=${gomobile.out}:$GOPATH
     export NIX_GOWORKDIR=${NIX_GOWORKDIR}
 
   '' + optionalString (platform == "android") ''


### PR DESCRIPTION
We had some issues with how artifacts were named after publishing a release to GitHub, this fixes it.
Specifically [this part](https://github.com/status-im/status-react-jenkins/pull/13/commits/955430912175889ddf7a2b4e11ce3f7fabd5ceac#diff-70fb2526b4d266e67368cc54aa3e9716R135-R136) was causing the filenames to contain a `pkgs.` prefix.

Related: https://github.com/status-im/status-react-jenkins/pull/13

I also snuck in a simplified build of `gomobile`.