### PR TITLE
ci: use pipefail to actually catch test errors

### DIFF
--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -54,10 +54,20 @@ pipeline {
     stage('Checks') {
       parallel {
         stage('Lint') {
-          steps { sh "make lint 2>&1 | tee ${LOG_FILE}" }
+          steps {
+            sh """#!/bin/bash
+              set -eo pipefail
+              make lint 2>&1 | tee ${LOG_FILE}
+            """
+          }
         }
         stage('Tests') {
-          steps { sh "make test 2>&1 | tee -a ${LOG_FILE}" }
+          steps {
+            sh """#!/bin/bash
+              set -eo pipefail
+              make test 2>&1 | tee -a ${LOG_FILE}
+            """
+          }
         }
       }
     }


### PR DESCRIPTION
Because otherwise when piping optput to `tee` the exit code that affects the result of the whole `sh` call is the last command in the pipe.