### PR TITLE
ci: disable sandbox for iOS builds to fix status-go

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -50,7 +50,7 @@ pipeline {
           apke2e = jenkins.Build('status-mobile/platforms/android-e2e')
         } } }
         stage('Tests') { steps { script {
-          ios = jenkins.Build('status-mobile/platforms/tests')
+          jenkins.Build('status-mobile/platforms/tests')
         } } }
       }
     }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.2'
+library 'status-jenkins-lib@v1.5.3'
 
 pipeline {
   agent { label 'linux' }

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -9,7 +9,7 @@ max-jobs = auto
 # Helps avoid removing currently used dependencies via garbage collection
 keep-derivations = true
 keep-outputs = true
-# Extra isolation for network and filesystem, doesn't work on MacOS
-build-use-sandbox = false
+# Some builds on MacOS have issue with sandbox so they are disabled with __noChroot.
+sandbox = relaxed
 # Enable Nix v2 interface.
 experimental-features = nix-command

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -18,6 +18,10 @@ in buildGoPackage {
   inherit meta;
   inherit (source) src goPackagePath;
 
+  # Sandbox causes Xcode issues on MacOS. Requires sandbox=relaxed.
+  # https://github.com/status-im/status-mobile/pull/13912
+  __noChroot = (platform == "ios");
+
   extraSrcPaths = [ gomobile ];
   nativeBuildInputs = [ gomobile removeReferencesTo ]
     ++ optional (platform == "android") openjdk


### PR DESCRIPTION
Otherwise we get weird failures like these:
```
clang-11: error: cannot use 'cpp-output' output with multiple -arch options
clang-11: error: invalid argument '-mmacos-version-min=10.12' not allowed with '-miphoneos-version-min=8.0'
clang-11: error: invalid argument '-mmacos-version-min=10.12' not allowed with '-miphoneos-version-min=8.0'
```
https://ci.infra.status.im/job/status-mobile/job/platforms/job/ios/707/

Depends on: https://github.com/status-im/status-jenkins-lib/pull/47