### PR TITLE
ci: extrac Lint and Tests to separate job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,13 +298,12 @@ shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server
 
 test-watch: export TARGET := clojure
-test-watch: status-go-library
 test-watch: ##@ Watch tests and re-run no changes to cljs files
 	yarn install
 	nodemon --exec 'yarn shadow-cljs compile mocks && yarn shadow-cljs compile test && node --require ./test-resources/override.js target/test/test.js' -e cljs
 
 test: export TARGET := clojure
-test: status-go-library ##@test Run tests once in NodeJS
+test: ##@test Run tests once in NodeJS
 	# Here we creates the gyp bindings for nodejs
 	yarn install
 	yarn shadow-cljs compile mocks && \

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -56,43 +56,14 @@ pipeline {
         }
       }
     }
-    stage('Parallel Assemble') {
-      parallel {
-        stage('Checks') { stages {
-          stage('Lint') {
-            steps {
-              script {
-                /* We want the build result to be uploaded */
-                catchError(
-                  message: 'Linting check failed!',
-                  buildResult: 'FAILURE',
-                  stageResult: 'FAILURE'
-                ) {
-                  sh 'make lint'
-                }
-              }
-            }
-          }
-          stage('Tests') {
-            steps {
-              script {
-                sh 'make test'
-              }
-            }
-          }
-        } }
-        stage('Build') { stages {
-          stage('Bundle') {
-            steps {
-              script { apks = android.bundle() }
-            }
-          }
-          stage('Sign') {
-            steps {
-              script { apks = android.sign(apks) }
-            }
-          }
-        } }
+    stage('Bundle') {
+      steps {
+        script { apks = android.bundle() }
+      }
+    }
+    stage('Sign') {
+      steps {
+        script { apks = android.sign(apks) }
       }
     }
     stage('Parallel Upload') {
@@ -103,37 +74,30 @@ pipeline {
           } }
         }
         stage('Upload') {
-          steps {
-            script {
-              def urls = apks.collect { s3.uploadArtifact(it) }
-              /* return only the universal APK */
-              if (urls.size() > 1) { 
-                env.PKG_URL = urls.find { it.contains('universal') }
-              } else { /* if no universal is available pick first */
-                env.PKG_URL = urls.first()
-              }
-              jenkins.setBuildDesc(APK: env.PKG_URL)
-              /* e2e builds get tested in SauceLabs */
-              if (utils.isE2EBuild()) {
-                env.SAUCE_URL = android.uploadToSauceLabs()
-              }
-              if (utils.isNightlyBuild()) {
-                env.DIAWI_URL = android.uploadToDiawi()
-              }
+          steps { script {
+            def urls = apks.collect { s3.uploadArtifact(it) }
+            /* return only the universal APK */
+            if (urls.size() > 1) {
+              env.PKG_URL = urls.find { it.contains('universal') }
+            } else { /* if no universal is available pick first */
+              env.PKG_URL = urls.first()
             }
-          }
+            jenkins.setBuildDesc(APK: env.PKG_URL)
+            /* e2e builds get tested in SauceLabs */
+            if (utils.isE2EBuild()) {
+              env.SAUCE_URL = android.uploadToSauceLabs()
+            }
+            if (utils.isNightlyBuild()) {
+              env.DIAWI_URL = android.uploadToDiawi()
+            }
+          } }
         }
-      }
-    }
-    stage('Cleanup') {
-      steps {
-        sh 'make purge'
       }
     }
   }
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { sh 'make _fix-node-perms' }
+    always  { sh 'make purge' }
   }
 }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -49,6 +49,9 @@ pipeline {
         stage('Android e2e') { steps { script {
           apke2e = jenkins.Build('status-mobile/platforms/android-e2e')
         } } }
+        stage('Tests') { steps { script {
+          ios = jenkins.Build('status-mobile/platforms/tests')
+        } } }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -55,43 +55,14 @@ pipeline {
         }
       }
     }
-    stage('Parallel Assemble') {
-      parallel {
-        stage('Checks') { stages {
-          stage('Lint') {
-            steps {
-              script {
-                /* We want the build result to be uploaded */
-                catchError(
-                  message: 'Linting check failed!',
-                  buildResult: 'FAILURE',
-                  stageResult: 'FAILURE'
-                ) {
-                  sh 'make lint'
-                }
-              }
-            }
-          }
-          stage('Tests') {
-            steps {
-              script {
-                sh 'make test'
-              }
-            }
-          }
-        } }
-        stage('Build') { stages {
-          stage('JSBundle') {
-            steps {
-              script { ios.jsbundle() }
-            }
-          }
-          stage('Bundle') {
-            steps {
-              script { api = ios.bundle() }
-            }
-          }
-        } }
+    stage('JSBundle') {
+      steps {
+        script { ios.jsbundle() }
+      }
+    }
+    stage('Bundle') {
+      steps {
+        script { api = ios.bundle() }
       }
     }
     stage('Parallel Upload') {
@@ -102,31 +73,23 @@ pipeline {
           }
         }
         stage('Upload') {
-          steps {
-            script {
-              env.PKG_URL = s3.uploadArtifact(api)
-              jenkins.setBuildDesc(IPA: env.PKG_URL)
-              /* e2e builds get tested in SauceLabs */
-              if (utils.isE2EBuild()) {
-                env.SAUCE_URL = ios.uploadToSauceLabs()
-              } else {
-                env.DIAWI_URL = ios.uploadToDiawi()
-              }
+          steps { script {
+            env.PKG_URL = s3.uploadArtifact(api)
+            jenkins.setBuildDesc(IPA: env.PKG_URL)
+            /* e2e builds get tested in SauceLabs */
+            if (utils.isE2EBuild()) {
+              env.SAUCE_URL = ios.uploadToSauceLabs()
+            } else {
+              env.DIAWI_URL = ios.uploadToDiawi()
             }
-          }
+          } }
         }
-      }
-    }
-    stage('Cleanup') {
-      steps {
-        sh 'make watchman-clean'
-        sh 'make purge'
       }
     }
   }
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { sh 'make _fix-node-perms' }
+    always  { sh 'make purge' }
   }
 }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,0 +1,77 @@
+library 'status-jenkins-lib@v1.5.0'
+
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
+pipeline {
+  agent { label 'linux && x86_64 && nix-2.8' }
+
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 10, unit: 'MINUTES')
+    /* Limit builds retained */
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
+    ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
+  }
+
+  parameters {
+    string(
+      name: 'BUILD_TYPE',
+      description: 'Specify build type. Values: pr / e2e / nightly / release',
+      defaultValue: 'pr',
+    )
+  }
+
+  environment {
+    LANG     = "en_US.UTF-8"
+    LC_ALL   = "en_US.UTF-8"
+    LANGUAGE = "en_US.UTF-8"
+    TARGET   = 'tests'
+    BUILD_ENV = 'prod'
+    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
+    LOG_FILE = utils.pkgFilename(ext: 'log', arch: 'tests')
+  }
+
+  stages {
+    stage('Prep') {
+      steps {
+        script {
+          btype = utils.getBuildType()
+          print "Running ${btype} build!"
+          /* Cleanup and Prep */
+          commonPrep(btype)
+        }
+      }
+    }
+    stage('Checks') {
+      parallel {
+        stage('Lint') {
+          steps { sh "make lint > ${LOG_FILE}" }
+        }
+        stage('Tests') {
+          steps { sh "make test >> ${LOG_FILE}" }
+        }
+      }
+    }
+    stage('Upload') {
+      steps {
+        script {
+          env.PKG_URL = s3.uploadArtifact(LOG_FILE)
+        }
+      }
+    }
+  }
+  post {
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    always  { sh 'make purge' }
+  }
+}


### PR DESCRIPTION
This way we can make PRs depend only on successful tests, and not whole builds for all platforms, which take 10 min or more.

The added benefit is that builds are slightly faster, and test logs can be publicly available.