### PR TITLE
[#11003] Optionally use ENS name as author when building Android notifications

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/NewMessageSignalHandler.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/NewMessageSignalHandler.java
@@ -325,7 +325,9 @@ public class NewMessageSignalHandler {
 
     private StatusMessage createMessage(JSONObject messageData) {
         try {
-            Person author = getPerson(messageData.getString("from"), messageData.getString("identicon"), messageData.getString("alias"));
+            String ensName = messageData.optString("ensName");
+            String displayName = (ensName.isEmpty()) ? messageData.getString("alias") : ensName;
+            Person author = getPerson(messageData.getString("from"), messageData.getString("identicon"), displayName);
             return new StatusMessage(author,  messageData.getLong("whisperTimestamp"), messageData.getString("text"));
         } catch (JSONException e) {
             Log.e(TAG, "JSON conversion failed: " + e.getMessage());


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #11003 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This was an issue where the ENS name was not extracted from a chat message properly. The PR optionally gets the ENS name when present, and uses the 3-random name otherwise.

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms

- Android


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- As user A on an android device, start 1-1 chat with user B that has no ENS name yet
- Minimize app
- Send message from user B to user A
- 3-random name should be shown in notification on user A's device
- Register ENS name as user B
- Send message from user B to user A
- ENS name should be shown in notification on user A's device

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: wip <!-- Can be ready or wip -->
