### PR TITLE
nix: cleanup status-go mobile build derivation

### DIFF
--- a/nix/scripts/build.sh
+++ b/nix/scripts/build.sh
@@ -58,7 +58,7 @@ nixOpts=(
 ${GIT_ROOT}/nix/scripts/gcroots.sh "${TARGET}" "${@}"
 
 # Run the actual build
-echo "${GRN}Running:${RST} nix-build "${nixOpts[@]}" "${@}" default.nix"
+echo -e "${GRN}Running:${RST} ${BLD}nix-build "${nixOpts[@]}" ${@}${RST}"
 nixResultPath=$(nix-build "${nixOpts[@]}" "${@}" default.nix)
 
 echo -e "\n${YLW}Extracting result${RST}: ${BLD}${nixResultPath}${RST}"

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -28,12 +28,9 @@ let
     "-s" # -s disabled symbol table
     "-w" # -w disables DWARF debugging information
   ];
-
-  goBuildFlags = [ "-v" ];
-
 in rec {
   mobile = callPackage ./mobile {
-    inherit meta source goBuildFlags goBuildLdFlags;
+    inherit meta source goBuildLdFlags;
   };
 
   library = callPackage ./library {

--- a/nix/status-go/mobile/default.nix
+++ b/nix/status-go/mobile/default.nix
@@ -1,22 +1,19 @@
-{ callPackage
-, meta, source
-, goBuildFlags
-, goBuildLdFlags }:
+{ callPackage, meta, source, goBuildLdFlags }:
 
 {
   android = callPackage ./build.nix {
     platform = "android";
-    # 386 is for android simulator
-    architectures = [ "arm" "arm64" "386" ];
+    platformVersion = "23";
+    architectures = [ "arm" "arm64" "386" ]; # 386 is for android simulator.
     outputFileName = "status-go-${source.shortRev}.aar";
-    inherit meta source goBuildFlags goBuildLdFlags;
+    inherit meta source goBuildLdFlags;
   };
 
   ios = callPackage ./build.nix {
     platform = "ios";
-    # amd64 is for ios simulator
-    architectures = [ "arm64" "amd64" ];
+    platformVersion = "8.0";
+    architectures = [ "arm64" "amd64" ]; # amd64 is for ios simulator.
     outputFileName = "Statusgo.framework";
-    inherit meta source goBuildFlags goBuildLdFlags;
+    inherit meta source goBuildLdFlags;
   };
 }


### PR DESCRIPTION
While working on Nix builds for `go-waku` I figured this derivation could use some cleanup, to make it shorter and more readable.