### PR TITLE
ci: add wait for GitHub release to appear

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.4'
+library 'status-jenkins-lib@v1.5.5'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
Because somtimes upload is attempted so fast release doesn't exist yet:
```
+ github-release upload -u status-im -r status-mobile -t 1.20.0 -n StatusIm-Mobile-v1.20.0-cbe19b-arm64-v8a.apk -f pkg/StatusIm-Mobile-v1.20.0-cbe19b-arm64-v8a.apk
error: could not find the release corresponding to tag 1.20.0
```
https://ci.infra.status.im/job/status-mobile/job/release/job/release%252F1.20.x/

Depends on: https://github.com/status-im/status-jenkins-lib/pull/49