### PR TITLE
📜 [#11350] Fix scroll issue

### DIFF
--- a/src/status_im/ui/screens/offline_messaging_settings/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/views.cljs
@@ -57,23 +57,24 @@
        [{:icon    :main-icons/add-circle
          :on-press #(re-frame/dispatch [:mailserver.ui/add-pressed])}]}]
 
-     [react/view {:style styles/switch-container}
-      [profile.components/settings-switch-item
-       {:label-kw  :t/offline-messaging-use-history-nodes
-        :value     use-mailservers?
-        :action-fn #(re-frame/dispatch [:mailserver.ui/use-history-switch-pressed (not use-mailservers?)])}]]
-     [react/view {:style styles/use-history-explanation-text-container}
-      [react/text {:style styles/explanation-text}
-       (i18n/label :t/offline-messaging-use-history-explanation)]]
+     [react/scroll-view
+      [react/view {:style styles/switch-container}
+       [profile.components/settings-switch-item
+        {:label-kw  :t/offline-messaging-use-history-nodes
+         :value     use-mailservers?
+         :action-fn #(re-frame/dispatch [:mailserver.ui/use-history-switch-pressed (not use-mailservers?)])}]]
+      [react/view {:style styles/use-history-explanation-text-container}
+       [react/text {:style styles/explanation-text}
+        (i18n/label :t/offline-messaging-use-history-explanation)]]
 
-     (when use-mailservers?
-       [:<>
-        [pinned-state preferred-mailserver-id]
+      (when use-mailservers?
+        [:<>
+         [pinned-state preferred-mailserver-id]
 
-        [react/text {:style styles/history-nodes-label}
-         (i18n/label :t/history-nodes)]
-        [list/flat-list {:data               (vals mailservers)
-                         :default-separator? false
-                         :key-fn             :name
-                         :render-fn          (render-row current-mailserver-id
-                                                         preferred-mailserver-id)}]])]))
+         [react/text {:style styles/history-nodes-label}
+          (i18n/label :t/history-nodes)]
+         [list/flat-list {:data               (vals mailservers)
+                          :default-separator? false
+                          :key-fn             :name
+                          :render-fn          (render-row current-mailserver-id
+                                                          preferred-mailserver-id)}]])]]))


### PR DESCRIPTION
fixes #11350 

### Summary
When selecting mailservers manually, the page was not scroll-able, which led to a messy UX. Especially on smaller devices. This PR makes the entire page scroll-able.


#### Platforms
- Android
- iOS


#### Areas that maybe impacted
None. UI only change.

##### Functional
- mailservers


### Steps to test

- Open Status
- Goto Profile
- Goto Settings > Sync Settings
- Turn off automatic mailserver selection
- The entire page should scroll (without this PR, only the mailserver list will scroll)


status: ready