### PR TITLE
[Fixes: #11290] Increase group size to 20

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -50,7 +50,7 @@
 (def command-state-transaction-sent 7)
 
 (def min-password-length 6)
-(def max-group-chat-participants 10)
+(def max-group-chat-participants 20)
 (def default-number-of-messages 20)
 
 (def mailserver-password "status-offline-inbox")


### PR DESCRIPTION
Fixes: #11290

Increases the maximum size of a group chat to 20.

We should test the performance sending messages on a lower end device when 20 participants are in the group.

status: ready