### PR TITLE
Reduce recording time to 1 minute

### DIFF
--- a/src/status_im/ui/screens/chat/audio_message/views.cljs
+++ b/src/status_im/ui/screens/chat/audio_message/views.cljs
@@ -22,7 +22,6 @@
 ;; reference db levels
 (def total-silence-db -160)
 (def silence-db -35)
-(def max-db 0)
 
 ;; update interval for the pulsing rec button
 (def metering-interval 100)
@@ -47,9 +46,8 @@
                    {:filename (str base-filename default-format)
                     :meteringInterval metering-interval}))
 
-;; maximum 2 minutes of recordings time
-;; to keep data under 900k
-(def max-recording-ms (* 2 60 1000))
+;; maximum 1 minute of recordings time to keep data at certain size
+(def max-recording-ms (* 1 60 1000))
 
 ;; audio objects
 (defonce recorder-ref (atom nil))

--- a/test/appium/tests/critical/chats/test_1_1_public_chats.py
+++ b/test/appium/tests/critical/chats/test_1_1_public_chats.py
@@ -253,17 +253,17 @@ class TestOneToOneChatMultipleSharedDevices(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(6316)
-    def test_1_1_chat_text_message_with_push(self):
+    def test_1_1_chat_audio_message_with_push(self):
         self.home_2.just_fyi("Put app on background (to check Push notification received for audio message)")
         self.home_2.click_system_home_button()
 
         self.home_2.just_fyi("Sending audio message to device who is on background")
-        self.chat_1.record_audio_message(message_length_in_seconds=125)
+        self.chat_1.record_audio_message(message_length_in_seconds=65)
         if not self.chat_1.element_by_text("Maximum recording time reached").is_element_displayed():
-            self.drivers[0].fail("Exceeded 2 mins limit of recording time.")
+            self.drivers[0].fail("Exceeded 1 min limit of recording time.")
 
         self.chat_1.ok_button.click()
-        if self.chat_1.audio_message_recorded_time.text != "1:59":
+        if self.chat_1.audio_message_recorded_time.text != "0:59":
             self.errors.append("Timer exceed 2 minutes")
         self.chat_1.send_message_button.click()
 


### PR DESCRIPTION
temporary workaround for #13914

### Summary
Reduced voice message record time to 1 minute.

#### Platforms
- Android
- iOS

##### Functional
- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- [See here](https://github.com/status-im/status-mobile/issues/13914#:~:text=Actual%20behavior-,Reproduction,-Start%201%2D1)
- See if sent ok

status: ready