### PR TITLE
Add update gesture to wallet

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -21,6 +21,7 @@
                             :ReanimatedModule       {:configureProps (fn [])}}
 
             :View                     {}
+            :RefreshControl           {}
             :FlatList                 {}
             :Text                     {}
             :ProgressBarAndroid       {}

--- a/src/quo/components/animated_header.cljs
+++ b/src/quo/components/animated_header.cljs
@@ -44,7 +44,7 @@
         offset          (reagent/atom 0)
         on-layout       (fn [evt]
                           (reset! offset (oget evt "nativeEvent" "layout" "height")))]
-    (fn [{:keys [extended-header] :as props} children]
+    (fn [{:keys [extended-header refresh on-scroll-begin-drag] :as props} children]
       [animated/view {:flex           1
                       :pointer-events :box-none}
        [animated/code {:key  (str @offset)
@@ -66,16 +66,20 @@
                                                              :offset    @offset}]]
                          :title-align     :left}
                         (dissoc props :extended-header))]]
-       (into [animated/scroll-view {:on-scroll           on-scroll
-                                    :style               {:z-index 1}
-                                    :scrollEventThrottle 16}
-              [animated/view {:pointer-events :box-none}
-               [animated/view {:pointer-events :box-none
-                               :on-layout      on-layout}
-                [extended-header {:value     y
-                                  :animation animation
-                                  :offset    @offset}]]]]
-             children)])))
+       (let [scroll-view-options (merge {:on-scroll           on-scroll
+                                         :style               {:z-index 1}
+                                         :scrollEventThrottle 16}
+                                        (when refresh {:refresh-control (refresh)})
+                                        (when on-scroll-begin-drag
+                                          {:on-scroll-begin-drag (on-scroll-begin-drag)}))]
+         (into [animated/scroll-view scroll-view-options
+                [animated/view {:pointer-events :box-none}
+                 [animated/view {:pointer-events :box-none
+                                 :on-layout    on-layout}
+                  [extended-header {:value     y
+                                    :animation animation
+                                    :offset    @offset}]]]]
+               children))])))
 
 (defn header [{:keys [use-insets] :as props} & children]
   (if use-insets

--- a/src/quo/react_native.cljs
+++ b/src/quo/react_native.cljs
@@ -18,6 +18,8 @@
 (def scroll-view (reagent/adapt-react-class (.-ScrollView ^js rn)))
 (def modal (reagent/adapt-react-class (.-Modal ^js rn)))
 
+(def refresh-control (reagent/adapt-react-class (.-RefreshControl ^js rn)))
+
 (def touchable-opacity (reagent/adapt-react-class (.-TouchableOpacity ^js rn)))
 (def touchable-highlight (reagent/adapt-react-class (.-TouchableHighlight ^js rn)))
 (def touchable-without-feedback (reagent/adapt-react-class (.-TouchableWithoutFeedback ^js rn)))

--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -14,6 +14,7 @@
             [status-im.ui.screens.wallet.accounts.sheets :as sheets]
             [status-im.ui.screens.wallet.accounts.views :as accounts]
             [status-im.ui.screens.wallet.transactions.views :as history]
+            [status-im.ui.screens.wallet.refresh-control :as rc]
             [status-im.utils.money :as money]
             [status-im.wallet.utils :as wallet.utils])
   (:require-macros [status-im.utils.views :as views]))
@@ -41,14 +42,11 @@
 (views/defview account-card [{:keys [address color type] :as account}]
   (views/letsubs [currency        [:wallet/currency]
                   portfolio-value [:account-portfolio-value address]
-                  window-width    [:dimensions/window-width]
-                  prices-loading? [:prices-loading?]]
+                  window-width    [:dimensions/window-width]]
     [react/view {:style (styles/card window-width color)}
      [react/view {:padding 16 :padding-bottom 12 :flex 1 :justify-content :space-between}
       [react/view {:style {:flex-direction :row}}
-       (if prices-loading?
-         [react/small-loading-indicator :colors/white-persist]
-         [react/text {:style {:font-size 32 :color colors/white-persist :font-weight "600"}} portfolio-value])
+       [react/text {:style {:font-size 32 :color colors/white-persist :font-weight "600"}} portfolio-value]
        [react/text {:style {:font-size 32 :color colors/white-transparent-persist :font-weight "600"}} (str " " (:code currency))]]
       [quo/text {:number-of-lines 1
                  :ellipsize-mode  :middle
@@ -196,7 +194,8 @@
          :on-scroll             (animation/event
                                  [{:nativeEvent {:contentOffset {:y scroll-y}}}]
                                  {:useNativeDriver true})
-         :scrollEventThrottle   1}
+         :scrollEventThrottle   1
+         :refresh-control (rc/refresh-control)}
         [react/view {:padding-left 16}
          [react/scroll-view {:horizontal true}
           [react/view {:flex-direction :row :padding-top 8 :padding-bottom 12}

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -176,8 +176,7 @@
        [quo/animated-header
         {:extended-header   total-value
          :use-insets        true
-         :refresh              (rc/refresh-control)
-         :on-scroll-begin-drag rc/refresh-action
+         :refresh           rc/refresh-control
          :right-accessories [{:on-press            #(re-frame/dispatch
                                                      [::qr-scanner/scan-code
                                                       {:handler :wallet.send/qr-scanner-result}])

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -10,6 +10,7 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.wallet.accounts.sheets :as sheets]
             [status-im.ui.screens.wallet.accounts.styles :as styles]
+            [status-im.ui.screens.wallet.refresh-control :as rc]
             [status-im.qr-scanner.core :as qr-scanner]
             [status-im.wallet.utils :as wallet.utils]
             [status-im.keycard.login :as keycard.login])
@@ -17,8 +18,7 @@
 
 (views/defview account-card [{:keys [name color address type] :as account}]
   (views/letsubs [currency        [:wallet/currency]
-                  portfolio-value [:account-portfolio-value address]
-                  prices-loading? [:prices-loading?]]
+                  portfolio-value [:account-portfolio-value address]]
     [react/touchable-highlight
      {:on-press            #(re-frame/dispatch [:navigate-to :wallet-account account])
       :accessibility-label (str "accountcard" name)
@@ -28,10 +28,9 @@
      [react/view {:style (styles/card color)}
       [react/view {:flex-direction :row :align-items :center :justify-content :space-between}
        [react/view {:style {:flex-direction :row}}
-        (if prices-loading?
-          [react/small-loading-indicator :colors/white-persist]
-          [react/text {:style               {:color colors/white-persist :font-weight "500"}
-                       :accessibility-label "account-total-value"} portfolio-value])
+        [react/text {:style
+                     {:color colors/white-persist :font-weight "500"}
+                     :accessibility-label "account-total-value"} portfolio-value]
         [react/text {:style {:color colors/white-transparent-persist :font-weight "500"}} (str " " (:code currency))]]
        [react/touchable-highlight
         {:on-press #(re-frame/dispatch [:show-popover
@@ -177,6 +176,8 @@
        [quo/animated-header
         {:extended-header   total-value
          :use-insets        true
+         :refresh              (rc/refresh-control)
+         :on-scroll-begin-drag rc/refresh-action
          :right-accessories [{:on-press            #(re-frame/dispatch
                                                      [::qr-scanner/scan-code
                                                       {:handler :wallet.send/qr-scanner-result}])

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -17,3 +17,8 @@
  ::wallet-add-custom-token
  (fn [{:keys [db]}]
    {:db (dissoc db :wallet/custom-token-screen)}))
+
+(handlers/register-handler-fx
+ :prices-loading?
+ (fn [{:keys [db]}]
+   {:db (assoc db :prices-loading? true)}))

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -17,8 +17,3 @@
  ::wallet-add-custom-token
  (fn [{:keys [db]}]
    {:db (dissoc db :wallet/custom-token-screen)}))
-
-(handlers/register-handler-fx
- :prices-loading?
- (fn [{:keys [db]}]
-   {:db (assoc db :prices-loading? true)}))

--- a/src/status_im/ui/screens/wallet/refresh_control.cljs
+++ b/src/status_im/ui/screens/wallet/refresh_control.cljs
@@ -1,0 +1,15 @@
+(ns status-im.ui.screens.wallet.refresh-control
+  (:require [re-frame.core :as re-frame]
+            [reagent.core :as reagent]
+            [quo.react-native :as rn]))
+
+(defn refresh-action []
+  (fn []
+    (when (false? @(re-frame/subscribe [:prices-loading?]))
+      (re-frame/dispatch [:wallet.ui/pull-to-refresh]))))
+
+(defn refresh-control
+  []
+  (fn []
+    (reagent/as-element
+     [rn/refresh-control {:refreshing @(re-frame/subscribe [:prices-loading?])}])))

--- a/src/status_im/ui/screens/wallet/refresh_control.cljs
+++ b/src/status_im/ui/screens/wallet/refresh_control.cljs
@@ -4,12 +4,10 @@
             [quo.react-native :as rn]))
 
 (defn refresh-action []
-  (fn []
-    (when (false? @(re-frame/subscribe [:prices-loading?]))
-      (re-frame/dispatch [:wallet.ui/pull-to-refresh]))))
+  (re-frame/dispatch-sync [:wallet.ui/pull-to-refresh])
+  (reagent/flush))
 
-(defn refresh-control
-  []
-  (fn []
-    (reagent/as-element
-     [rn/refresh-control {:refreshing @(re-frame/subscribe [:prices-loading?])}])))
+(defn refresh-control []
+  (reagent/as-element
+   [rn/refresh-control {:refreshing @(re-frame/subscribe [:prices-loading?])
+                        :onRefresh  refresh-action}]))

--- a/src/status_im/wallet/prices.cljs
+++ b/src/status_im/wallet/prices.cljs
@@ -24,15 +24,12 @@
 (re-frame/reg-fx
  :wallet/get-prices
  (fn [{:keys [from to mainnet? success-event error-event chaos-mode?]}]
-   (let [milliseconds 1000
-         get-prices   (fn []
-                        (prices/get-prices from
-                                           to
-                                           mainnet?
-                                           #(re-frame/dispatch [success-event %])
-                                           #(re-frame/dispatch [error-event %])
-                                           chaos-mode?))]
-     (js/setTimeout get-prices milliseconds))))
+   (prices/get-prices from
+                      to
+                      mainnet?
+                      #(re-frame/dispatch [success-event %])
+                      #(re-frame/dispatch [error-event %])
+                      chaos-mode?)))
 
 (fx/defn on-update-prices-success
   {:events [::update-prices-success]}


### PR DESCRIPTION
**CONTEXT**: I was in a chat with Ceri, @andremedeiros & @hesterbruikman while I worked on this issue: https://github.com/status-im/status-react/issues/10242


### Summary

Works on a feature as specified in https://github.com/status-im/status-react/issues/10242

<!-- (Optional, remove if no changes to documentation) -->
Documentation change PR (review please): https://github.com/status-im/status.im/pull/xxx
(❓ **QUESTION:** What do I put above, the URL of this PR?)
### Review notes
I've posted the question below, but here it is for completeness: 

> hi, I have a question about this event :wallet.ui/pull-to-refresh.
>
> For this task, is this a sufficient/correct place to call it?
>
> Because under a single wallet view, there are Collectibles and History.
>
> So for :wallet.transactions.history/screen which populates History and for :wallet/visible-assets-with-values, which would  deal with Assets & Collectibles, should I do any additional work? And if I should, is there a way to add this data, as a stub to pre-populate it, so that it's meaningful?


### Testing notes
<!-- (Optional) -->

#### Platforms

- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions

### Steps to test

- Go to **Wallet**, pull to refresh

