### PR TITLE
Migrate to API 31 for android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <meta-data android:name="commitHash" android:value="${commitHash}"/>
         <activity
                 android:name=".MainActivity"
+                android:exported="true"
                 android:label="@string/app_name"
                 android:screenOrientation="portrait"
                 android:windowSoftInputMode="adjustResize"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -23,8 +23,8 @@
 # Version requirements used throughout the Gradle scripts
 kotlinVersion=1.3.50
 minSdkVersion=23
-compileSdkVersion=30
-targetSdkVersion=30
+compileSdkVersion=31
+targetSdkVersion=31
 buildToolsVersion=31.0.0
 supportLibVersion=28.0.0
 # This should match version from nix/mobile/android/maven-and-npm-deps/maven/default.nix

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/ForegroundService.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/ForegroundService.java
@@ -78,9 +78,10 @@ public class ForegroundService extends Service {
         
 
       
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE);
         Intent stopIntent = new Intent(PushNotificationHelper.ACTION_TAP_STOP);
-        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0, stopIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0, stopIntent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
 
         Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_stat_notify_status)

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationHelper.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationHelper.java
@@ -522,7 +522,7 @@ public class PushNotificationHelper {
                     actionIntent.setPackage(packageName);
 
                     PendingIntent pendingActionIntent = PendingIntent.getBroadcast(context, notificationID, actionIntent,
-                            PendingIntent.FLAG_UPDATE_CURRENT);
+                            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                       notification.addAction(new NotificationCompat.Action.Builder(icon, action, pendingActionIntent).build());
@@ -708,26 +708,30 @@ public class PushNotificationHelper {
         Intent intent = new Intent(ACTION_DELETE_NOTIFICATION);
         intent.putExtra("im.status.ethereum.deepLink", deepLink);
         intent.putExtra("im.status.ethereum.groupId", groupId);
-        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
     }
 
     private PendingIntent createGroupOnTapIntent(Context context, int notificationId, String groupId, String deepLink) {
         Intent intent = new Intent(ACTION_TAP_NOTIFICATION);
         intent.putExtra("im.status.ethereum.deepLink", deepLink);
         intent.putExtra("im.status.ethereum.groupId", groupId);
-        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
    }
 
     private PendingIntent createOnTapIntent(Context context, int notificationId, String deepLink) {
         Intent intent = new Intent(ACTION_TAP_NOTIFICATION);
         intent.putExtra("im.status.ethereum.deepLink", deepLink);
-        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
    }
 
     private PendingIntent createOnDismissedIntent(Context context, int notificationId, String deepLink) {
         Intent intent = new Intent(ACTION_DELETE_NOTIFICATION);
         intent.putExtra("im.status.ethereum.deepLink", deepLink);
-        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        return PendingIntent.getBroadcast(context.getApplicationContext(), notificationId, intent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
     }
 
     public void removeStatusMessage(Bundle bundle) {

--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -11,7 +11,7 @@ androidenv.composeAndroidPackages {
   toolsVersion = "26.1.1";
   platformToolsVersion = "33.0.1";
   buildToolsVersions = [ "31.0.0" ];
-  platformVersions = [ "30" ];
+  platformVersions = [ "31" ];
   cmakeVersions = [ "3.18.1" ];
   ndkVersion = "22.1.7171670";
   includeNDK = true;


### PR DESCRIPTION
fixes #13890

### Summary
Migrate to API 31 for android
Looking at [previous Android update](https://github.com/status-im/status-mobile/pull/12542)

- [x] update SDK declaration in Gradle and nix
- [x] add [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) tag to activities with intent filters declarations.
- [x] [Pending intents mutability](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability)
- [x] Test hibernation functionality

#### Platforms
- Android

### Steps to test
- Reinstall on Android
- Open Status
- Test everything. Especially things that require permissions.
- Test notifications
- Also try to put the app into hibernation and then start using it again
- Check if not crashing

status: ready