### PR TITLE
ci: upgrade XCode 12.3 to 12.5

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
-  agent { label 'macos-xcode-12.3' }
+  agent { label 'macos-xcode-12.5' }
 
   parameters {
     string(


### PR DESCRIPTION
It's about time to upgrade, especially since `13.0` is near.

Related to: https://github.com/status-im/infra-ci/commit/2d63c1f3

Right now only `macos-03` is upgraded, we can do a second host once this is approved.