### PR TITLE
Fix mentions on edited message

### DIFF
--- a/src/status_im/ui/screens/chat/components/input.cljs
+++ b/src/status_im/ui/screens/chat/components/input.cljs
@@ -218,11 +218,19 @@
   [{:keys [db] :as cofx} text chat-id]
   (let [text-with-mentions (mentions/->input-field text)
         contacts (:contacts db)
+        all-contacts (:contacts/contacts db)
+        chat (get-in db [:chats chat-id])
+        current-multiaccount (:multiaccount db)
+        mentionable-users (mentions/get-mentionable-users chat all-contacts current-multiaccount nil)
         hydrated-mentions (map (fn [[t mention :as e]]
                                  (if (= t :mention)
-                                   [:mention (str "@" (multiaccounts/displayed-name
-                                                       (or (get contacts mention)
-                                                           {:public-key mention})))]
+                                   (let [displayed-name (multiaccounts/displayed-name
+                                                         (or (get contacts mention)
+                                                             (get mentionable-users mention)
+                                                             {:public-key mention}))]
+                                     [:mention (if (string/starts-with? displayed-name "@")
+                                                 displayed-name
+                                                 (str "@" displayed-name))])
                                    e)) text-with-mentions)
         info (mentions/->info hydrated-mentions)]
     {:set-input-text [chat-id text]


### PR DESCRIPTION
fixes #14051

### Summary
Fixes edited messages mentions

#### Platforms
- Android
- iOS

##### Functional
- 1-1 chat
- public chats
- group chats
- account recovery
- new account
- user profile updates

### Steps to test
- Open Status
- Send messages that mention other users (with and without ENS usernames)
- Edit those messages
- See if edited messages with ENS name are displayed correctly
- Also check if anywhere username is mentioned is displayed correctly
- Have a nice day

status: ready