### PR TITLE
add newline when creating status-go diff link

### DIFF
--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -16,7 +16,7 @@ COMMIT_MSG_FILE=$1
 # Check if the commit message already contains the link (rebase) and update otherwise insert into line2
 if ! grep -qF "${GITHUB_LINK_PREFIX}" "${COMMIT_MSG_FILE}" >/dev/null; then
   sed -in'' -e "2i\\
-${GITHUB_LINK}\n" "${COMMIT_MSG_FILE}"
+\n${GITHUB_LINK}" "${COMMIT_MSG_FILE}"
 else
   sed -in'' -e "s;^${GITHUB_LINK_PREFIX}.*$;${GITHUB_LINK};" "${COMMIT_MSG_FILE}"
 fi

--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -10,7 +10,7 @@ GO_COMMIT_MERGE_BASE=$(git show "${MERGE_BASE}":status-go-version.json | jq -r '
 GO_COMMIT_CURRENT=$(jq -r '."commit-sha1"' status-go-version.json)
 GITHUB_LINK_PREFIX="https://github.com/status-im/status-go/compare/"
 # Link to the current StatusGo changelog being updated.
-GITHUB_LINK="${GITHUB_LINK_PREFIX}${GO_COMMIT_MERGE_BASE}...${GO_COMMIT_CURRENT}"
+GITHUB_LINK="${GITHUB_LINK_PREFIX}${GO_COMMIT_MERGE_BASE::8}...${GO_COMMIT_CURRENT::8}"
 
 COMMIT_MSG_FILE=$1
 # Check if the commit message already contains the link (rebase) and update otherwise insert into line2


### PR DESCRIPTION
Otherwise Fugitive plugin in Vim complains about it.

![image](https://user-images.githubusercontent.com/2212681/171618464-3db51bbe-8a83-4efd-a07d-baa4df0308a6.png)

Now:

![image](https://user-images.githubusercontent.com/2212681/171618606-64bf2134-5f09-4c67-8b35-9e2138eab6fe.png)