### PR TITLE
✂️ Escape address so newlines don't interfere

### DIFF
--- a/src/status_im/ui/screens/wallet/recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/recipient/views.cljs
@@ -272,7 +272,7 @@
              :text-align-vertical :top
              :on-change-text      #(do
                                      (re-frame/dispatch [:set-in [:wallet/recipient :searching] :searching])
-                                     (debounce/debounce-and-dispatch [:wallet.recipient/address-changed %] 600))
+                                     (debounce/debounce-and-dispatch [:wallet.recipient/address-changed (utils/safe-trim %)] 600))
              :accessibility-label :recipient-address-input}]]
           [react/view {:align-items :center :height 30 :padding-bottom 8}
            (if searching


### PR DESCRIPTION
fixes #11261 

### Summary
The ENS lookup didn't trim the input string. This caused issues with lookup when line break or space was added in the address text input. This PR fixes the issue by escaping the the input.


### Steps to test
- Go to wallet
- Initiate transaction
- In the recipient input box add a known ENS username, like simon
- The search spinner should resolve to an address
- Now add line breaks (by pressing enter) or spaces
- The spinner should continue to resolve to an address

status: ready