### PR TITLE
hooks: use AWK instead of jq for better portability

### DIFF
--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 if [[ -z $(git diff --cached --name-only -r | grep status-go-version.json) ]]; then
   exit 0 # No status-go-version.json changes found.
 fi
+
+# MacOS sed is garbage and interprets newlines differently.
+[[ "$(uname)" -eq "Darwin" ]] && NL=$'\\\n' || NL="\n"
 
 MERGE_BASE=$(git merge-base -a develop "$(git rev-parse --abbrev-ref HEAD)" develop)
 GO_COMMIT_MERGE_BASE=$(git show "${MERGE_BASE}":status-go-version.json | awk -F'"' '/commit-sha1/{print $4}')
@@ -16,7 +19,7 @@ COMMIT_MSG_FILE=$1
 # Check if the commit message already contains the link (rebase) and update otherwise insert into line2
 if ! grep -qF "${GITHUB_LINK_PREFIX}" "${COMMIT_MSG_FILE}" >/dev/null; then
   sed -in'' -e "2i\\
-\n${GITHUB_LINK}" "${COMMIT_MSG_FILE}"
+${NL}${GITHUB_LINK}" "${COMMIT_MSG_FILE}"
 else
   sed -in'' -e "s;^${GITHUB_LINK_PREFIX}.*$;${GITHUB_LINK};" "${COMMIT_MSG_FILE}"
 fi

--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -6,8 +6,8 @@ if [[ -z $(git diff --cached --name-only -r | grep status-go-version.json) ]]; t
 fi
 
 MERGE_BASE=$(git merge-base -a develop "$(git rev-parse --abbrev-ref HEAD)" develop)
-GO_COMMIT_MERGE_BASE=$(git show "${MERGE_BASE}":status-go-version.json | jq -r '."commit-sha1"')
-GO_COMMIT_CURRENT=$(jq -r '."commit-sha1"' status-go-version.json)
+GO_COMMIT_MERGE_BASE=$(git show "${MERGE_BASE}":status-go-version.json | awk -F'"' '/commit-sha1/{print $4}')
+GO_COMMIT_CURRENT=$(awk -F'"' '/commit-sha1/{print $4}' status-go-version.json)
 GITHUB_LINK_PREFIX="https://github.com/status-im/status-go/compare/"
 # Link to the current StatusGo changelog being updated.
 GITHUB_LINK="${GITHUB_LINK_PREFIX}${GO_COMMIT_MERGE_BASE::8}...${GO_COMMIT_CURRENT::8}"


### PR DESCRIPTION
Some systems don't have jq installed, and using something like `nix-shell` in the shebang would make this script noticeably slower.

We're not using `grep` because it lacks `-P` flag on MacOS.

Also added a fix for `n` showing up in the link on MacOS because MacOS `sed` just needs newlines to be escaped differently.

Resolves: https://github.com/status-im/status-mobile/issues/13322