### PR TITLE
fdroid: fix permissions on TMPDIR for Vagrant builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,8 @@ fdroid-nix-dir: ##@prepare Create /nix directory for F-Droid Vagrant builders
 	chown vagrant /nix
 
 fdroid-fix-tmp: SHELL := /bin/sh
-fdroid-fix-tmp: ##@prepare Fix /tmp permissions for Vagrant builder
-	chown -R vagrant /tmp
+fdroid-fix-tmp: ##@prepare Fix TMPDIR permissions so Vagrant user is the owner
+	chown -R vagrant "$(TMPDIR)"
 
 fdroid-build-env: fdroid-max-watches fdroid-nix-dir fdroid-fix-tmp ##@prepare Setup build environment for F-Droud build
 


### PR DESCRIPTION
Our `Makefile` implicitly creates the `TMPDIR` folder. The issue with that is that if `make fdroid-build-env` is called by
`root` - as it is when being used by F-Droid - then the `TMPDIR` is also owned by `root`, and because its permissions are `0755` the `vagrant` user is unable to write to it.

This is why implicit targets like this are a nightmare to debug:
https://github.com/status-im/status-react/blob/63290fd019d26647e0b8a3d5f1e323b762644337/Makefile#L120-L124

For more details see:
https://gitlab.com/fdroid/fdroidserver/-/issues/910
https://gitlab.com/fdroid/fdroiddata/-/merge_requests/8879
https://gitlab.com/fdroid/fdroiddata/-/merge_requests/9140