### PR TITLE
[#10771] Fix loading of tx history before 10000000th block

### DIFF
--- a/src/status_im/ethereum/transactions/core.cljs
+++ b/src/status_im/ethereum/transactions/core.cljs
@@ -158,8 +158,8 @@
          (fn [{:keys [min-block] :as acc}
               {:keys [block hash]}]
            (cond
-             (or (nil? min-block) (> min-block block))
-             {:min-block                 block
+             (or (nil? min-block) (> min-block (js/parseInt block)))
+             {:min-block                 (js/parseInt block)
               :min-block-transfers-count 1}
 
              (and (= min-block block)
@@ -168,7 +168,8 @@
 
              :else acc))
          {:min-block
-          (get-min-known-block db address)
+          (when-let [min-block-string (get-min-known-block db address)]
+            (js/parseInt min-block-string))
 
           :min-block-transfers-count
           (min-block-transfers-count db address)}


### PR DESCRIPTION
fix #10771

The problem was caused by string comparison, because `"9" > "10" == true` `¯\_(ツ)_/¯`