### PR TITLE
nix: upgrade from 2.8.0 to 2.11.1

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.5.5'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.8' }
+  agent { label 'linux && x86_64 && nix-2.11' }
 
   options {
     timestamps()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.5.5'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'macos && x86_64 && nix-2.8 && xcode-13.4' }
+  agent { label 'macos && x86_64 && nix-2.11 && xcode-13.4' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.5.5'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.8' }
+  agent { label 'linux && x86_64 && nix-2.11' }
 
   options {
     timestamps()

--- a/nix/KNOWN_ISSUES.md
+++ b/nix/KNOWN_ISSUES.md
@@ -20,14 +20,10 @@ And use `sudo sysctl --system` to load these new settings.
 
 ### Multi-User Installation
 
-The other reason why this error could appear are limits fo `nix-daemon` service:
-https://github.com/NixOS/nix/issues/6007
+This has been fixed in Nix `2.9.0`:
 
-Since Systemd services ignore system-wide limits you will have to add the following line:
-```
-LimitNOFILE=4096:1048576
-```
-To the `/etc/systemd/system/nix-daemon.service` service definition.
+* https://github.com/NixOS/nix/issues/6007
+* https://github.com/NixOS/nix/pull/6553
 
 ## Cache Downloads Timing Out
 

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -6,9 +6,9 @@ GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
 
-NIX_VERSION="2.8.0"
+NIX_VERSION="2.11.1"
 NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-NIX_INSTALL_SHA256="f43bfedfca9151479462d8bc11f238615a2d52f19b14894d8e2b59980e75ef72"
+NIX_INSTALL_SHA256="4569a01dc5f62056f29f3195673bc3242fc70bf2474927fb5d8549c4d997402d"
 NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"
 
 install_nix() {


### PR DESCRIPTION
This also includes the fix for too low `LimitNOFILE`:

* https://github.com/NixOS/nix/pull/6553

Release: https://github.com/NixOS/nix/releases/tag/2.11.1
Infra change: https://github.com/status-im/infra-ci/commit/230c5d0e