### PR TITLE
nix: upgrade nixpkgs, keep Go at 1.14.15

### DIFF
--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -29,7 +29,7 @@ pipeline {
   stages {
     stage('Setup') {
       steps { script {
-        nix.shell('nix-env -i openssh', pure: false)
+        nix.shell('nix-env -i openssh', sandbox: false, pure: false)
         /* some build targets don't build on MacOS */
         uname = sh(script: 'uname', returnStdout: true)
       } }

--- a/fastlane/default.nix
+++ b/fastlane/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, bundlerEnv, ruby, makeWrapper }:
+{ stdenv, lib, bundlerEnv, ruby, makeWrapper }:
 
 let
   fastlane = stdenv.mkDerivation rec {
@@ -28,7 +28,7 @@ let
       export FASTLANE_PLUGINFILE_PATH=$STATUS_REACT_HOME/fastlane/Pluginfile
     '';
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description     = "A tool to automate building and releasing iOS and Android apps";
       longDescription = "fastlane is a tool for iOS and Android developers to automate tedious tasks like generating screenshots, dealing with provisioning profiles, and releasing your application.";
       homepage        = https://github.com/fastlane/fastlane;

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -18,6 +18,11 @@
 
   # Android SDK requires an accepted license
   android_sdk.accept_license = true;
-  # Android Env still needs old OpenSSL
-  permittedInsecurePackages = [ "openssl-1.0.2u" ];
+
+  permittedInsecurePackages = [
+    # Android Env still needs old OpenSSL
+    "openssl-1.0.2u"
+    # Support for Go 1.14 ended with the release of Go 1.16
+    "go-1.14.15"
+  ];
 }

--- a/nix/lib/mkFilter_test.nix
+++ b/nix/lib/mkFilter_test.nix
@@ -16,8 +16,7 @@
 
 let
   pkgs = import <nixpkgs> { };
-  lib = pkgs.stdenv.lib;
-  mkFilter = pkgs.callPackage ./mkFilter.nix { inherit lib; };
+  mkFilter = pkgs.callPackage ./mkFilter.nix { inherit (pkgs) lib; };
   absPath = "/ABS/PATH";
   filter = mkFilter {
     root = absPath;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -13,8 +13,8 @@ let
     name = "nixpkgs-source";
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "51894963cbdc41f0cd8f571b7bcf79437d940355";
-    sha256 = "13nfghpnhnr5hbbibsrq172g1rdibd8lycis7ncvf9yxd4rdlf7b";
+    rev = "76f53eef48cc6c340ed063c117aac75c4652627c";
+    sha256 = "0a2wn0ryq0ngd3ybc3ag70dp9z1x4w1jgy6qr4dzfnzbnn3s5246";
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
   };

--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -7,16 +7,16 @@
 
 androidenv.composeAndroidPackages {
   toolsVersion = "26.1.1";
-  platformToolsVersion = "30.0.5";
+  platformToolsVersion = "31.0.2";
   buildToolsVersions = [ "30.0.3" ];
   includeEmulator = false;
   includeSources = false;
   platformVersions = [ "29" ];
   includeSystemImages = false;
   systemImageTypes = [ "default" ];
-  cmakeVersions = [ "3.10.2" ];
+  cmakeVersions = [ "3.18.1" ];
   includeNDK = true;
-  ndkVersion = "21.3.6528147";
+  ndkVersion = "22.1.7171670";
   useGoogleAPIs = false;
   useGoogleTVAddOns = false;
   includeExtras = [

--- a/nix/pkgs/gomobile/default.nix
+++ b/nix/pkgs/gomobile/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, utils, callPackage, fetchgit, buildGo114Package,
+{ stdenv, lib, utils, callPackage, fetchgit, buildGo114Package,
   ncurses5, zlib, makeWrapper, patchelf, androidPkgs, xcodeWrapper
 }:
 
 let
   inherit (stdenv) isDarwin;
-  inherit (stdenv.lib) optional optionalString strings;
+  inherit (lib) optional optionalString strings;
 in buildGo114Package rec {
   pname = "gomobile";
   version = "20200622-${strings.substring 0 7 rev}";
@@ -57,7 +57,7 @@ in buildGo114Package rec {
     url = "https://go.googlesource.com/mobile";
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A tool for building and running mobile apps written in Go.";
     longDescription = "Gomobile is a tool for building and running mobile apps written in Go.";
     homepage = https://go.googlesource.com/mobile;

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -3,15 +3,22 @@
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/scripts/colors.sh"
 
-NIX_VERSION="2.3.6"
+NIX_VERSION="2.3.12"
 NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
+NIX_INSTALL_SHA256="468a49a1cef293d59508bb3b62625dfcd99ec00334a14309f125cf8de513d5f1"
+NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"
 
 function install_nix() {
   # Don't break people's profiles
   export NIX_INSTALLER_NO_MODIFY_PROFILE=1
   # Fix for installing on MacOS Catalina
   export NIX_IGNORE_SYMLINK_STORE=1
-  bash <(curl "${NIX_INSTALL_URL}") --no-daemon
+  # Download installer and verify SHA256
+  curl -s "${NIX_INSTALL_URL}" -o "${NIX_INSTALL_PATH}"
+  echo "${NIX_INSTALL_SHA256}  ${NIX_INSTALL_PATH}" | sha256sum -c
+  chmod +x "${NIX_INSTALL_PATH}"
+  # Run the installer
+  "${NIX_INSTALL_PATH}" --no-daemon
   if [ $? -eq 0 ]; then
     echo -e "${GRN}The Nix package manager was successfully installed.${RST}"
   else

--- a/nix/tools/envParser.nix
+++ b/nix/tools/envParser.nix
@@ -1,9 +1,9 @@
 # This Nix expression takes care of reading/parsing the correct .env configuration file and return it as an attr set
-{ config, stdenv }:
+{ config, stdenv, lib }:
 
 let
   inherit (builtins) listToAttrs head tail readFile;
-  inherit (stdenv.lib) attrByPath filter hasPrefix nameValuePair splitString;
+  inherit (lib) attrByPath filter hasPrefix nameValuePair splitString;
 
   build-type = attrByPath ["status-im" "build-type"] "" config;
   ci = (attrByPath ["status-im" "ci"] "" config) != "";


### PR DESCRIPTION
In order to make the problematic PR #11986 smaller and easier to debug I'm moving just the Nixpkgs upgrade here.

Notable software upgrades:
    
- Go `1.14.13` to `1.14.15`
- Clojure `1.10.1.763` to `1.10.3.855`
- NodeJS `12.20.1` to `12.22.1`
- Git `2.29.2` to `2.31.1`
- CMake `3.10.2` to `3.18.1`
- Curl `7.74.0` to `7.76.1`
- Android NDK `21.3.6528147` to `22.1.7171670`
- Android Platform Tools `30.0.5` to `31.0.2`

Also a bunch of Gradle packages and upgrade of Nix binary itself from `2.3.6` to `2.3.12`.