### PR TITLE
nix: add script for adding missing Gradle packages

### DIFF
--- a/nix/deps/gradle/README.md
+++ b/nix/deps/gradle/README.md
@@ -45,7 +45,7 @@ One dependency these scripts require is the [go-maven-resolver](https://github.c
 
 # Known Issues
 
-One edge case that is currently not handled by this setup is an addition of a new dependency that requires a version of Gradle we don't have. In that case running `make nix-update-gradle` would fail with:
+One edge case that is currently not automatically handled by this setup is an addition of a new dependency that requires a version of Gradle we don't have. In that case running `make nix-update-gradle` would fail with:
 ```
 AILURE: Build failed with an exception.
 
@@ -61,16 +61,14 @@ A problem occurred configuring project ':react-native-example-project'.
 ```
 This happens because `get_projects.sh` and `get_deps.sh` depend on running Gradle to generate their output, and that will not work because Gradle cannot find the matching JAR for the new dependency.
 
-A manual solution would involve adding that specific Gradle version into `deps.urls`:
+You can use the `add_package.sh` script to add missing Gradle dependencies:
 ```
-echo com.android.tools.build:gradle:3.4.0 | go-maven-resolver >> nix/deps/gradle/deps.urls
+ > make shell TARGET=gradle
+Configuring Nix shell for target 'gradle'...
+
+[nix-shell:~/status-react]$ nix/deps/gradle/add_package.sh com.android.tools.build:gradle:3.4.0
+Regenerating Nix files...
+Found 548 direct dependencies...
+Successfully added: com.android.tools.build:gradle:3.4.0
 ```
-Then you'll need to remove duplicates and sort `deps.urls`:
-```
-sort -uo nix/deps/gradle/deps.urls nix/deps/gradle/deps.urls
-```
-And finally generate the `deps.json` for Nix using:
-```
-nix/deps/gradle/generate.sh gen_deps_json
-```
-After run `make nix-update-gradle` and it should work just fine.
+This may take a bit longer than normal `make nix-update-gradle` but should add the missing package.

--- a/nix/deps/gradle/add_package.sh
+++ b/nix/deps/gradle/add_package.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -Eeu
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: add_package.sh <package>" >&2
+    exit 1
+fi
+if ! command -v go-maven-resolver &> /dev/null; then
+   echo "Use 'make shell TARGET=gradle' for this script" >&2
+    exit 1
+fi
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+source "${GIT_ROOT}/scripts/colors.sh"
+
+# Add missing package to dependencies.
+echo "${1}" | go-maven-resolver >> nix/deps/gradle/deps.urls
+
+# Remove duplicates and sort.
+sort -uo nix/deps/gradle/deps.urls nix/deps/gradle/deps.urls
+
+# Re-generate dependencies JSON.
+${GIT_ROOT}/nix/deps/gradle/generate.sh gen_deps_json
+
+# Re-generate dependencies list.
+${GIT_ROOT}/nix/deps/gradle/generate.sh gen_deps_list
+
+echo -e "${GRN}Successfully added:${RST} ${BLD}${1}${RST}" >&2

--- a/nix/deps/gradle/generate.sh
+++ b/nix/deps/gradle/generate.sh
@@ -14,10 +14,9 @@ fi
 # required to build the project
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
-THIS_SCRIPT=$(realpath --relative-to="${GIT_ROOT}" ${BASH_SOURCE})
-CUR_DIR=$(cd "${BASH_SOURCE%/*}" && pwd)
 source "${GIT_ROOT}/scripts/colors.sh"
 
+CUR_DIR=$(cd "${BASH_SOURCE%/*}" && pwd)
 PROJ_LIST="${CUR_DIR}/proj.list"
 DEPS_LIST="${CUR_DIR}/deps.list"
 DEPS_URLS="${CUR_DIR}/deps.urls"


### PR DESCRIPTION
This handles the usual case where a missing Gradle version causes the call to `make nix-update-gradle` to fail since call to Gradle also fails.

This is simpler than getting a dev to run commands manually.