### PR TITLE
ci: use different IPFS gateway for release builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.0'
+library 'status-jenkins-lib@v1.5.1'
 
 pipeline {
   agent { label 'linux' }

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -12,7 +12,10 @@
       abi-include = "armeabi-v7a;arm64-v8a;x86"; # Android architectures to build for
     };
 
-    status-go = { src-override = null; };
+    status-go = {
+      src-override = null;
+      ipfs-gateway-url = "https://ipfs.status.im/";
+    };
   };
 
   # Android SDK requires an accepted license

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -1,7 +1,7 @@
 { lib, callPackage, mkShell }:
 
 let
-  inherit (lib) attrValues mapAttrs;
+  inherit (lib) getConfig attrValues mapAttrs;
 
   # Metadata common to all builds of status-go
   meta = {
@@ -17,6 +17,8 @@ let
   goBuildParams = {
     GitCommit = source.rev;
     Version = source.cleanVersion;
+    # FIXME: This should be moved to status-go config.
+    IpfsGatewayURL = getConfig "status-go.ipfs-gateway-url" "https://ipfs.status.im/";
   };
 
   # These are necessary for status-go to show correct version

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.106.2",
-    "commit-sha1": "f43f43cc30e56d342cf8d25d2e0e56aecc83fa6e",
-    "src-sha256": "0j9xgkblv56h3vvkiwsy3wnwazs0fcs4z3f3mvlvs058vpdkv9hw"
+    "version": "v0.107.0",
+    "commit-sha1": "86054875a4f0296ed38858553448dfe92c14da9c",
+    "src-sha256": "1mw6v20h20g1zy30qs97ys2dv5nggzvdbfmdfygwvf3fj018yklg"
 }


### PR DESCRIPTION
fixes: #13794

__WARNING:__ Do not merge until the https://github.com/status-im/status-go/pull/2795 PR is merged and `status-jenkins-lib` tagged.

Depends on:
- https://github.com/status-im/status-jenkins-lib/pull/44
- https://github.com/status-im/status-go/pull/2795