### PR TITLE
nix: fix gomobile builds requiring Android SDK

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -42,6 +42,8 @@ in {
     allowHigher = true;
   };
   gomobile = super.gomobile.override {
+    # FIXME: No Android SDK packages for aarch64-darwin.
+    withAndroidPkgs = stdenv.system != "aarch64-darwin";
     androidPkgs = self.androidEnvCustom.compose;
   };
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -11,10 +11,10 @@ let
   # We follow the master branch of official nixpkgs.
   nixpkgsSrc = fetchFromGitHub {
     name = "nixpkgs-source";
-    owner = "NixOS";
+    owner = "status-im";
     repo = "nixpkgs";
-    rev = "65135081f63ca2f5eaa9b7b54bfc7bf31502cfd6";
-    sha256 = "074lyh19x8xs8xqf4wwwl64870rpml96g7dhx1y09i81w5k29aga";
+    rev = "15111f8a9ad423d300886b537647691c2faa28cd";
+    sha256 = "05ny644x3dpxigljnb4rmams5vrs5gkbcyqjfamvlqm8rdmsi0kn";
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
   };


### PR DESCRIPTION
This works fine on `x86_64`, but will fail when used on `aarch64`. Also upgrades Nixpkgs.

Notable package upgrades:

| Software  | Old          | New           |
|-----------|--------------|---------------|
| Glibc     | `2.32`       | `2.33`        |
| BinUtils  | `2.35.1`     | `2.35.2`      |
| CoreUtils | `8.32`       | `9.0`         |
| OpenSSL   | `1.1.1k`     | `1.1.1l`      |
| Git       | `2.31.1`     | `2.33.1`      |
| GCC       | `8.4.0`      | `8.5.0`       |
| Clojure   | `1.10.3.855` | `1.10.3.1029` |
| Node.js   | `12.22.1`    | `12.22.7`     |
| Yarn      | `1.22.10`    | `1.22.17`     |

Issue: https://github.com/status-im/status-react/issues/12794