### PR TITLE
Disable back button when migrating to a keycard 📱➡️ 💳.

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -279,6 +279,11 @@
   [{:keys [db]} k v]
   {:db (assoc db k v)})
 
+(fx/defn set-view-id
+  {:events [:set-view-id]}
+  [{:keys [db]} view-id]
+  {:db (assoc db :view-id view-id)})
+
 ;;TODO :replace by named events
 (fx/defn set-once-event
   {:events [:set-once]}

--- a/src/status_im/keycard/backup_key.cljs
+++ b/src/status_im/keycard/backup_key.cljs
@@ -4,6 +4,7 @@
             [status-im.utils.utils :as utils]
             [status-im.i18n.i18n :as i18n]
             [status-im.ethereum.mnemonic :as mnemonic]
+            [status-im.keycard.common :as common]
             [status-im.multiaccounts.recover.core :as multiaccounts.recover]
             [status-im.navigation :as navigation]
             [status-im.signing.core :as signing.core]
@@ -64,4 +65,5 @@
                       (assoc-in [:keycard :flow] :recovery)
                       (update :multiaccounts/key-storage dissoc :seed-phrase))
              :dismiss-keyboard nil}
+            (common/listen-to-hardware-back-button)
             (navigation/navigate-to-cofx :keycard-onboarding-intro nil)))

--- a/src/status_im/keycard/core.cljs
+++ b/src/status_im/keycard/core.cljs
@@ -592,19 +592,6 @@
   [{:keys [db]} listeners]
   {:db (update-in db [:keycard :listeners] merge listeners)})
 
-(defn onboarding-intro-back-handler
-  "The back button handler is used to manage device back press.
-
-  If the handler returns false, the back button functions as usual (ie. dispatchs GO_BACK event).
-  If it returns true, the back button becomes inactive.
-
-  We want to deactivate the back button when the user comes from key-storage and migration flow."
-  []
-  (-> @re-frame.db/app-db
-      :keycard
-      :from-key-storage-and-migration?
-      boolean))
-
 (fx/defn ui-recovery-phrase-cancel-pressed
   {:events [:keycard.ui/recovery-phrase-cancel-pressed]}
   [{:keys [db]}]

--- a/src/status_im/keycard/onboarding.cljs
+++ b/src/status_im/keycard/onboarding.cljs
@@ -175,7 +175,9 @@
               {:keycard/check-nfc-enabled nil}
               (if (= flow :import)
                 (navigation/navigate-to-cofx :keycard-recovery-intro nil)
-                (navigation/navigate-to-cofx :keycard-onboarding-intro nil)))))
+                (do
+                  (common/listen-to-hardware-back-button)
+                  (navigation/navigate-to-cofx :keycard-onboarding-intro nil))))))
 
 (fx/defn start-onboarding-flow
   {:events [:keycard/start-onboarding-flow]}
@@ -183,6 +185,7 @@
   (fx/merge cofx
             {:db                           (assoc-in db [:keycard :flow] :create)
              :keycard/check-nfc-enabled nil}
+            (common/listen-to-hardware-back-button)
             (navigation/navigate-to-cofx :keycard-onboarding-intro nil)))
 
 (fx/defn open-nfc-settings-pressed

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -86,6 +86,7 @@
   (fx/merge cofx
             {:db                           (assoc-in db [:keycard :flow] :recovery)
              :keycard/check-nfc-enabled nil}
+            (common/listen-to-hardware-back-button)
             (navigation/navigate-to-cofx :keycard-onboarding-intro nil)))
 
 (fx/defn cancel-pressed

--- a/src/status_im/multiaccounts/key_storage/core.cljs
+++ b/src/status_im/multiaccounts/key_storage/core.cljs
@@ -2,6 +2,7 @@
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
             [status-im.ethereum.mnemonic :as mnemonic]
+            [status-im.keycard.common :as common]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.multiaccounts.recover.core :as multiaccounts.recover]
             [status-im.multiaccounts.model :as multiaccounts.model]
@@ -244,6 +245,7 @@ We don't need to take the exact steps, just set the required state and redirect 
                       (assoc-in [:keycard :converting-account?] (not (get-in db [:multiaccounts/key-storage :reset-db-checked?])))
                       (dissoc :multiaccounts/key-storage))}
             (popover/hide-popover)
+            (common/listen-to-hardware-back-button)
             (navigation/navigate-to-cofx :keycard-onboarding-intro nil)))
 
 (fx/defn handle-delete-multiaccount-error

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -113,7 +113,7 @@
 (defn set-view-id [view-id]
   (log/debug "set-view-id" view-id)
   (when-let [{:keys [on-focus]} (get views/screens view-id)]
-    (re-frame/dispatch [:set :view-id view-id])
+    (re-frame/dispatch [:set-view-id view-id])
     (re-frame/dispatch [:screens/on-will-focus view-id])
     (when on-focus
       (re-frame/dispatch on-focus))))

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -3,7 +3,6 @@
             [quo.previews.main :as quo.preview]
             [status-im.add-new.core :as new-chat.events]
             [status-im.i18n.i18n :as i18n]
-            [status-im.keycard.core :as keycard.core]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.ui.screens.about-app.views :as about-app]
             [status-im.ui.screens.add-new.new-chat.views :as new-chat]
@@ -749,7 +748,10 @@
                                         ;KEYCARD
            {:name         :keycard-onboarding-intro
             :insets       {:bottom true}
-            :back-handler keycard.core/onboarding-intro-back-handler
+            :options      {:topBar             {:visible false}
+                           :popGesture         false
+                           :hardwareBackButton {:dismissModalOnPress false
+                                                :popStackOnPress     false}}
             :component    keycard.onboarding/intro}
            {:name      :keycard-onboarding-puk-code
             :insets    {:bottom true}


### PR DESCRIPTION
fixes #13943

### Summary
Disable the back button when migrating to keycard on android.

#### Platforms
- Android
- iOS

##### Functional
- account recovery
- new account

### Steps to test
- Open Status
- follow [these steps](https://github.com/status-im/status-mobile/issues/13943#:~:text=Keycard%20on%20Android-,STR%3A,-Install%20Status)
- see how it all works perfectly

status: ready