### PR TITLE
fastlane: use Apple Store Connect API for CI builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.9'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.9'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.9'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label 'macos-xcode-12.3' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.9'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.9'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.9'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label 'linux' }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,6 +95,19 @@ class Keychain
   end
 end
 
+# App Store Connect API is an official public API used to manage Apps.
+# This includes metadata, pricing and availability, provisioning, and more.
+# It provides a JSON API and auth using API Keys to generate a JSON Web Token (JWT).
+def asc_api_key()
+  app_store_connect_api_key(
+    key_id: ENV['FASTLANE_ASC_API_KEY_ID'],
+    issuer_id: ENV['FASTLANE_ASC_API_ISSUER_ID'],
+    key_filepath: ENV['FASTLANE_ASC_API_KEY_FILE_PATH'],
+    duration: 1500, # seconds, session length
+    in_house: false,
+  )
+end
+
 # builds an ios app with ad-hoc configuration and put it
 # to "status-ios" output folder
 # `readonly`:
@@ -114,6 +127,7 @@ def build_ios_adhoc(readonly: false, pr_build: false)
   match(
     type: 'adhoc',
     readonly: readonly,
+    api_key: asc_api_key(),
     app_identifier: app_id,
     force_for_new_devices: true,
     keychain_name: kc.name,
@@ -150,6 +164,7 @@ def build_ios_e2e
   match(
     type: 'adhoc',
     readonly: true,
+    api_key: asc_api_key(),
     force_for_new_devices: true,
     keychain_name: kc.name,
     keychain_password: kc.pass
@@ -230,6 +245,7 @@ platform :ios do
     match(
       type: 'appstore',
       readonly: true,
+      api_key: asc_api_key(),
       app_identifier: 'im.status.ethereum',
       keychain_name: kc.name,
       keychain_password: kc.pass


### PR DESCRIPTION
Because our CI Apple account still has 2FA disabled in order for it to be usable in Jenkin it is now failing with an error that seems unrelated to 2FA.

The recommended way of doing Apple authentication for CI are App Store Connect API JWTs. The API appears to support both pushing builds as well as updating metadata and other tasks like refreshing of provisioning profiles.

Fixes: https://github.com/status-im/status-react/issues/11713
Issue: https://github.com/fastlane/fastlane/issues/18098
Docs: https://docs.fastlane.tools/app-store-connect-api/