### PR TITLE
Add dinamically toggling webview debug on android

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -9,6 +9,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
+
 import android.preference.PreferenceManager;
 
 import androidx.core.content.FileProvider;
@@ -16,6 +17,7 @@ import androidx.core.content.FileProvider;
 import android.util.Log;
 import android.view.Window;
 import android.view.WindowManager;
+import android.webkit.WebView;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 import android.webkit.WebStorage;
@@ -1048,6 +1050,22 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             cookieSyncManager.stopSync();
             cookieSyncManager.sync();
         }
+    }
+
+    @ReactMethod
+    public void toggleWebviewDebug(final boolean val) {
+        Log.d(TAG, "toggleWebviewDebug");
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+
+        activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    WebView.setWebContentsDebuggingEnabled(val);
+                }
+        });
     }
 
     @ReactMethod

--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -66,6 +66,11 @@
    (native-module/chaos-mode-update on (constantly nil))))
 
 (re-frame/reg-fx
+ ::webview-debug-changed
+ (fn [value]
+   (native-module/toggle-webview-debug value)))
+
+(re-frame/reg-fx
  ::blank-preview-flag-changed
  (fn [flag]
    (native-module/set-blank-preview-flag flag)))
@@ -85,6 +90,15 @@
   (multiaccounts.update/multiaccount-update cofx
                                             :dev-mode? dev-mode?
                                             {}))
+
+(fx/defn switch-webview-debug
+  {:events [:multiaccounts.ui/switch-webview-debug]}
+  [{:keys [db] :as cofx} value]
+  (fx/merge cofx
+            {::webview-debug-changed value}
+            (multiaccounts.update/multiaccount-update
+             :webview-debug (boolean value)
+             {})))
 
 (fx/defn switch-chaos-mode
   [{:keys [db] :as cofx} chaos-mode?]

--- a/src/status_im/multiaccounts/logout/core.cljs
+++ b/src/status_im/multiaccounts/logout/core.cljs
@@ -6,6 +6,7 @@
             [status-im.native-module.core :as status]
             [status-im.transport.core :as transport]
             [status-im.utils.fx :as fx]
+            [status-im.multiaccounts.core :as multiaccounts]
             [status-im.utils.keychain.core :as keychain]
             [status-im.notifications.core :as notifications]))
 
@@ -13,9 +14,10 @@
   [{:keys [db] :as cofx} {:keys [auth-method logout?]}]
   (let [key-uid (get-in db [:multiaccount :key-uid])]
     (fx/merge cofx
-              {::logout                      nil
-               :keychain/clear-user-password key-uid
-               ::init/open-multiaccounts     #(re-frame/dispatch [::init/initialize-multiaccounts % {:logout? logout?}])}
+              {::logout                              nil
+               ::multiaccounts/webview-debug-changed false
+               :keychain/clear-user-password         key-uid
+               ::init/open-multiaccounts             #(re-frame/dispatch [::init/initialize-multiaccounts % {:logout? logout?}])}
               (notifications/logout-disable)
               (keychain/save-auth-method key-uid auth-method)
               (transport/stop-whisper)

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -308,6 +308,10 @@
   (log/debug "[native-module] chaos-mode-update")
   (.chaosModeUpdate ^js (status) on on-result))
 
+(defn toggle-webview-debug [on]
+  (log/debug "[native-module] toggle-webview-debug" on)
+  (.toggleWebviewDebug ^js (status) on))
+
 (defn get-nodes-from-contract
   [rpc-endpoint contract-address on-result]
   (log/debug "[native-module] get-nodes-from-contract")

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -11,7 +11,8 @@
 (defn- normal-mode-settings-data [{:keys [network-name
                                           current-log-level
                                           waku-bloom-filter-mode
-                                          current-fleet]}]
+                                          current-fleet
+                                          webview-debug]}]
   [{:size                 :small
     :title                (i18n/label :t/network)
     :accessibility-label  :network-button
@@ -63,6 +64,15 @@
       #(re-frame/dispatch [:navigate-to :notifications-advanced-settings])
       :chevron             true})
    {:size                   :small
+    :title                   "Webview debug"
+    :accessibility-label     :webview-debug-switch
+    :container-margin-bottom 8
+    :on-press
+    #(re-frame/dispatch
+      [:multiaccounts.ui/switch-webview-debug (not webview-debug)])
+    :accessory               :switch
+    :active                  webview-debug}
+   {:size                    :small
     :title                   (i18n/label :t/waku-bloom-filter-mode)
     :accessibility-label     :waku-bloom-filter-mode-settings-switch
     :container-margin-bottom 8
@@ -71,7 +81,7 @@
       [:multiaccounts.ui/waku-bloom-filter-mode-switched (not waku-bloom-filter-mode)])
     :accessory               :switch
     :active                  waku-bloom-filter-mode}
-   #_{:size                   :small
+   #_{:size                    :small
       :title                   :t/dev-mode
       :accessibility-label     :dev-mode-settings-switch
       :container-margin-bottom 8
@@ -119,7 +129,7 @@
     [quo/list-item props]))
 
 (views/defview advanced-settings []
-  (views/letsubs [{:keys [chaos-mode?]} [:multiaccount]
+  (views/letsubs [{:keys [chaos-mode? webview-debug]} [:multiaccount]
                   network-name             [:network-name]
                   waku-bloom-filter-mode   [:waku/bloom-filter-mode]
                   current-log-level        [:log-level/current-log-level]
@@ -133,6 +143,7 @@
                     :current-fleet          current-fleet
                     :dev-mode?              false
                     :waku-bloom-filter-mode waku-bloom-filter-mode
+                    :webview-debug          webview-debug
                     :chaos-mode?            chaos-mode?})
        :key-fn    (fn [_ i] (str i))
        :render-fn render-item}]]))


### PR DESCRIPTION
This PR aims to fix some "develop in the dark" issues that Dapp developers have been having.

Effectively, because they can't download the production version of our app and debug their dapps, they develop in the dark. This PR should allow them to temporarily turn debug mode on and attach a remote Chrome / Safari to the dapp browser to make sure they can develop using the tools they usually use.