### PR TITLE
Fix crash when passcode disabled

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -224,7 +224,7 @@
                  :on-success #(re-frame/dispatch [::get-settings-callback %])}]}
               (when save-password?
                 (keychain/save-user-password key-uid password))
-              (keychain/save-auth-method key-uid (or new-auth-method auth-method)))))
+              (keychain/save-auth-method key-uid (or new-auth-method auth-method keychain/auth-method-none)))))
 
 (fx/defn create-only-events
   [{:keys [db] :as cofx}]


### PR DESCRIPTION

fixes #11085

### Summary

Fixes problem with crash on login when passcode was disabled on iOS. 


### Review notes
In code we don't expect that `auth_method` could be `nil` and pass it to `keychain/save-auth-method`. That results in calling `(.setInternetCredentials react-native-keychain)` with `nil` password and crash.

### Testing notes

#### Platforms
- iOS

#### Areas that maybe impacted
Login flow


### Steps to test

- Open Status
- Create account and login
- Turn on "Save password", enable biometric authentication
- Relogin
- On your device: go to Settings > Touch ID and Passcode > select "Turn passcode off"
- open Status and try to login

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
