### PR TITLE
nix: patch gomobile to sanitize xcrun output

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -43,7 +43,12 @@ in {
   go = super.pkgs.go_1_17;
   buildGoPackage = super.pkgs.buildGo117Package;
   buildGoModule = super.pkgs.buildGo117Module;
-  gomobile = super.gomobile.override {
+  gomobile = (super.gomobile.overrideAttrs (old: {
+    patches = self.pkgs.fetchurl { # https://github.com/golang/mobile/pull/84
+      url = "https://github.com/golang/mobile/commit/f20e966e05b8f7e06bed500fa0da81cf6ebca307.patch";
+      sha256 = "sha256-TZ/Yhe8gMRQUZFAs9G5/cf2b9QGtTHRSObBFD5Pbh7Y=";
+    };
+  })).override {
     # FIXME: No Android SDK packages for aarch64-darwin.
     withAndroidPkgs = stdenv.system != "aarch64-darwin";
     androidPkgs = self.androidEnvCustom.compose;


### PR DESCRIPTION
This resolves issues with weird `status-go` build errors like:
```
cgo: C compiler "2022-09-07" not found: exec: "2022-09-07": executable file not found in $PATH
```
Such errors are caused by `xcrun` spewing warnings to `stdout`. The PR to fix this issue permanently has been created but it might take a while before it's merged.

Fix PR: https://github.com/golang/mobile/pull/84
Resolves: https://github.com/status-im/status-mobile/issues/13949