### PR TITLE
[mentions] Open profile tab instead of user profile view on pressing own mention

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -282,6 +282,17 @@
                      (i18n/label :cooldown/warning-message)
                      #())))
 
+(fx/defn show-profile-without-adding-contact
+  {:events [:chat.ui/show-profile-without-adding-contact]}
+  [{:keys [db] :as cofx} identity]
+  (let [my-public-key (get-in db [:multiaccount :public-key])]
+    (if (= my-public-key identity)
+      (navigation/navigate-to-cofx cofx :my-profile nil)
+      (fx/merge
+       cofx
+       {:db (assoc db :contacts/identity identity)}
+       (navigation/navigate-to-cofx :profile nil)))))
+
 (fx/defn show-profile
   {:events [:chat.ui/show-profile]}
   [cofx identity]

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -90,7 +90,7 @@
                                     outgoing                                            colors/mention-outgoing
                                     :else                                               colors/mention-incoming)}
                 :on-press (when-not (= content-type constants/content-type-system-text)
-                            #(re-frame/dispatch [:chat.ui/show-profile literal]))}
+                            #(re-frame/dispatch [:chat.ui/show-profile-without-adding-contact literal]))}
                [mention-element literal]])
     "status-tag"
     (conj acc [react/text-class


### PR DESCRIPTION
status: ready