### PR TITLE
nix: drop KEYSTORE_PATH from extra-sandbox-paths

### DIFF
--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -45,9 +45,9 @@ if [[ -n "${OPENSEA_API_KEY}" ]]; then append_env_export 'OPENSEA_API_KEY'; fi
 
 # If no secrets were passed there's no need to pass the 'secretsFile'.
 if [[ -s "${SECRETS_FILE_PATH}" ]]; then
+  nixOpts+=("--option" "extra-sandbox-paths" "${SECRETS_FILE_PATH}")
   nixOpts+=("--argstr" "secretsFile" "${SECRETS_FILE_PATH}")
 fi
-nixOpts+=("--option" "extra-sandbox-paths" "${KEYSTORE_PATH} ${SECRETS_FILE_PATH}")
 
 # Used by Clojure at compile time to include JS modules
 nixOpts+=("--argstr" "buildEnv" "$(must_get_env BUILD_ENV)")


### PR DESCRIPTION
This is no longer necessary as we sign APKs in a separate step using the `scripts/sign-android.sh` script, and this causes issues for F-Droid builds.
```
error: getting attributes of path '/home/vagrant/.gradle/status-im.keystore': No such file or directory
```
https://gitlab.com/flexsurfer/fdroiddata/-/jobs/3053990084