### PR TITLE
Fix #12088 and #11861

### DIFF
--- a/src/status_im/multiaccounts/key_storage/core.cljs
+++ b/src/status_im/multiaccounts/key_storage/core.cljs
@@ -29,6 +29,16 @@
   [{:keys [db] :as cofx} checked?]
   {:db (assoc-in db [:multiaccounts/key-storage :move-keystore-checked?] checked?)})
 
+(fx/defn navigate-back
+  {:events [::navigate-back]}
+  [{:keys [db] :as cofx}]
+  (fx/merge
+   cofx
+   {:db (-> db
+            (dissoc :recovered-account?)
+            (update :keycard dissoc :from-key-storage-and-migration? :creating-backup?))}
+   (navigation/navigate-back)))
+
 (fx/defn enter-seed-pressed
   "User is logged out and probably wants to move multiaccount to Keycard. Navigate to enter seed phrase screen"
   {:events [::enter-seed-pressed]}

--- a/src/status_im/ui/screens/multiaccounts/key_storage/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/key_storage/views.cljs
@@ -18,9 +18,10 @@
             [status-im.ui.screens.multiaccounts.key-storage.styles :as styles]
             [status-im.utils.security]))
 
-(defn local-topbar [subtitle]
-  [topbar/topbar {:title   (i18n/label :t/key-managment)
-                  :subtitle subtitle}])
+(defn local-topbar [subtitle action]
+  [topbar/topbar (merge {:title   (i18n/label :t/key-managment)
+                         :subtitle subtitle}
+                        (when action {:navigation {:on-press #(re-frame/dispatch [action])}}))])
 
 (defonce accordian-data
   [{:id    :type
@@ -106,7 +107,7 @@
     [{:keys [seed-word-count seed-shape-invalid?]} [:multiaccounts/key-storage]
      {:keys [creating-backup?]} [:keycard]]
     [react/keyboard-avoiding-view {:flex 1}
-     [local-topbar (i18n/label :t/enter-seed-phrase)]
+     [local-topbar (i18n/label :t/enter-seed-phrase) ::multiaccounts.key-storage/navigate-back]
      [multiaccounts.views/seed-phrase-input
       {:on-change-event     [::multiaccounts.key-storage/seed-phrase-input-changed]
        :seed-word-count     seed-word-count


### PR DESCRIPTION
when exiting the backup card or account migration flow by cancelling it (through navigation) some flags were not removed. This should fix both #12088 and #11861 