### PR TITLE
Allow sending multiple images at once

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -259,8 +259,8 @@ PODS:
     - React
   - react-native-splash-screen (3.2.0):
     - React
-  - react-native-webview (10.3.1):
-    - React
+  - react-native-webview (10.9.2):
+    - React-Core
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
   - React-RCTAnimation (0.62.2):
@@ -630,7 +630,7 @@ SPEC CHECKSUMS:
   react-native-shake: de052eaa3eadc4a326b8ddd7ac80c06e8d84528c
   react-native-slider: 12bd76d3d568c9c5500825db54123d44b48e4ad4
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
-  react-native-webview: 40bbeb6d011226f34cb83f845aeb0fdf515cfc5f
+  react-native-webview: 4e96d493f9f90ba4f03b28933f30b2964df07e39
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71

--- a/src/quo/design_system/colors.cljs
+++ b/src/quo/design_system/colors.cljs
@@ -46,7 +46,8 @@
    :shadow-01      "rgba(0,9,26,0.12)"     ; Main shadow color
    :backdrop       "rgba(0,0,0,0.4)"       ; Backdrop for modals and bottom sheet
    :border-01      "rgba(238,242,245,1)"
-   :border-02      "rgba(67, 96, 223, 0.1)"})
+   :border-02      "rgba(67, 96, 223, 0.1)"
+   :highlight      "rgba(67,96,223,0.4)"})
 
 (def dark-theme
   {:positive-01    "rgba(68,208,88,1)"
@@ -75,7 +76,8 @@
    :shadow-01      "rgba(0,0,0,0.75)"
    :backdrop       "rgba(0,0,0,0.4)"
    :border-01      "rgba(37,37,40,1)"
-   :border-02      "rgba(97,119,229,0.1)"})
+   :border-02      "rgba(97,119,229,0.1)"
+   :highlight      "rgba(67,96,223,0.4)"})
 
 (def theme (reagent/atom light-theme))
 

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -233,8 +233,12 @@
             (rebuild-message-list chat-id)))
 
 (fx/defn send-message
-  [{:keys [db now] :as cofx} {:keys [chat-id] :as message}]
-  (protocol/send-chat-message cofx message))
+  [{:keys [db now] :as cofx} message]
+  (protocol/send-chat-messages cofx [message]))
+
+(fx/defn send-messages
+  [{:keys [db now] :as cofx} messages]
+  (protocol/send-chat-messages cofx messages))
 
 (fx/defn toggle-expand-message
   [{:keys [db]} chat-id message-id]

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -5,31 +5,31 @@
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]))
 
-(fx/defn send-chat-message [cofx {:keys [chat-id
-                                         text
-                                         response-to
-                                         ens-name
-                                         image-path
-                                         audio-path
-                                         audio-duration-ms
-                                         message-type
-                                         sticker
-                                         content-type]
-                                  :as message}]
-  {::json-rpc/call [{:method (json-rpc/call-ext-method
-                              "sendChatMessage")
-                     :params [{:chatId chat-id
-                               :text text
-                               :responseTo response-to
-                               :ensName ens-name
-                               :imagePath image-path
-                               :audioPath audio-path
-                               :audioDurationMs audio-duration-ms
-                               :sticker sticker
-                               :contentType content-type}]
-                     :on-success
-                     #(re-frame/dispatch [:transport/message-sent % 1])
-                     :on-failure #(log/error "failed to send a message" %)}]})
+(defn build-message [{:keys [chat-id
+                             text
+                             response-to
+                             ens-name
+                             image-path
+                             audio-path
+                             audio-duration-ms
+                             sticker
+                             content-type]}]
+  {:method     (json-rpc/call-ext-method "sendChatMessage")
+   :params     [{:chatId          chat-id
+                 :text            text
+                 :responseTo      response-to
+                 :ensName         ens-name
+                 :imagePath       image-path
+                 :audioPath       audio-path
+                 :audioDurationMs audio-duration-ms
+                 :sticker         sticker
+                 :contentType     content-type}]
+   :on-success
+   #(re-frame/dispatch [:transport/message-sent % 1])
+   :on-failure #(log/error "failed to send a message" %)})
+
+(fx/defn send-chat-messages [cofx messages]
+  {::json-rpc/call (mapv build-message messages)})
 
 (fx/defn send-reaction [cofx {:keys [message-id chat-id emoji-id]}]
   {::json-rpc/call [{:method     (json-rpc/call-ext-method

--- a/src/status_im/ui/components/permissions.cljs
+++ b/src/status_im/ui/components/permissions.cljs
@@ -6,13 +6,14 @@
   {:read-external-storage  (cond
                              platform/android? (.-READ_EXTERNAL_STORAGE (.-ANDROID PERMISSIONS)))
    :write-external-storage (cond
-                             platform/android? (.-WRITE_EXTERNAL_STORAGE (.-ANDROID PERMISSIONS)))
+                             platform/android? (.-WRITE_EXTERNAL_STORAGE (.-ANDROID PERMISSIONS))
+                             platform/ios?     (.-PHOTO_LIBRARY (.-IOS PERMISSIONS)))
    :camera                 (cond
                              platform/android? (.-CAMERA (.-ANDROID PERMISSIONS))
-                             platform/ios? (.-CAMERA (.-IOS PERMISSIONS)))
+                             platform/ios?     (.-CAMERA (.-IOS PERMISSIONS)))
    :record-audio           (cond
                              platform/android? (.-RECORD_AUDIO (.-ANDROID PERMISSIONS))
-                             platform/ios? (.-MICROPHONE (.-IOS PERMISSIONS)))})
+                             platform/ios?     (.-MICROPHONE (.-IOS PERMISSIONS)))})
 
 (defn all-granted? [permissions]
   (let [permission-vals (distinct (vals permissions))]

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -192,9 +192,9 @@
 (defn show-image-picker
   ([images-fn]
    (show-image-picker images-fn nil))
-  ([images-fn media-type]
+  ([images-fn {:keys [multiple media-type]}]
    (->  ^js image-picker
-        (.openPicker (clj->js {:multiple false :mediaType (or media-type "any")}))
+        (.openPicker (clj->js {:multiple multiple :mediaType (or media-type "any")}))
         (.then images-fn)
         (.catch show-access-error))))
 

--- a/src/status_im/ui/screens/chat/components/input.cljs
+++ b/src/status_im/ui/screens/chat/components/input.cljs
@@ -287,7 +287,7 @@
      {:style (styles/input-container)}
      (when reply
        [reply/reply-message reply])
-     (when sending-image
+     (when (seq sending-image)
        [reply/send-image sending-image])
      [rn/view {:style (styles/input-row)}
       [text-input props]

--- a/src/status_im/ui/screens/chat/components/reply.cljs
+++ b/src/status_im/ui/screens/chat/components/reply.cljs
@@ -71,13 +71,17 @@
        [icons/icon :main-icons/close-circle {:container-style (styles/close-button)
                                              :color           (:icon-01 @colors/theme)}]]]]))
 
-(defn send-image [{:keys [uri]}]
+(defn send-image [images]
   [rn/view {:style (styles/reply-container true)}
-   [rn/view {:style (styles/reply-content)}
-    [rn/image {:source {:uri uri}
-               :style  {:width         56
-                        :height        56
-                        :border-radius 4}}]]
+   [rn/scroll-view {:horizontal true
+                    :style      (styles/reply-content)}
+    (for [{:keys [uri]} (vals images)]
+      ^{:key uri}
+      [rn/image {:source {:uri uri}
+                 :style  {:width         56
+                          :height        56
+                          :border-radius 4
+                          :margin-right  4}}])]
    [rn/view
     [pressable/pressable {:on-press            #(re-frame/dispatch [:chat.ui/cancel-sending-image])
                           :accessibility-label :cancel-send-image}

--- a/src/status_im/ui/screens/chat/styles/message/message.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/message.cljs
@@ -301,9 +301,21 @@
     (outgoing-blockquote-text-style)
     (default-blockquote-text-style)))
 
-(defn image-content [outgoing]
-  {:overflow                   :hidden
+(defn image-message
+  [{:keys [outgoing width height]}]
+  {:overflow                   "hidden"
    :border-top-left-radius     16
    :border-top-right-radius    16
    :border-bottom-left-radius  (if outgoing 16 4)
-   :border-bottom-right-radius (if outgoing 4 16)})
+   :border-bottom-right-radius (if outgoing 4 16)
+   :width                      width
+   :height                     height})
+
+(defn image-message-border [opts]
+  (merge (image-message opts)
+         {:position         :absolute
+          :top              0
+          :left             0
+          :background-color "transparent"
+          :border-width     1
+          :border-color     colors/black-transparent}))


### PR DESCRIPTION
Fixes 2 subtasks from #10727

* [x] Allow queuing and sending multiple images in a batch
* [x] Add a 1px 10% black transparent inner border over the images in chat so that there's a subtle outline separation from the background

Open question:

* ~~Should we add a limit for max images in batch?~~ Added limit of 5

Extra:

* On Android, it is not possible to set a max limit for gallery picking. If a user will select too many images the app crashes, because of that on android we allow choosing one image at a time.
* The gallery picker and camera roll return different images paths. Because of that, we cannot distingush inside the camera roll if a given image was already selected from the gallery. Other apps doesn't allow a user to mix them, if you open gallery then the access to camera roll is hidden and vice-versa.

