### PR TITLE
activate tx data popup in keycard web3 request screen

### DIFF
--- a/src/status_im/utils/types.cljs
+++ b/src/status_im/utils/types.cljs
@@ -10,8 +10,11 @@
 (defn js->clj [data]
   (cljs.core/js->clj data :keywordize-keys true))
 
+(defn clj->pretty-json [data spaces]
+  (.stringify js/JSON (clj-bean/->js data) nil spaces))
+
 (defn clj->json [data]
-  (.stringify js/JSON (clj-bean/->js data)))
+  (clj->pretty-json data 0))
 
 (defn json->clj [json]
   (when-not (= json "undefined")


### PR DESCRIPTION
### Summary

Active the `show data` button in the keycard cash request screens to show the raw typed message to be signed.

### Review notes

* The button was there but not visible
* The button was available only for generic typed messages but we enabled it for Payment and Redeem messages as well.
* The transaction data has been converted to a indented pretty-json text

### Testing notes

This functionality is described in the [Keycard web3 extensions](https://keycard.tech/docs/web3.html) documentation, and can be tested using this [test dapp](https://github.com/status-im/keycard-cash-test-dapp).

#### Platforms
- Android

### Steps to test
- Open this build
- Switch to the ropsten network
- Navigate with the Status browser to https://status-im.github.io/keycard-cash-test-dapp/

status: ready