### PR TITLE
nix: nixpgs upgrade, Android SDK fixes, Coreutils 9.1

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -11,10 +11,10 @@ let
   # We follow the master branch of official nixpkgs.
   nixpkgsSrc = fetchFromGitHub {
     name = "nixpkgs-source";
-    owner = "status-im";
+    owner = "NixOS";
     repo = "nixpkgs";
-    rev = "4ba5f26780e7a27aa2e97676603cd9ef04f11e74";
-    sha256 = "sha256-ZpHXUuF9bvHooKwGuR1Mr/n2mE/LJ6/MCdCk2AfdD9M=";
+    rev = "8a782b05cb764db86f2826995adb9128e26dffe2";
+    sha256 = "sha256-9+Ys74yxniHBz2/kLVSzboqCNRx1E+Dv/yzSBtw0jDQ=";
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
   };

--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -9,7 +9,7 @@
 # by setting android_sdk.accept_license = true.
 androidenv.composeAndroidPackages {
   toolsVersion = "26.1.1";
-  platformToolsVersion = "31.0.3";
+  platformToolsVersion = "33.0.1";
   buildToolsVersions = [ "31.0.0" ];
   platformVersions = [ "30" ];
   cmakeVersions = [ "3.18.1" ];


### PR DESCRIPTION
Notable version changes:

- Coreutils `9.0` to `9.1`
- OpenSSL `1.1.1n` to `1.1.1o`
- NodeJS `16.14.2` to `16.15.1`
- Clojure `1.11.1.1107` to `1.11.1.1113`
- Ruby `2.7.5p203` to `2.7.6p219`
- Cocoapods `1.11.0` to `1.11.3`
- Git `2.35.1` to `2.36.1`
- Curl `7.82.0` to `7.83.1`
- Android SDK Platform Tools `31.0.3` to `33.0.1`

Most important is the Coreutils upgrade to 9.1 which includes a fix for iOS builds on new M1 ARM64 processors:
- https://github.com/status-im/status-react/issues/12799

Also fixes broken Android SDK builds on Linux due to `auto-patchelf-hook` change:
- https://github.com/NixOS/nixpkgs/pull/163924

I've fixed this in `nixpkgs` PR:
- https://github.com/NixOS/nixpkgs/pull/173376