### PR TITLE
ci: specify nix version via agent label

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'linux' }
+  agent { label 'linux && x86_64 && nix-2.3' }
 
   options {
     timestamps()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'macos && x86_64 && xcode-12.5' }
+  agent { label 'macos && x86_64 && nix-2.3 && xcode-12.5' }
 
   parameters {
     string(


### PR DESCRIPTION
Will make it easier and safer to upgrade Nix on CI hosts.

Also added architecture since we are starting to mix those.