### PR TITLE
Update nREPL to the latest stable

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,7 +14,7 @@
                 [mvxcvi/alphabase "1.0.0"]
                 ;; dev dependencies
                 [refactor-nrepl "2.5.0"]
-                [cider/cider-nrepl "0.24.0"]
+                [cider/cider-nrepl "0.25.3"]
                 [cider/piggieback "0.4.1"]
                 [re-frisk-remote "1.3.1"]
                 ;; routing


### PR DESCRIPTION



### Summary

With the update of Emacs CIDER 0.26.1, it expects to have the latest
cider-nrepl dependency to be at 0.25.3 otherwise it throws an error
when connecting to the project's REPL.

### Platforms

Not applicable, it can only be seen on developers machines.

### Steps to test

With Emacs, install the latest CIDER mode at the time of this writing, start the project as per documentation and you should not see an error.

To see the error, downgrade `cider-nrepl` to `0.24.0`.
