### PR TITLE
nix: add missing args to gcroots.sh script

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.1'
+library 'status-react-jenkins@v1.2.2'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.1'
+library 'status-react-jenkins@v1.2.2'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.1'
+library 'status-react-jenkins@v1.2.2'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.1'
+library 'status-react-jenkins@v1.2.2'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.1'
+library 'status-react-jenkins@v1.2.2'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.1'
+library 'status-react-jenkins@v1.2.2'
 
 pipeline {
   agent { label 'linux' }

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -143,6 +143,7 @@ in stdenv.mkDerivation rec {
     pushd ./android
     ${adhocEnvVars} ${pkgs.gradle}/bin/gradle \
       ${toString gradleOpts} \
+      --console=plain \
       --offline --stacktrace \
       -Dorg.gradle.daemon=false \
       -Dmaven.repo.local='${deps.gradle}' \

--- a/nix/scripts/build.sh
+++ b/nix/scripts/build.sh
@@ -55,7 +55,7 @@ nixOpts=(
 )
 
 # Save derivation from being garbage collected
-${GIT_ROOT}/nix/scripts/gcroots.sh "${TARGET}"
+${GIT_ROOT}/nix/scripts/gcroots.sh "${TARGET}" "${@}"
 
 # Run the actual build
 echo "Running: nix-build "${nixOpts[@]}" "${@}" default.nix"

--- a/nix/scripts/gcroots.sh
+++ b/nix/scripts/gcroots.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -Eeu
+set -Ee
 
 _NIX_GCROOTS="${_NIX_GCROOTS:-/nix/var/nix/gcroots/per-user/${USER}/status-react}"
 
@@ -9,6 +9,7 @@ source "${GIT_ROOT}/nix/scripts/source.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
 
 TARGET="${1}"
+shift
 if [[ -z "${TARGET}" ]]; then
     echo -e "${RED}No target specified for gcroots.sh!${RST}" >&2
     exit 1
@@ -18,4 +19,4 @@ fi
 # This prevents it from being removed by 'gc-collect-garbage'.
 nix-instantiate --attr "${TARGET}" \
     --add-root "${_NIX_GCROOTS}/${TARGET}" \
-    "${GIT_ROOT}/default.nix" >/dev/null
+    "${@}" "${GIT_ROOT}/default.nix" >/dev/null


### PR DESCRIPTION
This should fix the following error showing up on MacOS:
```
error: assertion ((__lessThan  0)  ((builtins).stringLength  watchmanSockPath))
failed at /Users/jenkins/repos/status-react/nix/mobile/android/watchman.nix:8:9
```
Which was caused by flags like `--argstr` not being passed.
    
Also added `--console=plain` for Gradle call in Nix.