### PR TITLE
fdroid: add fix for /tmp permission on Vagrant builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,11 @@ fdroid-nix-dir: ##@prepare Create /nix directory for F-Droid Vagrant builders
 	mkdir -m 0755 /nix
 	chown vagrant /nix
 
-fdroid-build-env: fdroid-max-watches fdroid-nix-dir ##@prepare Setup build environment for F-Droud build
+fdroid-fix-tmp: SHELL := /bin/sh
+fdroid-fix-tmp: ##@prepare Fix /tmp permissions for Vagrant builder
+	chown -R vagrant /tmp
+
+fdroid-build-env: fdroid-max-watches fdroid-nix-dir fdroid-fix-tmp ##@prepare Setup build environment for F-Droud build
 
 xcode-clean: SHELL := /bin/sh
 xcode-clean: XCODE_HOME := $(HOME)/Library/Developer/Xcode


### PR DESCRIPTION
You can see details about this in these PRs:
https://gitlab.com/fdroid/fdroidserver/-/issues/910
https://gitlab.com/fdroid/fdroiddata/-/merge_requests/8879
https://gitlab.com/fdroid/fdroiddata/-/merge_requests/9140

Without this the build fails with:
```
error: creating directory '/tmp/tmp-status-react-896b583da/nix-shell-900-0': Permission denied
```
https://monitor.f-droid.org/builds/log/im.status.ethereum/2021042608

It doesn't make any sense to me, since `/tmp` has to have `1777` permissions, but it is what it is.