### PR TITLE
ci: fix keystore used when validating APK

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.2'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
Necessary to avoid validation errors due to missing release keystore.

Depends on:
* https://github.com/status-im/status-jenkins-lib/pull/46