### PR TITLE
ci: do no delete non-draft releases

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.16'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -88,7 +88,7 @@ pipeline {
           case 'nightly':
             /* Create JSON file with newest build URLs */
             s3.updateBucketJSON(urls, 'latest.json');
-            build(job: 'misc/status.im', wait: false);
+            build(job: 'website/status.im', wait: false);
             break;
           case 'release':
             github.publishReleaseFiles(repo: 'status-react');

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.16'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.16'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label 'macos-xcode-12.3' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.16'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.16'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label 'macos' }


### PR DESCRIPTION
We identified this issue in status-desktop release from branch `release/0.1.0-beta.10` which had old version in VERSION file.
https://ci.status.im/job/status-desktop/job/release/job/release%252F0.1.0-beta.10/
    
Depends on: https://github.com/status-im/status-jenkins-lib/pull/28

Also fixes wrong job folder for `status.im` site CI job.