### PR TITLE
Revert "[13857] Extend integration tests to recover multiaccount from seed phrase"

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -26,7 +26,6 @@
             :View                     {}
             :RefreshControl           {}
             :AppState                 {}
-            :Alert                    {:alert (fn [])}
             :FlatList                 {}
             :SectionList              {}
             :Text                     {}
@@ -137,7 +136,6 @@
                                                    :setDefaultOptions identity
                                                    :setRoot identity
                                                    :dismissOverlay #(js/Promise.resolve)
-                                                   :showOverlay identity
                                                    :setLazyComponentRegistrator identity
                                                    :pop identity
                                                    :push identity

--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -4,7 +4,6 @@
             [clojure.string :as string]
             [re-frame.core :as rf]
             status-im.events
-            [status-im.utils.security :as security]
             [status-im.multiaccounts.logout.core :as logout]
             [status-im.transport.core :as transport]
             status-im.subs ;;so integration tests can run independently
@@ -174,34 +173,6 @@
          (logout!)
          (rf-test/wait-for [::logout/logout-method] ; we need to logout to make sure the node is not in an inconsistent state between tests
                            (assert-logout)))))))))
-
-(def multiaccount-name "Narrow Frail Lemming")
-(def multiaccount-mnemonic "tattoo ramp health green tongue universe style vapor become tape lava reason")
-(def multiaccount-key-uid "0x694b8229524820a3a00a6e211141561d61b251ad99d6b65daf82a73c9a57697b")
-
-(deftest recover-multiaccount-test
-  (log/info "========= recover-multiaccount-test ==================")
-  (rf-test/run-test-async
-   (initialize-app!)
-   (rf-test/wait-for
-    [:status-im.init.core/initialize-view]
-    (rf/dispatch-sync [:init-root :onboarding])
-    (rf/dispatch-sync [:multiaccounts.recover.ui/recover-multiaccount-button-pressed])
-    (rf/dispatch-sync [:status-im.multiaccounts.recover.core/enter-phrase-pressed])
-    (rf/dispatch-sync [:multiaccounts.recover/enter-phrase-input-changed
-                       (security/mask-data multiaccount-mnemonic)])
-    (rf/dispatch [:multiaccounts.recover/enter-phrase-next-pressed])
-    (rf-test/wait-for
-     [:status-im.multiaccounts.recover.core/import-multiaccount-success]
-     (rf/dispatch-sync [:multiaccounts.recover/re-encrypt-pressed])
-     (rf/dispatch [:multiaccounts.recover/enter-password-next-pressed password])
-     (rf-test/wait-for
-      [:status-im.multiaccounts.recover.core/store-multiaccount-success]
-      (let [multiaccount @(rf/subscribe [:multiaccount])] ; assert multiaccount is recovered
-        (is (= multiaccount-key-uid (:key-uid multiaccount)))
-        (is (= multiaccount-name (:name multiaccount))))
-      (logout!) (rf-test/wait-for [::logout/logout-method]
-                                  (assert-logout)))))))
 
 (comment
   (run-tests))

--- a/src/status_im/utils/test.cljs
+++ b/src/status_im/utils/test.cljs
@@ -48,6 +48,7 @@
                                     settings
                                     config
                                     accounts-data))
+
             :logout (fn []
                       (.logout native-status))
             :generateAliasAndIdenticonAsync (fn [seed callback]
@@ -59,11 +60,6 @@
                                                        (.multiAccountGenerateAndDeriveAddresses
                                                         native-status
                                                         json)))
-            :multiAccountImportMnemonic (fn [json callback]
-                                          (callback
-                                           (.multiAccountImportMnemonic
-                                            native-status
-                                            json)))
             :multiAccountLoadAccount (fn [json callback]
                                        (callback
                                         (.multiAccountLoadAccount
@@ -79,11 +75,8 @@
                              (.initKeystore
                               native-status
                               (str test-dir "/keystore/" key-uid))))
+
             :identicon (fn [pk]
                          (.identicon native-status pk))
-            :validateMnemonic (fn [json callback]
-                                (callback
-                                 (.validateMnemonic
-                                  native-status
-                                  json)))
+
             :startLocalNotifications identity}))


### PR DESCRIPTION
This test has been introduced in:

* https://github.com/status-im/status-mobile/pull/13896/files

And has caused `status-go` segmentation faults:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x7fb109afac12]

goroutine 17 [running, locked to thread]:
github.com/status-im/status-go/services/ens.(*Service).Stop(...)
    github.com/status-im/status-go/services/ens/service.go:39
github.com/status-im/status-go/node.(*StatusNode).Cleanup(0xc004a89380)
    github.com/status-im/status-go/node/status_node_services.go:587 +0x112
github.com/status-im/status-go/api.(*GethStatusBackend).cleanupServices(...)
    github.com/status-im/status-go/api/geth_backend.go:1175
github.com/status-im/status-go/api.(*GethStatusBackend).Logout(0xc000e6b4a0)
    github.com/status-im/status-go/api/geth_backend.go:1146 +0xb9
github.com/status-im/status-go/mobile.Logout()
    github.com/status-im/status-go/mobile/status.go:398 +0x25
main.Logout()
    ./main.go:132 +0x19s
```