### PR TITLE
CI: Generalize release functions for desktop

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.11'
+library 'status-jenkins-lib@v1.2.12'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.11'
+library 'status-jenkins-lib@v1.2.12'
 
 pipeline {
   agent { label 'linux' }
@@ -91,7 +91,7 @@ pipeline {
             build(job: 'misc/status.im', wait: false);
             break;
           case 'release':
-            github.publishReleaseMobile();
+            github.publishReleaseFiles(repo: 'status-react');
             break;
         }
       } }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -41,13 +41,13 @@ pipeline {
     stage('Build') {
       parallel {
         stage('iOS') { steps { script {
-          ios = jenkins.Build('status-react/combined/mobile-ios')
+          ios = jenkins.Build('status-react/platforms/ios')
         } } }
         stage('Android') { steps { script {
-          apk = jenkins.Build('status-react/combined/mobile-android')
+          apk = jenkins.Build('status-react/platforms/android')
         } } }
         stage('Android e2e') { steps { script {
-          apke2e = jenkins.Build('status-react/combined/mobile-android-e2e')
+          apke2e = jenkins.Build('status-react/platforms/android-e2e')
         } } }
       }
     }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.11'
+library 'status-jenkins-lib@v1.2.12'
 
 pipeline {
   agent { label 'macos-xcode-12.3' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.11'
+library 'status-jenkins-lib@v1.2.12'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/README.md
+++ b/ci/README.md
@@ -6,11 +6,11 @@ This folder contains files defininf [Jenkins pipelines](https://jenkins.io/doc/b
 
 All `Jenkinsfile`s contain the following line:
 ```groovy
-library 'status-react-jenkins@master'
+library 'status-jenkins-lib@master'
 ```
 
 Which loads the used methods - like `nix.shell()` - from a separate private repo:
 
-https://github.com/status-im/status-react-jenkins
+https://github.com/status-im/status-jenkins-lib
 
 This is done to improve security of our CI setup.

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.11'
+library 'status-jenkins-lib@v1.2.12'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.11'
+library 'status-jenkins-lib@v1.2.12'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
This is required to also ad GitHub releases to `status-desktop`.
    
Depends on: https://github.com/status-im/status-react-jenkins/pull/23
Related to: https://github.com/status-im/status-desktop/pull/2270

I'm also renaming the `combined` sub-job folder to `platforms` to match `status-desktop`.
Renamed `status-react-jenkins` to `status-jenkins-lib` so the name matches the purpose, as it's also used in desktop builds.