### PR TITLE
nix: avoid nesting of Nix shells, show errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,10 @@ endif
 # Nix targets
 #----------------
 
-# WARNING: This has to be located right before the targets
-ifdef IN_NIX_SHELL
-SHELL := env bash
-else
+# WARNING: This has to be located right before all the targets.
 SHELL := ./nix/scripts/shell.sh
-endif
 
+shell: export TARGET ?= default
 shell: ##@prepare Enter into a pre-configured shell
 ifndef IN_NIX_SHELL
 	@ENTER_NIX_SHELL

--- a/nix/DETAILS.md
+++ b/nix/DETAILS.md
@@ -47,9 +47,9 @@ It pulls in all the `pkgs`, `targets` and `shells` defined in [`nix/default.nix`
 
 # Shells
 
-Normally shells are started using `make shell TARGET=android`, but that is essentially the same as calling:
+Normally shells are started using `make shell TARGET=default`, but that is essentially the same as calling:
 ```bash
-nix-shell -A shells.android default.nix
+nix-shell -A shells.default default.nix
 ```
 The [`nix/scripts/shell.sh`](./scripts/shell.sh) script is essentially a wrapper around that command to make it usable as shell for the `Makefile`.
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -47,6 +47,8 @@ This way your shell and all other nix commands should run in a setup that is tai
 
 For valid values you can check the [`nix/shells.nix`](/nix/shells.nix) file.
 
+:warning: __WARNING__: To have Nix pick up all changes a new `nix-shell` needs to be spawned.
+
 ## Using a local status-go repository
 
 If you need to use a locally checked-out status-go repository, you can achieve that by defining the `STATUS_GO_SRC_OVERRIDE`

--- a/nix/scripts/shell.sh
+++ b/nix/scripts/shell.sh
@@ -15,46 +15,56 @@ source "${GIT_ROOT}/nix/scripts/source.sh"
 export TERM=xterm # fix for colors
 shift # we remove the first -c from arguments
 
-nixArgs=(
-  "--show-trace"
-)
-
 if [[ -z "${TARGET}" ]]; then
-    TARGET="default"
+    export TARGET="default"
     echo -e "${YLW}Missing TARGET, assuming default target.${RST} See nix/README.md for more details." 1>&2
 fi
+
 # Minimal shell with just Nix sourced, useful for `make nix-gc`.
 if [[ "${TARGET}" == "nix" ]]; then
     eval $@
-    exit
+    exit 0
+fi
+if [[ -n "${IN_NIX_SHELL}" ]] && [[ -n "${NIX_SHELL_TARGET}" ]]; then
+    if [[ "${NIX_SHELL_TARGET}" == "${TARGET}" ]]; then
+        echo -e "${YLW}Nix shell for TARGET=${TARGET} is already active.${RST}" >&2
+        exit 0
+    else
+        # Nesting nix shells does not work due to how we detect already present shell.
+        echo -e "${RED}Cannot nest Nix shells with different targets!${RST}" >&2
+        exit 1
+    fi
 fi
 
 entryPoint="default.nix"
-nixArgs+=("--attr shells.${TARGET}")
+nixArgs=(
+    "--show-trace"
+    "--attr shells.${TARGET}"
+)
 
 config=''
-if [ -n "${STATUS_GO_SRC_OVERRIDE}" ]; then
-  config+="status-im.status-go.src-override=\"${STATUS_GO_SRC_OVERRIDE}\";"
+if [[ -n "${STATUS_GO_SRC_OVERRIDE}" ]]; then
+    config+="status-im.status-go.src-override=\"${STATUS_GO_SRC_OVERRIDE}\";"
 fi
-if [ -n "${NIMBUS_SRC_OVERRIDE}" ]; then
-  config+="status-im.nimbus.src-override=\"${NIMBUS_SRC_OVERRIDE}\";"
+if [[ -n "${NIMBUS_SRC_OVERRIDE}" ]]; then
+    config+="status-im.nimbus.src-override=\"${NIMBUS_SRC_OVERRIDE}\";"
 fi
 config+="status-im.build-type=\"${BUILD_TYPE}\";"
 
-if [ -n "$config" ]; then
-  nixArgs+=("--arg config {$config}")
+if [[ -n "$config" ]]; then
+    nixArgs+=("--arg config {$config}")
 fi
 
 # This variable allows specifying which env vars to keep for Nix pure shell
 # The separator is a colon
 if [[ -n "${_NIX_KEEP}" ]]; then
-  nixArgs+=("--keep ${_NIX_KEEP//,/ --keep }")
+    nixArgs+=("--keep ${_NIX_KEEP//,/ --keep }")
 fi
 
 # Not all builds are ready to be run in a pure environment
 if [[ -n "${_NIX_PURE}" ]]; then
-  nixArgs+=("--pure")
-  pureDesc='pure '
+    nixArgs+=("--pure")
+    pureDesc='pure '
 fi
 
 echo -e "${GRN}Configuring ${pureDesc}Nix shell for target '${TARGET}'...${RST}" 1>&2
@@ -65,7 +75,8 @@ ${GIT_ROOT}/nix/scripts/gcroots.sh "shells.${TARGET}"
 # ENTER_NIX_SHELL is the fake command used when `make shell` is run.
 # It is just a special string, not a variable, and a marker to not use `--run`.
 if [[ "${@}" == "ENTER_NIX_SHELL" ]]; then
-  exec nix-shell ${nixArgs[@]} ${entryPoint}
+    export NIX_SHELL_TARGET="${TARGET}"
+    exec nix-shell ${nixArgs[@]} --keep NIX_SHELL_TARGET ${entryPoint}
 else
-  exec nix-shell ${nixArgs[@]} --run "$@" ${entryPoint}
+    exec nix-shell ${nixArgs[@]} --run "$@" ${entryPoint}
 fi


### PR DESCRIPTION
Nesting of Nix shells does not work, since we have no way to safely do that without starting an infinite loop of nested Nix shells.

Example:

![image](https://user-images.githubusercontent.com/2212681/140510597-6fcdccb0-645d-4a0c-a422-3cd4776dec52.png)

I'd appreciate some local testing of these changes.