### PR TITLE
Aligning react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "hi-base32": "^0.5.0",
     "i18n-js": "^3.3.0",
     "qrcode": "^1.4.1",
-    "react": "16.11.0",
+    "react": "16.13.0",
     "react-dom": "^16.4.2",
     "react-native": "0.62.2",
     "react-native-background-timer": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6717,10 +6717,10 @@ react-refresh@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.2.tgz#54a277a6caaac2803d88f1d6f13c1dcfbd81e334"
   integrity sha512-kv5QlFFSZWo7OlJFNYbxRtY66JImuP2LcrFgyJfQaf85gSP+byzG21UbDQEYjU7f//ny8rwiEkO6py2Y+fEgAQ==
 
-react@16.11.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
-  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+react@16.13.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.0.tgz#d046eabcdf64e457bbeed1e792e235e1b9934cf7"
+  integrity sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
When starting the project the following would be spat out:

```
NPM dependency "react" has installed version "16.11.0"

"16.13.0" was required by jar:file:/Users/alex/.m2/repository/reagent/reagent/0.10.0/reagent-0.10.0.jar!/deps.cljs
```

I've bumped up the version in package.json to to match the one being
pulled in by reagent.


### Summary

Ensuring that the versions of `react` as defined by NPM & shadow-cljs match.

### Review notes

If any known issues exist that require `16.11.0` then this would be an issue.
But since one version is defined and the source of another used...

### Testing notes

Start the app and confirm that there are no issues.

I've tested it in the simulator, no issues seen. 

#### Platforms

- Android
- iOS




