### PR TITLE
android: use projectDir for VERSION file path

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -159,7 +159,10 @@ def getVersionName = { ->
         if (project.hasProperty("releaseVersion")) {
             return project.releaseVersion
         }
-        version = new File('../VERSION').text
+        /* Necessary because Android Studio uses wrong PWD.
+         * Is actually absolute directory path of this file. */
+        def configDir = project.projectDir.toString() 
+        version = new File(configDir + '/../../VERSION').text
         return version.replaceAll("\\s","")
     }
 }


### PR DESCRIPTION
Otherwise Android Studio can't find the relative path because it uses `/` as it's working directory. Which makes no sense.