### PR TITLE
ci: use newly added disableConcurrentBuilds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.4.3'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent { label 'linux && x86_64 && nix-2.8' }
 
@@ -15,6 +18,10 @@ pipeline {
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-react/*')
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   parameters {
@@ -44,7 +51,6 @@ pipeline {
         script {
           btype = utils.getBuildType()
           print "Running ${btype} build!"
-          jenkins.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           commonPrep(btype)
         }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.4.3'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent { label 'macos && x86_64 && nix-2.8 && xcode-13.3' }
 
@@ -23,6 +26,10 @@ pipeline {
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-react/*')
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {
@@ -43,7 +50,6 @@ pipeline {
         script {
           btype = utils.getBuildType()
           print "Running ${btype} build!"
-          jenkins.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           commonPrep(btype)
         }


### PR DESCRIPTION
* https://github.com/jenkinsci/workflow-job-plugin/pull/200

Removes the need to use our own convoluted implementation:
https://github.com/status-im/status-jenkins-lib/blob/17c1d0ea/vars/jenkins.groovy#L6-L27