### PR TITLE
nix: lock Go builders at 1.17.x, small cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,6 @@ build-fdroid: export ANDROID_ABI_INCLUDE = armeabi-v7a;arm64-v8a;x86;x86_64
 build-fdroid: ##@build Build release for F-Droid
 	@scripts/build-android.sh
 
-build-android: SHELL := /bin/sh
 build-android: export BUILD_ENV ?= prod
 build-android: export BUILD_TYPE ?= nightly
 build-android: export BUILD_NUMBER ?= $(TMP_BUILD_NUMBER)

--- a/nix/lib/mkFilter_test.nix
+++ b/nix/lib/mkFilter_test.nix
@@ -51,10 +51,6 @@ let
     { path = "${absPath}/ios/subfile"; type = "file";
       expected = false; }
   ];
-  # make paths absolute
-  testsAbs = builtins.map (
-    t: t // { path = "${absPath}/${t.path}"; }
-  ) tests;
 in builtins.map (
     t: let
       rval = (filter t.path t.type);

--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, deps, callPackage, mkShell
+{ pkgs, deps, callPackage, mkShell
 , status-go, androidPkgs, androidShell }:
 
 let

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -1,6 +1,5 @@
-{ stdenv, pkgs, deps, lib, config, callPackage,
-  watchmanFactory, androidPkgs, patchMavenSources,
-  jsbundle, status-go }:
+{ stdenv, pkgs, deps, lib, watchmanFactory
+, androidPkgs, patchMavenSources, jsbundle, status-go }:
 
 {
   # Value for BUILD_ENV checked by Clojure code at compile time
@@ -15,9 +14,7 @@
 assert (lib.stringLength watchmanSockPath) > 0 -> stdenv.isDarwin;
 
 let
-  inherit (lib)
-    toLower optionalString stringLength assertMsg
-    getConfig makeLibraryPath checkEnvVarSet elem;
+  inherit (lib) toLower optionalString stringLength getConfig makeLibraryPath elem;
 
   # Pass secretsFile for INFURA_TOKEN to jsbundle build
   builtJsBundle = jsbundle { inherit secretsFile; };
@@ -28,9 +25,6 @@ let
   gradleOpts = getConfig "android.gradle-opts" null;
   # Used to detect end-to-end builds
   androidAbiInclude = getConfig "android.abi-include" "armeabi-v7a;arm64-v8a;x86";
-
-  baseName = "${buildType}-android";
-  name = "status-react-build-${baseName}";
 
   envFileName = 
     if androidAbiInclude == "x86"                  then ".env.e2e" 
@@ -44,8 +38,10 @@ let
   apksPath = "./android/app/build/outputs/apk/${toLower gradleBuildType}";
   patchedWatchman = watchmanFactory watchmanSockPath;
 
+  baseName = "${buildType}-android";
 in stdenv.mkDerivation rec {
-  inherit name;
+  name = "status-react-build-${baseName}";
+
   src = let path = ./../../..;
   # We use builtins.path so that we can name the resulting derivation
   in builtins.path {

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -1,8 +1,6 @@
-{ config, lib, stdenvNoCC, callPackage, mkShell, status-go }:
+{ lib, callPackage, mkShell, status-go }:
 
 let
-  inherit (lib) catAttrs concatStrings optional unique;
-
   fastlane = callPackage ./fastlane { };
 
   android = callPackage ./android {
@@ -24,7 +22,7 @@ let
 
 in {
   shell = mkShell {
-    inputsFrom = (catAttrs "shell" selectedSources);
+    inputsFrom = lib.catAttrs "shell" selectedSources;
   };
 
   # TARGETS

--- a/nix/mobile/ios/status-go-shell.nix
+++ b/nix/mobile/ios/status-go-shell.nix
@@ -3,7 +3,7 @@
 # It copies the status-go build result to 'modules/react-native-status/ios/RCTStatus'.
 #
 
-{ lib, mkShell, status-go }:
+{ mkShell, status-go }:
 
 mkShell {
   shellHook = ''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -33,7 +33,6 @@ in {
   gradlePropParser = callPackage ./tools/gradlePropParser.nix { };
 
   # Package version adjustments
-  go = super.pkgs.go_1_17;
   gradle = super.pkgs.gradle_5;
   nodejs = super.pkgs.nodejs-16_x;
   openjdk = super.pkgs.openjdk8_headless;
@@ -41,6 +40,9 @@ in {
     version = "13.3";
     allowHigher = true;
   };
+  go = super.pkgs.go_1_17;
+  buildGoPackage = super.pkgs.buildGo117Package;
+  buildGoModule = super.pkgs.buildGo117Module;
   gomobile = super.gomobile.override {
     # FIXME: No Android SDK packages for aarch64-darwin.
     withAndroidPkgs = stdenv.system != "aarch64-darwin";

--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -3,7 +3,7 @@
 # for the Android development environment.
 #
 
-{ stdenv, config, callPackage, androidenv, openjdk, mkShell }:
+{ androidenv }:
 
 # The "android-sdk-license" license is accepted
 # by setting android_sdk.accept_license = true.

--- a/nix/pkgs/android-sdk/default.nix
+++ b/nix/pkgs/android-sdk/default.nix
@@ -3,7 +3,7 @@
 # for the Android development environment.
 #
 
-{ callPackage, stdenv, writeScript }:
+{ callPackage }:
 
 let
   compose = callPackage ./compose.nix { };

--- a/nix/pkgs/go-maven-resolver/default.nix
+++ b/nix/pkgs/go-maven-resolver/default.nix
@@ -1,8 +1,8 @@
-{ lib, buildGo116Module, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 let
   inherit (lib) strings;
-in buildGo116Module rec {
+in buildGoModule rec {
   pname = "go-maven-resolver";
   version = "v1.1.2";
 

--- a/nix/pkgs/go-maven-resolver/default.nix
+++ b/nix/pkgs/go-maven-resolver/default.nix
@@ -1,8 +1,6 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ buildGoModule, fetchFromGitHub }:
 
-let
-  inherit (lib) strings;
-in buildGoModule rec {
+buildGoModule rec {
   pname = "go-maven-resolver";
   version = "v1.1.2";
 

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -71,7 +71,7 @@ let
   };
 
   # for merging the default shell with others
-  mergeDefaultShell = (key: val: lib.mergeSh default [ val ]);
+  mergeDefaultShell = (_: val: lib.mergeSh default [ val ]);
 
 # values here can be selected using `nix-shell --attr shells.$TARGET default.nix`
 # the nix/scripts/shell.sh wrapper does this for us and expects TARGET to be set

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, mkShell, openjdk, androidPkgs }:
+{ lib, callPackage, mkShell }:
 
 let
   inherit (lib) attrValues mapAttrs;
@@ -39,7 +39,6 @@ in rec {
   library = callPackage ./library {
     inherit meta source;
   };
-
 
   shell = mkShell {
     inputsFrom = [ mobile.android mobile.ios ];

--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -1,13 +1,8 @@
-{ lib, stdenv, utils, buildGoPackage
-, go, xcodeWrapper
+{ buildGoPackage
 # object with source attributes
 , meta, source}:
 
-let
-  inherit (stdenv) isDarwin;
-  inherit (lib) optional;
-
-in buildGoPackage {
+buildGoPackage {
   pname = source.repo;
   version = "${source.cleanVersion}-${source.shortRev}";
 
@@ -25,9 +20,7 @@ in buildGoPackage {
   # Build the Go library
   buildPhase = ''
     runHook preBuild
-
-    go build -buildmode=c-archive -o $out/libstatus.a  $NIX_BUILD_TOP/main.go
-
+    go build -buildmode=c-archive -o $out/libstatus.a $NIX_BUILD_TOP/main.go
     runHook postBuild
   '';
 }

--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, utils, buildGo117Package
+{ lib, stdenv, utils, buildGoPackage
 , go, xcodeWrapper
 # object with source attributes
 , meta, source}:
@@ -7,7 +7,7 @@ let
   inherit (stdenv) isDarwin;
   inherit (lib) optional;
 
-in buildGo117Package {
+in buildGoPackage {
   pname = source.repo;
   version = "${source.cleanVersion}-${source.shortRev}";
 

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, utils, callPackage, buildGo116Package
+{ lib, stdenv, utils, callPackage, buildGoPackage
 , go, androidPkgs, openjdk, gomobile, xcodeWrapper
 # object with source attributes
 , meta, source
@@ -23,7 +23,7 @@ let
   # formatted for use with -target
   targetArchs = map (a: "${platform}/${a}") architectures;
 
-in buildGo116Package {
+in buildGoPackage {
   pname = source.repo;
   version = "${source.cleanVersion}-${source.shortRev}-${platform}";
 

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, utils, callPackage, buildGoPackage
+{ lib, stdenv, utils, buildGoPackage
 , go, androidPkgs, openjdk, gomobile, xcodeWrapper
 # object with source attributes
 , meta, source
@@ -13,9 +13,7 @@
 
 let
   inherit (stdenv) isDarwin;
-  inherit (lib)
-    concatStrings concatStringsSep concatMapStrings optionalString
-    getAttr attrValues makeBinPath optional;
+  inherit (lib) concatStringsSep concatMapStrings optionalString makeBinPath optional;
 
   removeReferences = [ go ];
   removeExpr = refs: ''remove-references-to ${concatMapStrings (ref: " -t ${ref}") refs}'';

--- a/nix/status-go/source.nix
+++ b/nix/status-go/source.nix
@@ -1,7 +1,7 @@
-{ config, utils, lib, callPackage, fetchFromGitHub }:
+{ utils, lib, fetchFromGitHub }:
 
 let
-  inherit (lib) strings traceValFn attrByPath importJSON getConfig;
+  inherit (lib) strings traceValFn importJSON getConfig;
 
   srcOverride = getConfig "status-go.src-override" null;
   # Warning message about using local sources

--- a/nix/tools/envParser.nix
+++ b/nix/tools/envParser.nix
@@ -1,12 +1,11 @@
 # This Nix expression takes care of reading/parsing the correct .env configuration file and return it as an attr set
-{ config, stdenv, lib }:
+{ config, lib }:
 
 let
   inherit (builtins) listToAttrs head tail readFile;
   inherit (lib) attrByPath filter hasPrefix nameValuePair splitString;
 
   build-type = attrByPath ["status-im" "build-type"] "" config;
-  ci = (attrByPath ["status-im" "ci"] "" config) != "";
 
   readLinesFromFile =
     file:

--- a/nix/tools/gradlePropParser.nix
+++ b/nix/tools/gradlePropParser.nix
@@ -11,7 +11,7 @@ let
   lines = splitString "\n" (readFile gradlePropsFile);
 
   isKeyValueLine = line: line != "" && !hasPrefix "#" line;
-  cleanup = lines: filter isKeyValueLine lines;
+  cleanup = filter isKeyValueLine;
   extractKeyValues = line:
     let flag = splitString "=" line;
     in nameValuePair (head flag) (last flag);

--- a/nix/tools/utils.nix
+++ b/nix/tools/utils.nix
@@ -53,9 +53,9 @@ let
   sanitizeVersion = version:
     if (builtins.match versionRegex version) != null
     # Geth forces a 'v' prefix for all versions
-    then lib.removePrefix "v" (dropSlashes version) 
+    then lib.removePrefix "v" (dropSlashes version)
     # reduce metrics cardinality in Prometheus
-    else lib.traceValFn (v: "WARNING: Marking build version as 'develop'!") "develop"; 
+    else lib.traceValFn (_: "WARNING: Marking build version as 'develop'!") "develop";
 
 in {
   inherit sanitizeVersion


### PR DESCRIPTION
If we keep using specific `buildGo117Package` we can easily forget to upgrade when we bump the Go compiler itself. By locking those explicitly in `overlay.nix` we make sure they all get bumped together.