### PR TITLE
nix: fix name fo config value for unsigned build

### DIFF
--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -75,7 +75,7 @@ in stdenv.mkDerivation rec {
 
   # custom env variables derived from config
   STATUS_GO_SRC_OVERRIDE = getConfig "nimbus.src-override" null;
-  ANDROID_APK_SIGNED = getConfig "android.apk-unsigned" "true";
+  ANDROID_APK_SIGNED = getConfig "android.apk-signed" "true";
   ANDROID_ABI_SPLIT = getConfig "android.abi-split" "false";
   ANDROID_ABI_INCLUDE = androidAbiInclude;
 


### PR DESCRIPTION
Not sure how this worked last time, but it somehow did. The correct name is `apk-signed`:
https://github.com/status-im/status-react/blob/ec2faa601ab0f6c1ff693d69ae679fb389ba1d3d/scripts/release-android.sh#L37
https://github.com/status-im/status-react/blob/ec2faa601ab0f6c1ff693d69ae679fb389ba1d3d/nix/config.nix#L10