### PR TITLE
nix: make status-go matching regex more lax

### DIFF
--- a/nix/tools/utils.nix
+++ b/nix/tools/utils.nix
@@ -48,14 +48,14 @@ let
 
   # paths don't like slashes in them
   dropSlashes = builtins.replaceStrings [ "/" ] [ "_" ];
-  # if version doesn't match this it's probably a commit
-  versionRegex = "^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].]+)?$";
+  # if version doesn't match this it's probably a commit, it's lax semver
+  versionRegex = "^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[[:alnum:]_.-]*$";
   sanitizeVersion = version:
     if (builtins.match versionRegex version) != null
     # Geth forces a 'v' prefix for all versions
     then lib.removePrefix "v" (dropSlashes version) 
     # reduce metrics cardinality in Prometheus
-    else "develop"; 
+    else lib.traceValFn (v: "WARNING: Marking build version as 'develop'!") "develop"; 
 
 in {
   inherit sanitizeVersion


### PR DESCRIPTION
We had an issue where the `1.7.0` release was using the [`v0.62.3.hotfix.3`](https://github.com/status-im/status-go/commit/59e66024) version of `status-go` which didn't match the regex we use to verify if the specified version is a valid version according to [Semantic Versioning](https://semver.org/).

You can check the current regex here: https://regex101.com/r/OeTQCv/3

You can see the raise in `vdevelop` version of Status nodes in the metrics starting with 2020/10/01 when `1.7.0` was released:
https://metrics.status.im/d/gxQG_R1Zk/status-peers?orgId=1&from=1601536351158&to=1601617994138&var-fleet=eth.prod&var-host=mail&var-type=StatusIM&var-platform=android-arm64&var-platform=android-arm