### PR TITLE
nix: upgrade nixpkgs

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -32,6 +32,8 @@ in {
   gradlePropParser = callPackage ./tools/gradlePropParser.nix { };
 
   # Package version adjustments
+  go = super.pkgs.go_1_14;
+  gradle = super.pkgs.gradle_5;
   nodejs = super.pkgs.nodejs-12_x;
   openjdk = super.pkgs.openjdk8_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -13,8 +13,8 @@ let
     name = "nixpkgs-source";
     owner = "status-im";
     repo = "nixpkgs";
-    rev = "6dacca5eb43a8bfb02fb09331df607d4465a28e9";
-    sha256 = "0whwzll9lvrq4gg5j838skg7fqpvb55w4z7y44pzib32k613y2qn";
+    rev = "3355743cfd8d89cfa8d3b8e6d40c48e62e72d36a";
+    sha256 = "1l7559m3xkzwkm202rkjq3a8cz52k7z9vxn9y2adc30cp197wc82";
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
   };

--- a/nix/pkgs/gomobile/default.nix
+++ b/nix/pkgs/gomobile/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, utils, callPackage, fetchgit, buildGoPackage,
+{ stdenv, utils, callPackage, fetchgit, buildGo114Package,
   ncurses5, zlib, makeWrapper, patchelf, androidPkgs, xcodeWrapper
 }:
 
 let
   inherit (stdenv) isDarwin;
   inherit (stdenv.lib) optional optionalString strings;
-in buildGoPackage rec {
+in buildGo114Package rec {
   pname = "gomobile";
-  version = "20200329-${strings.substring 0 7 rev}";
-  rev = "4c31acba000778d337c0e4f32091cc923b3363d2";
-  sha256 = "0k42pn6fq886k9hn85wbgg4h4y1myj7niw0746sn50zfbrmy3s2c";
+  version = "20200622-${strings.substring 0 7 rev}";
+  # WARNING: Next commit removes support for ARM 32 bit builds for iOS
+  rev = "33b80540585f2b31e503da24d6b2a02de3c53ff5";
+  sha256 = "0c9map2vrv34wmaycsv71k4day3b0z5p16yzxmlp8amvqb38zwlm";
 
   goPackagePath = "golang.org/x/mobile";
   subPackages = [ "bind" "cmd/gobind" "cmd/gomobile" ];

--- a/nix/pkgs/gomobile/deps.nix
+++ b/nix/pkgs/gomobile/deps.nix
@@ -1,20 +1,21 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
   {
-    goPackagePath = "golang.org/x/tools";
+    goPackagePath = "github.com/BurntSushi/xgb";
     fetch = {
       type = "git";
-      url = "https://go.googlesource.com/tools";
-      rev =  "6edc0a871e69";
-      sha256 = "1nxrr7nin65cmsm6i3vxdc57n03v1i541hfllw0p4zw8f414wfll";
+      url = "https://github.com/BurntSushi/xgb";
+      rev = "27f122750802";
+      sha256 = "18lp2x8f5bljvlz0r7xn744f0c9rywjsb9ifiszqqdcpwhsa0kvj";
     };
   }
   {
-    goPackagePath = "golang.org/x/mod";
+    goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
-      url = "https://go.googlesource.com/mod";
-      rev =  "331c550502dd";
-      sha256 = "0942gzs6mlsjal4drjmm8gr54pj1cdhsl9mnj3ygm200mf3fj6pi";
+      url = "https://go.googlesource.com/crypto";
+      rev = "87dc89f01550";
+      sha256 = "0z4i1m2yn3f31ci7wvcm2rxkx2yiv7a78mfzklncmsz2k97rlh2g";
     };
   }
   {
@@ -22,7 +23,7 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/exp";
-      rev =  "ec7cb31e5a56";
+      rev = "ec7cb31e5a56";
       sha256 = "19b4kdwfahq9f809v4lmn9h47sq1y67nkl7csnracn5qd334hp06";
     };
   }
@@ -31,8 +32,62 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/image";
-      rev =  "cff245a6509b";
+      rev = "cff245a6509b";
       sha256 = "0hiznlkiaay30acwvvyq8g6bm32r7bc6gv47pygrcxqpapasbz84";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mod";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mod";
+      rev = "331c550502dd";
+      sha256 = "0942gzs6mlsjal4drjmm8gr54pj1cdhsl9mnj3ygm200mf3fj6pi";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "3b0461eec859";
+      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "97732733099d";
+      sha256 = "118hkp01i4z1f5h6hcjm0ff2ngqhrzj1f7731n0kw8dr6hvbx0sw";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "6edc0a871e69";
+      sha256 = "1nxrr7nin65cmsm6i3vxdc57n03v1i541hfllw0p4zw8f414wfll";
     };
   }
   {
@@ -40,7 +95,7 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/xerrors";
-      rev =  "1b5146add8981d58be77b16229c0ff0f8bebd8c1";
+      rev = "1b5146add898";
       sha256 = "0w2akj91krxjag0xdhsg78470888nicc5ismc2ap9jqpss6v1zih";
     };
   }

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, utils, callPackage, buildGoPackage
+{ lib, stdenv, utils, callPackage, buildGo114Package
 , go, androidPkgs, openjdk, gomobile, xcodeWrapper
 # object with source attributes
 , meta, source
@@ -20,7 +20,7 @@ let
   # formatted for use with -target
   targetArchs = map (a: "${platform}/${a}") architectures;
 
-in buildGoPackage {
+in buildGo114Package {
   pname = source.repo;
   version = "${source.cleanVersion}-${source.shortRev}-${platform}";
 


### PR DESCRIPTION
Significant updates:

- Git: `2.25.1` to `2.28.0`
- Make: `4.2.1` to `4.3`
- Glibc: `2.30` to `2.31`
- PatchElf: `0.9` to `0.11`
- GoLang: `1.14.0` to `1.14.7`
- NodeJS: `v12.16.2` to `v12.18.3`
- Clojure: `1.10.1.507` to `1.10.1.645`
- OpenJDK: `8u242-b08` to `8u265-ga`
- GoMobile: `20200329` to `20200622`

This is done in advance of Android SDK/NDK updates when https://github.com/NixOS/nixpkgs/pull/89775 is merged.

Some local testing would be much appreciated.