### PR TITLE
ci: nicer artifact filenames for release builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.15'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.15'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.15'
 
 pipeline {
   agent { label 'macos-xcode-12.3' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.15'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.15'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.15'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
With this release build of Android univeral APK the filename will be
```
StatusIm-Mobile-v1.13.0-b299e2-universal.apk
```
instead of:
```
StatusIm-210420-090829-b299e2-release-universal.apk
```
I tested it with a streamlined manual release build: https://ci.status.im/job/status-react/job/manual/140/
![image](https://user-images.githubusercontent.com/2212681/115446130-0b273b00-a217-11eb-9bb3-fb705b47312a.png)

Depends on: https://github.com/status-im/status-jenkins-lib/pull/24