### PR TITLE
ci: allow for providing custom Nix cache hosts

### DIFF
--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -3,14 +3,24 @@ library 'status-jenkins-lib@v1.2.18'
 pipeline {
   agent { label params.AGENT_LABEL }
 
+  parameters {
+    string(
+      name: 'NIX_CACHE_HOST',
+      description: 'FQDN of Nix binary cache host.',
+      defaultValue: params.NIX_CACHE_HOST ?: 'cache-01.do-ams3.nix.ci.statusim.net'
+    )
+    string(
+      name: 'NIX_CACHE_USER',
+      description: 'Username for Nix binary cache host.',
+      defaultValue: params.NIX_CACHE_USER ?: 'nix-cache'
+    )
+  }
+
   environment {
     /* See nix/README.md */
     NIX_IGNORE_SYMLINK_STORE = 1
     /* we source .bash_profile to be able to use nix-store */
-    NIX_SSHOPTS = "-o StrictHostKeyChecking=no source .bash_profile;"
-    /* where our /nix/store is hosted */
-    NIX_CACHE_USER = 'nix-cache'
-    NIX_CACHE_HOST = 'master-01.do-ams3.ci.misc.statusim.net'
+    NIX_SSHOPTS = "-o StrictHostKeyChecking=no source .profile;"
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
   }
 
@@ -88,7 +98,8 @@ pipeline {
           nix.shell("""
               find /nix/store/ -mindepth 1 -maxdepth 1 -type d \
                 -not -name '*.links' -and -not -name '*-status-react-*' \
-                | xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
+                | xargs nix-copy-closure -v \
+                  --to ${params.NIX_CACHE_USER}@${params.NIX_CACHE_HOST}
             """,
             pure: false
           )


### PR DESCRIPTION
This is part of my work of moving Nix cache to a separate host
because our Master host with jenkins needs more space.

Also, new Nix installer updated `.profile`, not `.bash_profile`.