### PR TITLE
ci: add Jenkinsfile for pod repo updates

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -62,7 +62,7 @@ pipeline {
 
         withCredentials([
           usernamePassword(
-            credentialsId: 'status-im-auto-token',
+            credentialsId: 'status-im-auto',
             usernameVariable: 'GIT_HUB_USER', /* ignored */
             passwordVariable: 'GIT_HUB_TOKEN'
           ),

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -38,7 +38,7 @@ pipeline {
       steps { script {
         withCredentials([
           string(
-            credentialsId: 'SUPPLY_JSON_KEY_DATA',
+            credentialsId: 'google-play-api-key-json',
             variable: 'GOOGLE_PLAY_JSON_KEY'
           ),
         ]) {

--- a/ci/tools/Jenkinsfile.pod-repo-update
+++ b/ci/tools/Jenkinsfile.pod-repo-update
@@ -1,0 +1,43 @@
+/**
+ * This job runs daily and executes `pod repo update` on MacOS
+ * This is done to avoid issues with out of date repo causing errors like:
+ *
+ * Failed with exit code 1 (in target 'StatusImPR' from project 'StatusIm')
+ **/
+
+pipeline {
+  agent {
+    label params.HOST_LABEL
+  }
+
+  triggers {
+    /* Run daily at 2am */
+    cron('H 2 * * *')
+  }
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 5, unit: 'MINUTES')
+    /* Limit builds retained */
+    buildDiscarder(logRotator(
+      numToKeepStr: '20',
+    ))
+  }
+
+  parameters {
+    string(
+      name: 'HOST_LABEL',
+      description: 'Label of host to run on',
+      /* Using startTimeInMillis to randomize which host gets the update. */
+      defaultValue: "macos-0${(currentBuild.startTimeInMillis % 3) + 1}",
+    )
+  }
+
+  stages {
+    stage('Update') {
+      steps {
+        sh 'pod repo update'
+      }
+    }
+  }
+}

--- a/doc/RELEASE_GUIDE.md
+++ b/doc/RELEASE_GUIDE.md
@@ -8,4 +8,4 @@ You can update Play Store releae metadata using `fastlane android upload_metadat
 
 But that requires credentials necessary for accessing Play Store API. The simpler way is to edit files contained within [`fastlane/metadata`](metadata) and run the following CI job:
 
-https://ci.status.im/job/status-tools/job/update-playstore-metadata/
+https://ci.status.im/job/status-react/job/tools/job/update-playstore-metadata/


### PR DESCRIPTION
I'm cleaning up Jenkins credentials and moving some stuff around. Decided [this](https://ci.status.im/job/status-react/job/tools/job/run-pod-repo-update/) belongs in the repo.

I'm changing `status-im-auto-token` to `status-im-auto` from `Jenkinsfile.e2e-prs` to remove a duplicate credential.

Also updated link in docs to [update-playstore-metadata](https://ci.status.im/job/status-react/job/tools/job/update-playstore-metadata/) job.