### PR TITLE
Don't make inability to unfurl url a user's problem

### DIFF
--- a/src/status_im/chat/models/link_preview.cljs
+++ b/src/status_im/chat/models/link_preview.cljs
@@ -23,16 +23,17 @@
             {::json-rpc/call [{:method     (json-rpc/call-ext-method "getLinkPreviewData")
                                :params     [link]
                                :on-success #(re-frame/dispatch [::cache-link-preview-data link %])
-                               :on-error   #(log/error "Can't get preview data for " link)}]}))
+                               :on-error   #(re-frame/dispatch [::cache-link-preview-data
+                                                                link
+                                                                {:error (str  "Can't get preview data for " link)}])}]}))
 
 (fx/defn cache-link-preview-data
   {:events [::cache-link-preview-data]}
-  [{{:keys [multiaccount]} :db :as cofx} site {:keys [error] :as data}]
-  (when-not error
-    (multiaccounts.update/optimistic
-     cofx
-     :link-previews-cache
-     (assoc (get multiaccount :link-previews-cache {}) site data))))
+  [{{:keys [multiaccount]} :db :as cofx} site data]
+  (multiaccounts.update/optimistic
+   cofx
+   :link-previews-cache
+   (assoc (get multiaccount :link-previews-cache {}) site data)))
 
 (fx/defn should-suggest-link-preview
   {:events [::should-suggest-link-preview]}

--- a/src/status_im/ui/screens/chat/message/link_preview.cljs
+++ b/src/status_im/ui/screens/chat/message/link_preview.cljs
@@ -59,29 +59,29 @@
 
 (defview link-preview-loader [link outgoing]
   (letsubs [cache [:link-preview/cache]]
-    (let [{:keys [site title thumbnailUrl] :as preview-data} (get cache link)]
+    (let [{:keys [site title thumbnailUrl error] :as preview-data} (get cache link)]
       (if (not preview-data)
         (do
           (re-frame/dispatch
            [::link-preview/load-link-preview-data link])
           nil)
+        (when-not error
+          [react/touchable-highlight
+           {:on-press #(when (and (security/safe-link? link))
+                         (re-frame/dispatch
+                          [:browser.ui/message-link-pressed link]))}
 
-        [react/touchable-highlight
-         {:on-press #(when (and (security/safe-link? link))
-                       (re-frame/dispatch
-                        [:browser.ui/message-link-pressed link]))}
-
-         [react/view (styles/link-preview-wrapper outgoing)
-          [react/image {:source              {:uri thumbnailUrl}
-                        :style               (styles/link-preview-image outgoing)
-                        :accessibility-label :member-photo}]
-          [quo/text {:size :small
-                     :style styles/link-preview-title}
-           title]
-          [quo/text {:size :small
-                     :color :secondary
-                     :style styles/link-preview-site}
-           site]]]))))
+           [react/view (styles/link-preview-wrapper outgoing)
+            [react/image {:source              {:uri thumbnailUrl}
+                          :style               (styles/link-preview-image outgoing)
+                          :accessibility-label :member-photo}]
+            [quo/text {:size :small
+                       :style styles/link-preview-title}
+             title]
+            [quo/text {:size :small
+                       :color :secondary
+                       :style styles/link-preview-site}
+             site]]])))))
 
 (defview link-preview-wrapper [links outgoing]
   (letsubs


### PR DESCRIPTION
fixes #11417

### Summary

When `status-go` not able to unfurl url we simply ignore it. No error screen for user.

### Review notes

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Places with url unfurling - chats, status updates

##### Functional

- 1-1 chats
- public chats
- group chats
- user profile updates


### Steps to test
- Open Status
- post link https://www.youtube.com/c/statusim/live in a channel and make sure links unfurling for youtube enabled
- make sure no error appeared

status: ready