### PR TITLE
nix: add missing cljfmt dependencies to nix/deps/clojure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,15 +241,12 @@ endif
 lint: export TARGET := clojure
 lint: ##@test Run code style checks
 	yarn clj-kondo --confg .clj-kondo/config.edn --lint src && \
-	clojure -Sdeps '{:deps {cljfmt {:mvn/version "0.6.7"}}}' \
-		-m cljfmt.main check $$(git diff --diff-filter=d --cached --name-only src && echo src) \
-		--indents indentation.edn
+	TARGETS=$$(git diff --diff-filter=d --cached --name-only src && echo src) && \
+	clojure -Scp "$$CLASS_PATH" -m cljfmt.main check --indents indentation.edn $$TARGETS
 
 lint-fix: export TARGET := clojure
 lint-fix: ##@test Run code style checks and fix issues
-	clojure -Sdeps '{:deps {cljfmt {:mvn/version "0.6.7"}}}' \
-		-m cljfmt.main fix src \
-		--indents indentation.edn
+	clojure -Scp "$$CLASS_PATH" -m cljfmt.main fix src --indents indentation.edn
 
 test: export TARGET := clojure
 test: ##@test Run tests once in NodeJS

--- a/nix/deps/clojure/README.md
+++ b/nix/deps/clojure/README.md
@@ -1,0 +1,39 @@
+# Description
+
+This folder contains the scripts and Nix derivations necessary to generate Clojure dependencies for this project.
+
+# Usage
+
+Running [`generate.sh`](./generate.sh) in a shell that has available `shadow-cljs` and `clojure` should update the `deps.list` and `deps.json` files.
+
+# Details
+
+By using the following command:
+```sh
+shadow-cljs classpath --force-spawn
+```
+We both download the necessary JARs and POMs into `~/.m2` folder, but also get the classpath printed into standard output.
+
+We then use the classpath in combination with contents of `~/.m2` folder to generate the following files:
+
+* `deps.list` - List of JARs relative to the `~/.m2` cache folder.
+* `deps.json` - Full list of JARs and POMs including their SHAs.
+
+The `deps.list` file is just intermediate and for debugging purposes.
+The `deps.json` is loaded by the derivation in [`default.nix`](./default.nix) and used to produce a derivation that contains all the necessary dependencies:
+
+```
+ > grep cljfmt nix/deps/clojure/deps.list
+cljfmt/cljfmt/0.6.7/cljfmt-0.6.7.jar
+
+ > nix-build --no-out-link -A pkgs.deps.clojure
+/nix/store/d7p8r9vhq6z2jmxwakxpcb262wgkc86s-status-react-clojure-deps
+
+ > DEPS=$(nix-build --no-out-link -A pkgs.deps.clojure)                              
+
+ > find $DEPS -iname 'cljfmt-0.6.7.*'
+/nix/store/d7p...86s-status-react-clojure-deps/cljfmt/cljfmt/0.6.7/cljfmt-0.6.7.pom.sha1
+/nix/store/d7p...86s-status-react-clojure-deps/cljfmt/cljfmt/0.6.7/cljfmt-0.6.7.pom
+/nix/store/d7p...86s-status-react-clojure-deps/cljfmt/cljfmt/0.6.7/cljfmt-0.6.7.jar.sha1
+/nix/store/d7p...86s-status-react-clojure-deps/cljfmt/cljfmt/0.6.7/cljfmt-0.6.7.jar
+```

--- a/nix/deps/clojure/deps.json
+++ b/nix/deps/clojure/deps.json
@@ -78,6 +78,19 @@
   },
 
   {
+    "path": "cljfmt/cljfmt/0.6.7/cljfmt-0.6.7",
+    "host": "https://repo.clojars.org",
+    "pom": {
+      "sha1": "3d7ac9112908c9c9349adc056d1d06ae2cd33c21",
+      "sha256": "1q46q43mykn61f032y5734j84gcjca41pwd3iik9xghnzmphy2mn"
+    },
+    "jar": {
+      "sha1": "91e8afa2c19db72acdef7f881aad905871ba6e69",
+      "sha256": "0ara83gaqnafjgr2aqz5zqmywdsmhsz483xkkxpiwbn9lfqvidmh"
+    }
+  },
+
+  {
     "path": "cljs-bean/cljs-bean/1.3.0/cljs-bean-1.3.0",
     "host": "https://repo.clojars.org",
     "pom": {
@@ -256,6 +269,19 @@
     "jar": {
       "sha1": "751f548c85fa49f330cecbb1875893f971b33c4e",
       "sha256": "0clda1xrjfja969xsbrhc61ip588xvsi9k054kpd4cz1m5gfnhrd"
+    }
+  },
+
+  {
+    "path": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0",
+    "host": "https://repo1.maven.org/maven2",
+    "pom": {
+      "sha1": "7d5e372ff32c90095800f96d8308c41af0285a41",
+      "sha256": "1dj7p0m0kwnjvy1y3kq63zb6bw0azjf79i5xbccmy3wv63b1vqrg"
+    },
+    "jar": {
+      "sha1": "7e060dd5b19431e6d198e91ff670644372f60fbd",
+      "sha256": "1hn5plp7iyl626h8mrra56sysfm2qannj1dapr1m5afwkb24vfk1"
     }
   },
 
@@ -1439,6 +1465,32 @@
     "jar": {
       "sha1": "d54aa873a848f624a282c2c2f7df947c976a77b5",
       "sha256": "0yhsqpi3d8x11pl1aq8z23fdyjspvq07dsyvrlkpbyx7rm64i21h"
+    }
+  },
+
+  {
+    "path": "rewrite-clj/rewrite-clj/0.6.1/rewrite-clj-0.6.1",
+    "host": "https://repo.clojars.org",
+    "pom": {
+      "sha1": "05778b423e14e8f1b054cc78df4e5d048cc0fc68",
+      "sha256": "0wp9xvmfp37x88msm2yhhzi8sjwd4hxz0vv4bslhal3zi97c1bj6"
+    },
+    "jar": {
+      "sha1": "55b399417a088ca163ef835e56db76ea962ce0a9",
+      "sha256": "0qq3an9nrhhw5mba753zs1m9rnk86w9l1f04n8v0hz0i2kbf1cki"
+    }
+  },
+
+  {
+    "path": "rewrite-cljs/rewrite-cljs/0.4.4/rewrite-cljs-0.4.4",
+    "host": "https://repo.clojars.org",
+    "pom": {
+      "sha1": "4e7a2542517a5b0231631305461603605bea1592",
+      "sha256": "050imgkzw5q7200klwrkd4v32xxy1f4aghs8g4ma5dbg4rl4pgcd"
+    },
+    "jar": {
+      "sha1": "dd14a371d0d09eedccb39f01e3edabefb2d1e64f",
+      "sha256": "0hb07wg71i2bjn8wzs8q6w1nb3jb2s36nhr9kv9mc0gyrr6im244"
     }
   },
 

--- a/nix/deps/clojure/deps.list
+++ b/nix/deps/clojure/deps.list
@@ -4,6 +4,7 @@ binaryage/env-config/0.2.2/env-config-0.2.2.jar
 binaryage/oops/0.7.0/oops-0.7.0.jar
 cider/cider-nrepl/0.25.3/cider-nrepl-0.25.3.jar
 cider/piggieback/0.4.1/piggieback-0.4.1.jar
+cljfmt/cljfmt/0.6.7/cljfmt-0.6.7.jar
 cljs-bean/cljs-bean/1.3.0/cljs-bean-1.3.0.jar
 cljsjs/react/16.13.0-0/react-16.13.0-0.jar
 cljsjs/react-dom/16.13.0-0/react-dom-16.13.0-0.jar
@@ -18,6 +19,7 @@ com/cognitect/transit-js/0.8.846/transit-js-0.8.846.jar
 com/fasterxml/jackson/core/jackson-core/2.8.7/jackson-core-2.8.7.jar
 com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.jar
 com/google/code/gson/gson/2.7/gson-2.7.jar
+com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar
 com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar
 com/google/elemental2/elemental2-core/1.0.0-RC1/elemental2-core-1.0.0-RC1.jar
 com/google/errorprone/error_prone_annotations/2.3.1/error_prone_annotations-2.3.1.jar
@@ -109,6 +111,8 @@ refactor-nrepl/refactor-nrepl/2.5.0/refactor-nrepl-2.5.0.jar
 re-frame/re-frame/0.12.0/re-frame-0.12.0.jar
 re-frisk-remote/re-frisk-remote/1.3.11/re-frisk-remote-1.3.11.jar
 re-frisk/sente/1.15.0/sente-1.15.0.jar
+rewrite-clj/rewrite-clj/0.6.1/rewrite-clj-0.6.1.jar
+rewrite-cljs/rewrite-cljs/0.4.4/rewrite-cljs-0.4.4.jar
 ring-cors/ring-cors/0.1.8/ring-cors-0.1.8.jar
 ring/ring-codec/1.1.2/ring-codec-1.1.2.jar
 ring/ring-core/1.8.1/ring-core-1.8.1.jar

--- a/nix/deps/clojure/generate.sh
+++ b/nix/deps/clojure/generate.sh
@@ -21,7 +21,7 @@ declare -A REPOS=(
 
 function gen_deps_list() {
     # split into separate lines
-    CLASSPATH_LINES=$(yarn shadow-cljs classpath | tr ':' '\n')
+    CLASSPATH_LINES=$(yarn shadow-cljs classpath --force-spawn | tr ':' '\n')
     # remove unnecessary lines
     CLASSPATH_LINES=$(echo "${CLASSPATH_LINES}" | grep -vE '^(\$|yarn|Done|shadow-cljs|src|test)')
     # remove local home path

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -31,6 +31,10 @@ let
     clojure = mkShell {
       buildInputs = with pkgs; [ clojure flock maven openjdk ];
       inputsFrom = [ node-sh ];
+      # CLASSPATH from clojure deps with 'src' appended to find local sources.
+      shellHook = with pkgs; ''
+        export CLASS_PATH="$(find ${deps.clojure} -iname '*.jar' | tr '\n' ':')src"
+      '';
     };
 
     # for 'make watchman-clean'

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -21,7 +21,9 @@
                 [bidi "2.1.6"]
                 ;; test dependencies
                 [day8.re-frame/test "0.1.5"]
-                [com.taoensso/tufte "2.1.0"]]
+                [com.taoensso/tufte "2.1.0"]
+                ;; linting
+                [cljfmt/cljfmt "0.6.7"]]
 
  ;; port and middleware for repl in development
  :nrepl {:port 7888


### PR DESCRIPTION
It seems like this worked before purely because the `cljfmt` library was already in the `~/.m2` cache folder. This issue was noticed when I cleaned up the `~/.m2` folder on one Jenkins slave host and the Lint stage started randomly failing.