### PR TITLE
nix: refactor Gradle deps to be more generic

### DIFF
--- a/nix/deps/gradle/README.md
+++ b/nix/deps/gradle/README.md
@@ -24,6 +24,7 @@ Generating scripts:
 - `get_deps.sh` - Calls Gradle to get all the dependencies of sub-projects.
 - `gradle_parser.awk` - An AWK script that parses above Gradle output.
 - `url2json.sh` - Converts the list of URLs into a format consumable by Nix.
+- `add_package.sh` - Allows for adding a missing package manually.
 
 Finally we have the Nix derivation in `default.nix` which produces a derivation with all of the Gradle project dependencies:
 ```
@@ -66,9 +67,14 @@ You can use the `add_package.sh` script to add missing Gradle dependencies:
  > make shell TARGET=gradle
 Configuring Nix shell for target 'gradle'...
 
-[nix-shell:~/status-mobile]$ nix/deps/gradle/add_package.sh com.android.tools.build:gradle:3.4.0
+[nix-shell:~/work/status-mobile]$ nix/deps/gradle/add_package.sh com.android.tools.build:gradle:3.5.3
+Changes made:
+ nix/deps/gradle/deps.urls | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
 Regenerating Nix files...
-Found 548 direct dependencies...
-Successfully added: com.android.tools.build:gradle:3.4.0
+Successfully added: com.android.tools.build:gradle:3.5.3
+
+NOTICE: Running 'make nix-update-gradle' in a new shell is recommended.
 ```
-This may take a bit longer than normal `make nix-update-gradle` but should add the missing package.
+Keep in mind that the changes made by this script do not affect the already spawned shell.

--- a/nix/deps/gradle/add_package.sh
+++ b/nix/deps/gradle/add_package.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -Eeu
+# This script allows for adding a package by providing a Maven full name.
+# Such name consists of 3 sections separated by the colon character.
+# Example: com.android.tools.build:gradle:3.5.3
+
+set -Eeuo pipefail
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: add_package.sh <package>" >&2
@@ -18,12 +22,15 @@ source "${GIT_ROOT}/scripts/colors.sh"
 echo "${1}" | go-maven-resolver >> nix/deps/gradle/deps.urls
 
 # Remove duplicates and sort.
-sort -uo nix/deps/gradle/deps.urls nix/deps/gradle/deps.urls
+sort -uVo nix/deps/gradle/deps.urls nix/deps/gradle/deps.urls
+
+echo -e "${GRN}Changes made:${RST}" >&2
+git diff --stat nix/deps/gradle/deps.urls
+echo
 
 # Re-generate dependencies JSON.
 "${GIT_ROOT}/nix/deps/gradle/generate.sh" gen_deps_json
 
-# Re-generate dependencies list.
-"${GIT_ROOT}/nix/deps/gradle/generate.sh" gen_deps_list
-
 echo -e "${GRN}Successfully added:${RST} ${BLD}${1}${RST}" >&2
+echo
+echo -e "${YLW}NOTICE:${RST} Running '${BLD}make nix-update-gradle${RST}' in a new shell is recommended."

--- a/nix/deps/gradle/default.nix
+++ b/nix/deps/gradle/default.nix
@@ -1,82 +1,44 @@
 { stdenv, lib, pkgs, fetchurl, writeShellScriptBin }:
 
 let
-  inherit (lib)
-    removeSuffix optionalString splitString concatMapStrings
-    attrByPath attrValues last makeOverridable importJSON;
+  inherit (lib) concatStrings concatMapStrings mapAttrsToList makeOverridable;
 
-  inherit (pkgs) aapt2;
-
-  deps = importJSON ./deps.json;
-
-  # some .jar files have an `-aot` suffix that doesn't work for .pom files
-  getPOM = jarUrl: "${removeSuffix "-aot" jarUrl}.pom";
+  deps = lib.importJSON ./deps.json;
 
   script = writeShellScriptBin "create-local-maven-repo" (''
     mkdir -p $out
     cd $out
   '' +
-  # TODO: Generalize this section to not repeat the same code.
-  (concatMapStrings (dep: 
-    let
-      url = "${dep.host}/${dep.path}";
-      pom = {
-        sha1 = attrByPath [ "pom" "sha1" ] "" dep;
-        sha256 = attrByPath [ "pom" "sha256" ] "" dep;
-      };
-      pom-download = optionalString (pom.sha256 != "") (
-        fetchurl { url = getPOM url; inherit (pom) sha256; }
-      );
-      jar = {
-        sha1 = attrByPath [ "jar" "sha1" ] "" dep;
-        sha256 = attrByPath [ "jar" "sha256" ] "" dep;
-      };
-      jar-download = optionalString (jar.sha256 != "") (
-        fetchurl { url = "${url}.${dep.type}"; inherit (jar) sha256; }
-      );
-      nodeps = {
-        sha1 = attrByPath [ "nodeps" "sha1" ] "" dep;
-        sha256 = attrByPath [ "nodeps" "sha256" ] "" dep;
-      };
-      nodeps-download = optionalString (nodeps.sha256 != "") (
-        fetchurl { url = "${url}-nodeps.jar"; inherit (nodeps) sha256; }
-      );
-      fileName = last (splitString "/" dep.path);
-      directory = removeSuffix fileName dep.path;
-    in
-      ''
-        mkdir -p ${directory}
-
-        ${optionalString (pom-download != "") ''
-        ln -s "${pom-download}" "${getPOM dep.path}"
-        ''}
-        ${optionalString (pom.sha1 != "") ''
-        echo "${pom.sha1}" > "${getPOM dep.path}.sha1"
-        ''}
-        ${optionalString (jar-download != "") ''
-        ln -s "${jar-download}" "${dep.path}.${dep.type}"
-        ''}
-        ${optionalString (jar.sha1 != "") ''
-        echo "${jar.sha1}" > "${dep.path}.${dep.type}.sha1"
-        ''}
-        ${optionalString (nodeps-download != "") ''
-        ln -s "${nodeps-download}" "${dep.path}-nodeps.jar"
-        ''}
-        ${optionalString (nodeps.sha1 != "") ''
-        echo "${nodeps.sha1}" > "${dep.path}.${dep.type}.sha1"
-        ''}
+    # For each dependency in deps.json.
+    (concatMapStrings (dep: concatStrings
+      # And for each file in the 'files' dict of given dependency.
+      (mapAttrsToList (filename: hashes: let
+        # Download given file(POM, JAR, nodeps JAR, or AAR).
+        download = fetchurl {
+          url = "${dep.repo}/${dep.path}/${filename}";
+          inherit (hashes) sha256;
+        };
+        # And symlink it in the correct folder along with SHA1.
+      in ''
+        mkdir -p "${dep.path}"
+        ln -s "${download}" "${dep.path}/${filename}"
+        echo "${hashes.sha1}" > "${dep.path}/${filename}.sha1"
       '')
-    deps));
+      dep.files)
+    ) deps)
+  );
 
 in makeOverridable stdenv.mkDerivation {
   name = "status-mobile-maven-deps";
-  buildInputs = [ aapt2 ];
+
+  buildInputs = [ pkgs.aapt2 ];
+
   phases = [ "buildPhase" "patchPhase" ];
   buildPhase = "${script}/bin/create-local-maven-repo";
-  # Patched AAPT2 
+  # Replace AAPT2 package only with our patched version from overlay.
   patchPhase = ''
-    aapt2_dir=$out/com/android/tools/build/aapt2/${aapt2.version}
+    aapt2_dir=$out/com/android/tools/build/aapt2/${pkgs.aapt2.version}
     mkdir -p $aapt2_dir
-    ln -sf ${aapt2}/* $aapt2_dir
+    ln -sf ${pkgs.aapt2}/* $aapt2_dir
   '';
 }

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -1,10795 +1,11606 @@
 [
   {
-    "path": "androidx/activity/activity/1.0.0/activity-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f94af7350c14b899596aefd6c50e381a96d933ba",
-      "sha256": "10lv8v4dg1jfvmhznia10wsgqxi0inbs0cdql0nk3732c9sbx917"
-    },
-    "jar": {
-      "sha1": "ed7a64df6e3fbebf7d3d3dfc30b0f47efcc707f7",
-      "sha256": "0gacyh2zf933lcdkl2drim3knhaj9pgl936q2m256bjw8m19ig6i"
+    "path": "androidx/activity/activity/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "activity-1.0.0.pom": {
+        "sha1": "f94af7350c14b899596aefd6c50e381a96d933ba",
+        "sha256": "10lv8v4dg1jfvmhznia10wsgqxi0inbs0cdql0nk3732c9sbx917"
+      },
+      "activity-1.0.0.aar": {
+        "sha1": "ed7a64df6e3fbebf7d3d3dfc30b0f47efcc707f7",
+        "sha256": "0gacyh2zf933lcdkl2drim3knhaj9pgl936q2m256bjw8m19ig6i"
+      }
     }
   },
-
-  {
-    "path": "androidx/activity/activity/1.2.4/activity-1.2.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c14da44e34d4fb2dba4ad4099e1b6e7b84ff6ad6",
-      "sha256": "0rplagy7nzfim0rcvszkgbdhjxq8jsh2lklcyfdf5rnrffcds94h"
-    },
-    "jar": {
-      "sha1": "bebd083d1486ed7f033b2dcc06e7cdefede4445f",
-      "sha256": "06pq5lfnsl5kzp61sk039yyh5mfzlnjz6wqfv4m7sf3ywmyrr3mf"
+
+  {
+    "path": "androidx/activity/activity/1.2.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "activity-1.2.4.pom": {
+        "sha1": "c14da44e34d4fb2dba4ad4099e1b6e7b84ff6ad6",
+        "sha256": "0rplagy7nzfim0rcvszkgbdhjxq8jsh2lklcyfdf5rnrffcds94h"
+      },
+      "activity-1.2.4.aar": {
+        "sha1": "bebd083d1486ed7f033b2dcc06e7cdefede4445f",
+        "sha256": "06pq5lfnsl5kzp61sk039yyh5mfzlnjz6wqfv4m7sf3ywmyrr3mf"
+      }
     }
   },
 
-  {
-    "path": "androidx/annotation/annotation-experimental/1.0.0/annotation-experimental-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "ebc8cc79af3841ffa6a44ab02f31df2973c9b916",
-      "sha256": "0ckp9nqa313gs6qfdx0wj0whnb9qi9q6a2v2mg5xdcgl11kgywvb"
-    },
-    "jar": {
-      "sha1": "fe9ba8247a591ebf8e16f0cf80af7a2045c981e0",
-      "sha256": "048bdc778pbghhwfkfyzrdndyhr34kyw5y099r9vmr77d2sx46dj"
+  {
+    "path": "androidx/annotation/annotation-experimental/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-experimental-1.0.0.pom": {
+        "sha1": "ebc8cc79af3841ffa6a44ab02f31df2973c9b916",
+        "sha256": "0ckp9nqa313gs6qfdx0wj0whnb9qi9q6a2v2mg5xdcgl11kgywvb"
+      },
+      "annotation-experimental-1.0.0.aar": {
+        "sha1": "fe9ba8247a591ebf8e16f0cf80af7a2045c981e0",
+        "sha256": "048bdc778pbghhwfkfyzrdndyhr34kyw5y099r9vmr77d2sx46dj"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation-experimental/1.1.0/annotation-experimental-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "390754e0425d3b182589223fcf7c4c02113dc1ca",
-      "sha256": "1agpirb26v5bnrcdvraiggqwxsgbs4awrihwa2cwyixgw40nc2jm"
-    },
-    "jar": {
-      "sha1": "5481c9aca18271c977d67b30e26f484f3f8f1c02",
-      "sha256": "141z7qj60ding8zpp1clkanmgfk7zprq1005da4lfh06l9hxwmq1"
+    "path": "androidx/annotation/annotation-experimental/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-experimental-1.1.0.pom": {
+        "sha1": "390754e0425d3b182589223fcf7c4c02113dc1ca",
+        "sha256": "1agpirb26v5bnrcdvraiggqwxsgbs4awrihwa2cwyixgw40nc2jm"
+      },
+      "annotation-experimental-1.1.0.aar": {
+        "sha1": "5481c9aca18271c977d67b30e26f484f3f8f1c02",
+        "sha256": "141z7qj60ding8zpp1clkanmgfk7zprq1005da4lfh06l9hxwmq1"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation/1.0.0/annotation-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1ec1fd6918db230c4b2e8ffa78f724267fb6328c",
-      "sha256": "1d75s454jy1b88fra6s0wm5m15ml3n0z8qyvr400771xnhnw2yd1"
-    },
-    "jar": {
-      "sha1": "45599f2cd5965ac05a1488fa2a5c0cdd7c499ead",
-      "sha256": "05n0yygdjlvvkb67vlfisiasz4xsj55k416dh2m55bvwbxsykahb"
+    "path": "androidx/annotation/annotation/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-1.0.0.pom": {
+        "sha1": "1ec1fd6918db230c4b2e8ffa78f724267fb6328c",
+        "sha256": "1d75s454jy1b88fra6s0wm5m15ml3n0z8qyvr400771xnhnw2yd1"
+      },
+      "annotation-1.0.0.jar": {
+        "sha1": "45599f2cd5965ac05a1488fa2a5c0cdd7c499ead",
+        "sha256": "05n0yygdjlvvkb67vlfisiasz4xsj55k416dh2m55bvwbxsykahb"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation/1.0.1/annotation-1.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "08f7df7cd012aeb0458703f5698237d122599384",
-      "sha256": "0hklma0mzh9lmzlsfsd6r8b1r4l4nx3scp7zj9ws90j2h3wj77f8"
-    },
-    "jar": {
-      "sha1": "2dfd8f6b2a8fc466a1ae4e329fb79cd580f6393f",
-      "sha256": "1akc0bw3fsr2yjmr888s1pfc2ghj9nbmx8dm7kssm63hwl5z91hg"
+    "path": "androidx/annotation/annotation/1.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-1.0.1.pom": {
+        "sha1": "08f7df7cd012aeb0458703f5698237d122599384",
+        "sha256": "0hklma0mzh9lmzlsfsd6r8b1r4l4nx3scp7zj9ws90j2h3wj77f8"
+      },
+      "annotation-1.0.1.jar": {
+        "sha1": "2dfd8f6b2a8fc466a1ae4e329fb79cd580f6393f",
+        "sha256": "1akc0bw3fsr2yjmr888s1pfc2ghj9nbmx8dm7kssm63hwl5z91hg"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation/1.0.2/annotation-1.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f1dc2b36a23233b355a06839d55d7b4f0765b724",
-      "sha256": "1yb6b3fxhir79j07q3bfcwi8ib87b23asphqg88qwn2sj94qb1jw"
-    },
-    "jar": {
-      "sha1": "02f1d597d48e5309e935ce1212eedf5ae69d3f97",
-      "sha256": "1wk36710ax5blmq6m8s2blrxy1aqvd8mzpjigfw1s4h3a36g9kcv"
+    "path": "androidx/annotation/annotation/1.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-1.0.2.pom": {
+        "sha1": "f1dc2b36a23233b355a06839d55d7b4f0765b724",
+        "sha256": "1yb6b3fxhir79j07q3bfcwi8ib87b23asphqg88qwn2sj94qb1jw"
+      },
+      "annotation-1.0.2.jar": {
+        "sha1": "02f1d597d48e5309e935ce1212eedf5ae69d3f97",
+        "sha256": "1wk36710ax5blmq6m8s2blrxy1aqvd8mzpjigfw1s4h3a36g9kcv"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation/1.1.0/annotation-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "404526f88e3a7efa04f1c99074dfc10aff9061ee",
-      "sha256": "1zlyg49llmpnhmhr4z17wp0q51phw5k6py6v5aal9vw0fyx754rf"
-    },
-    "jar": {
-      "sha1": "e3a6fb2f40e3a3842e6b7472628ba4ce416ea4c8",
-      "sha256": "14mnsnd1a6wrzadh8air665ylbb9i9gz1ajhin0nf50gngnn73fk"
+    "path": "androidx/annotation/annotation/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-1.1.0.pom": {
+        "sha1": "404526f88e3a7efa04f1c99074dfc10aff9061ee",
+        "sha256": "1zlyg49llmpnhmhr4z17wp0q51phw5k6py6v5aal9vw0fyx754rf"
+      },
+      "annotation-1.1.0.jar": {
+        "sha1": "e3a6fb2f40e3a3842e6b7472628ba4ce416ea4c8",
+        "sha256": "14mnsnd1a6wrzadh8air665ylbb9i9gz1ajhin0nf50gngnn73fk"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation/1.2.0/annotation-1.2.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b1d9e8a4bbffcb85580a101f2032d68a9f426606",
-      "sha256": "10q3rjcn81jldydcj8gwyyfn244isrrbimkpf27f1vvp4z56vyv2"
-    },
-    "jar": {
-      "sha1": "57136ff68ee784c6e19db34ed4a175338fadfde1",
-      "sha256": "0dha965ykmsp7dmvg1wh4d6g48dszm59wjdy09nnw4ffvlmjcach"
+    "path": "androidx/annotation/annotation/1.2.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-1.2.0.pom": {
+        "sha1": "b1d9e8a4bbffcb85580a101f2032d68a9f426606",
+        "sha256": "10q3rjcn81jldydcj8gwyyfn244isrrbimkpf27f1vvp4z56vyv2"
+      },
+      "annotation-1.2.0.jar": {
+        "sha1": "57136ff68ee784c6e19db34ed4a175338fadfde1",
+        "sha256": "0dha965ykmsp7dmvg1wh4d6g48dszm59wjdy09nnw4ffvlmjcach"
+      }
     }
   },
 
   {
-    "path": "androidx/annotation/annotation/1.3.0/annotation-1.3.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8e41994f7c27b40c14f53bf3fa40c84d5d00b13d",
-      "sha256": "1c7vbr32dpv70xk92p10mj082ddgxb291p7w562vqjva4p2ig584"
-    },
-    "jar": {
-      "sha1": "021f49f5f9b85fc49de712539f79123119740595",
-      "sha256": "0lw5xq2qlpis7qh7hqgw8my4g484z7lvdf22v8hy98g3xyplbp4p"
+    "path": "androidx/annotation/annotation/1.3.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotation-1.3.0.pom": {
+        "sha1": "8e41994f7c27b40c14f53bf3fa40c84d5d00b13d",
+        "sha256": "1c7vbr32dpv70xk92p10mj082ddgxb291p7w562vqjva4p2ig584"
+      },
+      "annotation-1.3.0.jar": {
+        "sha1": "021f49f5f9b85fc49de712539f79123119740595",
+        "sha256": "0lw5xq2qlpis7qh7hqgw8my4g484z7lvdf22v8hy98g3xyplbp4p"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat-resources/1.1.0/appcompat-resources-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "04d25219b17a53da24285e9560bbf5c587abee38",
-      "sha256": "1wlhjv2g94w40vczb0vl8avg23hia4ancr95hha6y6xhdkhi2q04"
-    },
-    "jar": {
-      "sha1": "a573b2ab146d686244721ef1038d08043f18c67f",
-      "sha256": "0qbk5wi4yd4l4w4f5jdgm9xvszw3jm5qj8by6iya2lb5nhr4v50r"
+    "path": "androidx/appcompat/appcompat-resources/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-resources-1.1.0.pom": {
+        "sha1": "04d25219b17a53da24285e9560bbf5c587abee38",
+        "sha256": "1wlhjv2g94w40vczb0vl8avg23hia4ancr95hha6y6xhdkhi2q04"
+      },
+      "appcompat-resources-1.1.0.aar": {
+        "sha1": "a573b2ab146d686244721ef1038d08043f18c67f",
+        "sha256": "0qbk5wi4yd4l4w4f5jdgm9xvszw3jm5qj8by6iya2lb5nhr4v50r"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat-resources/1.2.0/appcompat-resources-1.2.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "2211657bde99e604557ac3cd44464d390c4c26f1",
-      "sha256": "1y60r75vl26h02cd54w7lrp1baz2l5mkjv78zn7yyjv6qg7di78l"
-    },
-    "jar": {
-      "sha1": "ad67e51b92364585bb335177664959001644327a",
-      "sha256": "1r8g22ixla5f0zfj3w2j1g0snqxf1jzg1b2xs71y2ggz0dy2jw64"
+    "path": "androidx/appcompat/appcompat-resources/1.2.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-resources-1.2.0.pom": {
+        "sha1": "2211657bde99e604557ac3cd44464d390c4c26f1",
+        "sha256": "1y60r75vl26h02cd54w7lrp1baz2l5mkjv78zn7yyjv6qg7di78l"
+      },
+      "appcompat-resources-1.2.0.aar": {
+        "sha1": "ad67e51b92364585bb335177664959001644327a",
+        "sha256": "1r8g22ixla5f0zfj3w2j1g0snqxf1jzg1b2xs71y2ggz0dy2jw64"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat-resources/1.3.1/appcompat-resources-1.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "fbf12448e003ff14e3aad1a2c9fd3c84af05cb1e",
-      "sha256": "0g8z7kanrddsv6crwbi3hkscihd0k70b61a1xqacjqp0mncirysq"
-    },
-    "jar": {
-      "sha1": "32ad26fa0a18f5df7c7bff16aeaa1ecfef593877",
-      "sha256": "0x8ai68r5gh4aiwksp61h56pq8qgb1wv7hsyvsjji6m1x79nqc73"
+    "path": "androidx/appcompat/appcompat-resources/1.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-resources-1.3.1.pom": {
+        "sha1": "fbf12448e003ff14e3aad1a2c9fd3c84af05cb1e",
+        "sha256": "0g8z7kanrddsv6crwbi3hkscihd0k70b61a1xqacjqp0mncirysq"
+      },
+      "appcompat-resources-1.3.1.aar": {
+        "sha1": "32ad26fa0a18f5df7c7bff16aeaa1ecfef593877",
+        "sha256": "0x8ai68r5gh4aiwksp61h56pq8qgb1wv7hsyvsjji6m1x79nqc73"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat/1.0.0/appcompat-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5ce716d352f95b3c0ea0ecf9f579691c1a79410f",
-      "sha256": "0asdria39qs9hf18wwpm11pp2bqvwzci9pr75lpb4ch8p36kyb10"
-    },
-    "jar": {
-      "sha1": "155b5a7193b5b87c3ece2ec444c85cd8de2347dd",
-      "sha256": "1kjndp9mip46205znb028ngi7vrvpkca8698dcrd7jrn43hm8hlr"
+    "path": "androidx/appcompat/appcompat/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-1.0.0.pom": {
+        "sha1": "5ce716d352f95b3c0ea0ecf9f579691c1a79410f",
+        "sha256": "0asdria39qs9hf18wwpm11pp2bqvwzci9pr75lpb4ch8p36kyb10"
+      },
+      "appcompat-1.0.0.aar": {
+        "sha1": "155b5a7193b5b87c3ece2ec444c85cd8de2347dd",
+        "sha256": "1kjndp9mip46205znb028ngi7vrvpkca8698dcrd7jrn43hm8hlr"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat/1.0.2/appcompat-1.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c9d71a88fea7f0af4bf936ec095161ebc5a57f12",
-      "sha256": "0bw5zydwk5nr55q97x653rfinwl6fvqd32dbvzs11xw9s9bv14g3"
-    },
-    "jar": {
-      "sha1": "002533a36c928bb27a3cc6843a25f83754b3c3ae",
-      "sha256": "00qdpzv9ajq8dvvyvkqiq8g03023gmjv2a6lz5rcnmjwbvfhq253"
+    "path": "androidx/appcompat/appcompat/1.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-1.0.2.pom": {
+        "sha1": "c9d71a88fea7f0af4bf936ec095161ebc5a57f12",
+        "sha256": "0bw5zydwk5nr55q97x653rfinwl6fvqd32dbvzs11xw9s9bv14g3"
+      },
+      "appcompat-1.0.2.aar": {
+        "sha1": "002533a36c928bb27a3cc6843a25f83754b3c3ae",
+        "sha256": "00qdpzv9ajq8dvvyvkqiq8g03023gmjv2a6lz5rcnmjwbvfhq253"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat/1.1.0/appcompat-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "83765254bf5e6aa04bb1f35960db460afd70b048",
-      "sha256": "1fdp5i5ri67xnvf1r2hcdlkl5rd3g8sqy338lq18xvzq45qn239l"
-    },
-    "jar": {
-      "sha1": "351d3409fe51f3d862bd2b1bcc0f3b6ded29460e",
-      "sha256": "1h5m5ajd7b66dilfh8z2zs0zqnglrdm7d5amgzqvvcscljy9jwld"
+    "path": "androidx/appcompat/appcompat/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-1.1.0.pom": {
+        "sha1": "83765254bf5e6aa04bb1f35960db460afd70b048",
+        "sha256": "1fdp5i5ri67xnvf1r2hcdlkl5rd3g8sqy338lq18xvzq45qn239l"
+      },
+      "appcompat-1.1.0.aar": {
+        "sha1": "351d3409fe51f3d862bd2b1bcc0f3b6ded29460e",
+        "sha256": "1h5m5ajd7b66dilfh8z2zs0zqnglrdm7d5amgzqvvcscljy9jwld"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat/1.2.0/appcompat-1.2.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c599cadd6e3ef8d628737532dcb341704b3a4261",
-      "sha256": "0hmv5vpzskw4zl99f9nxaggdnfdaq79f6ihn90xqa2dn4glcpcwf"
-    },
-    "jar": {
-      "sha1": "6487c8711252a8680baaa854247141cc1d2098f4",
-      "sha256": "0w6a1h11c6v5xd9l3d2kkqrsdvqih00y09i15qr7g9v1bajk289x"
+    "path": "androidx/appcompat/appcompat/1.2.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-1.2.0.pom": {
+        "sha1": "c599cadd6e3ef8d628737532dcb341704b3a4261",
+        "sha256": "0hmv5vpzskw4zl99f9nxaggdnfdaq79f6ihn90xqa2dn4glcpcwf"
+      },
+      "appcompat-1.2.0.aar": {
+        "sha1": "6487c8711252a8680baaa854247141cc1d2098f4",
+        "sha256": "0w6a1h11c6v5xd9l3d2kkqrsdvqih00y09i15qr7g9v1bajk289x"
+      }
     }
   },
 
   {
-    "path": "androidx/appcompat/appcompat/1.3.1/appcompat-1.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "080c26399978d9c495e3b29e81b85d91683b10a2",
-      "sha256": "03vs2jgpil5acaardv0mg3idaydpdlrhbi48zdh1va7g2lvwmg98"
-    },
-    "jar": {
-      "sha1": "b9bc6aeb85e9bd2bc7ce829960b07d47eda7a1a9",
-      "sha256": "00qkjz18dyl4lbmq6q3a5vamzg121drrfbq2s7pfgma0zsp1v6wm"
+    "path": "androidx/appcompat/appcompat/1.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-1.3.1.pom": {
+        "sha1": "080c26399978d9c495e3b29e81b85d91683b10a2",
+        "sha256": "03vs2jgpil5acaardv0mg3idaydpdlrhbi48zdh1va7g2lvwmg98"
+      },
+      "appcompat-1.3.1.aar": {
+        "sha1": "b9bc6aeb85e9bd2bc7ce829960b07d47eda7a1a9",
+        "sha256": "00qkjz18dyl4lbmq6q3a5vamzg121drrfbq2s7pfgma0zsp1v6wm"
+      }
     }
   },
 
   {
-    "path": "androidx/arch/core/core-common/2.0.0/core-common-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f99012a3ab10fd604a8631aaa8d525aa44df5da5",
-      "sha256": "08226chqfsadvgk08yg4bnf67hmqdvl4cvgdhm76n56xkm2isvsb"
-    },
-    "jar": {
-      "sha1": "bb21b9a11761451b51624ac428d1f1bb5deeac38",
-      "sha256": "1n3sqpd398a23jdqwpql9ls0if23vzhaj37fn1j6wllvfwvv702b"
+    "path": "androidx/arch/core/core-common/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-common-2.0.0.pom": {
+        "sha1": "f99012a3ab10fd604a8631aaa8d525aa44df5da5",
+        "sha256": "08226chqfsadvgk08yg4bnf67hmqdvl4cvgdhm76n56xkm2isvsb"
+      },
+      "core-common-2.0.0.jar": {
+        "sha1": "bb21b9a11761451b51624ac428d1f1bb5deeac38",
+        "sha256": "1n3sqpd398a23jdqwpql9ls0if23vzhaj37fn1j6wllvfwvv702b"
+      }
     }
   },
 
   {
-    "path": "androidx/arch/core/core-common/2.0.1/core-common-2.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8ebce13650b574c9e486fba87f1f948edd41949f",
-      "sha256": "0d9rv7d94jjkhf2hra5clwq3a2571l68vs5lngi9jz1cxj2xgs15"
-    },
-    "jar": {
-      "sha1": "3e8d84e4fe526be0ca1832a518bf323e729a79fd",
-      "sha256": "1j4p3y03dl0waph6yqq5q7ybsr7v0yc4wy2i2pxjmswrp226lcg7"
+    "path": "androidx/arch/core/core-common/2.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-common-2.0.1.pom": {
+        "sha1": "8ebce13650b574c9e486fba87f1f948edd41949f",
+        "sha256": "0d9rv7d94jjkhf2hra5clwq3a2571l68vs5lngi9jz1cxj2xgs15"
+      },
+      "core-common-2.0.1.jar": {
+        "sha1": "3e8d84e4fe526be0ca1832a518bf323e729a79fd",
+        "sha256": "1j4p3y03dl0waph6yqq5q7ybsr7v0yc4wy2i2pxjmswrp226lcg7"
+      }
     }
   },
 
   {
-    "path": "androidx/arch/core/core-common/2.1.0/core-common-2.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2b3b788454b0aa77266f2ce191eba3a7768678ca",
-      "sha256": "00fgwnngz2qbicwajshx599l3r0ljjslrjb6qc561g5a1sbb7fw3"
-    },
-    "jar": {
-      "sha1": "b3152fc64428c9354344bd89848ecddc09b6f07e",
-      "sha256": "129qclk47ifk57y8d135lfqchx7gffpswfgy55zkw1lx0azkf4py"
+    "path": "androidx/arch/core/core-common/2.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-common-2.1.0.pom": {
+        "sha1": "2b3b788454b0aa77266f2ce191eba3a7768678ca",
+        "sha256": "00fgwnngz2qbicwajshx599l3r0ljjslrjb6qc561g5a1sbb7fw3"
+      },
+      "core-common-2.1.0.jar": {
+        "sha1": "b3152fc64428c9354344bd89848ecddc09b6f07e",
+        "sha256": "129qclk47ifk57y8d135lfqchx7gffpswfgy55zkw1lx0azkf4py"
+      }
     }
   },
 
   {
-    "path": "androidx/arch/core/core-runtime/2.0.0/core-runtime-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "d3572f4d27cca318471a0005ce6c93740ad5e9cb",
-      "sha256": "04a44v91hyxbd9lmkfi6549027m4qlfmqyzdgyky57n6vm0ps072"
-    },
-    "jar": {
-      "sha1": "c5be9edf9ca9135a465d23939f6e7d0e1cf90b41",
-      "sha256": "13jzyv9kwnqjsh0yb0pgvbbbxd7b64jfwz4wchvv84n7cz3mzrl7"
+    "path": "androidx/arch/core/core-runtime/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-runtime-2.0.0.pom": {
+        "sha1": "d3572f4d27cca318471a0005ce6c93740ad5e9cb",
+        "sha256": "04a44v91hyxbd9lmkfi6549027m4qlfmqyzdgyky57n6vm0ps072"
+      },
+      "core-runtime-2.0.0.aar": {
+        "sha1": "c5be9edf9ca9135a465d23939f6e7d0e1cf90b41",
+        "sha256": "13jzyv9kwnqjsh0yb0pgvbbbxd7b64jfwz4wchvv84n7cz3mzrl7"
+      }
     }
   },
 
   {
-    "path": "androidx/arch/core/core-runtime/2.1.0/core-runtime-2.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "a86136badfffa9d668106a80ff4cda9ee9c1cc1b",
-      "sha256": "0pf0b1ljzrnl8w4jqsvw69rw35xnjaryhp81j21s2b6dc00yvi60"
-    },
-    "jar": {
-      "sha1": "2df0e03029caae7863ccb4825addaadc8ab6780c",
-      "sha256": "0ljqfpwcpga5mx1pklvw2550pca6mrdz4bdn27xml9yxsddn2xyx"
+    "path": "androidx/arch/core/core-runtime/2.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-runtime-2.1.0.pom": {
+        "sha1": "a86136badfffa9d668106a80ff4cda9ee9c1cc1b",
+        "sha256": "0pf0b1ljzrnl8w4jqsvw69rw35xnjaryhp81j21s2b6dc00yvi60"
+      },
+      "core-runtime-2.1.0.aar": {
+        "sha1": "2df0e03029caae7863ccb4825addaadc8ab6780c",
+        "sha256": "0ljqfpwcpga5mx1pklvw2550pca6mrdz4bdn27xml9yxsddn2xyx"
+      }
     }
   },
 
   {
-    "path": "androidx/asynclayoutinflater/asynclayoutinflater/1.0.0/asynclayoutinflater-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "fddbfd83af5c2af0884a3a36a91ad8113d7bd3a4",
-      "sha256": "0w9gk3l0i3zjngpsdw81mvfgxn5mv460vbyy556rr9wdvkp7w5j8"
-    },
-    "jar": {
-      "sha1": "5ffa788d19a6863799f25cb50d4fdfb0ec649037",
-      "sha256": "12vcz7x5c693gicyr8g1mbm1nq80fvz34n170sxr9pddaw6bdspp"
+    "path": "androidx/asynclayoutinflater/asynclayoutinflater/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "asynclayoutinflater-1.0.0.pom": {
+        "sha1": "fddbfd83af5c2af0884a3a36a91ad8113d7bd3a4",
+        "sha256": "0w9gk3l0i3zjngpsdw81mvfgxn5mv460vbyy556rr9wdvkp7w5j8"
+      },
+      "asynclayoutinflater-1.0.0.aar": {
+        "sha1": "5ffa788d19a6863799f25cb50d4fdfb0ec649037",
+        "sha256": "12vcz7x5c693gicyr8g1mbm1nq80fvz34n170sxr9pddaw6bdspp"
+      }
     }
   },
 
   {
-    "path": "androidx/cardview/cardview/1.0.0/cardview-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "93a261514381247a8a6bebe171338f9f2f883f27",
-      "sha256": "0v1y3h373chacgpbwi662jq3s58v1bl6z7jrggi8ydaqighg8kp6"
-    },
-    "jar": {
-      "sha1": "158dbc2e2bc502815821191b04446b8f663c1874",
-      "sha256": "1izy3bd2vn4rzf3mvgdnf5mdxbfnb664x7xfdnabbmm3496c14qi"
+    "path": "androidx/cardview/cardview/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "cardview-1.0.0.pom": {
+        "sha1": "93a261514381247a8a6bebe171338f9f2f883f27",
+        "sha256": "0v1y3h373chacgpbwi662jq3s58v1bl6z7jrggi8ydaqighg8kp6"
+      },
+      "cardview-1.0.0.aar": {
+        "sha1": "158dbc2e2bc502815821191b04446b8f663c1874",
+        "sha256": "1izy3bd2vn4rzf3mvgdnf5mdxbfnb664x7xfdnabbmm3496c14qi"
+      }
     }
   },
 
   {
-    "path": "androidx/collection/collection/1.0.0/collection-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6b6d5f96527a79bce10e9e9e8c4704f661b2cdc8",
-      "sha256": "1vsl1q19jj56f8c8m92cw59v2ry32j6bwbk1s9ayas5dfm93m4d7"
-    },
-    "jar": {
-      "sha1": "42858b26cafdaa69b6149f45dfc2894007bc2c7a",
-      "sha256": "1yf979z85xq8lxr06mqkc31icns9bgh5gf7yrnhj1h9bbixi33cw"
+    "path": "androidx/collection/collection/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "collection-1.0.0.pom": {
+        "sha1": "6b6d5f96527a79bce10e9e9e8c4704f661b2cdc8",
+        "sha256": "1vsl1q19jj56f8c8m92cw59v2ry32j6bwbk1s9ayas5dfm93m4d7"
+      },
+      "collection-1.0.0.jar": {
+        "sha1": "42858b26cafdaa69b6149f45dfc2894007bc2c7a",
+        "sha256": "1yf979z85xq8lxr06mqkc31icns9bgh5gf7yrnhj1h9bbixi33cw"
+      }
     }
   },
 
   {
-    "path": "androidx/collection/collection/1.1.0/collection-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e1eba7bcd8a98744b7850e5c474edebaafba6fbb",
-      "sha256": "1lan6jd3r0g1n5q4z3hizxbq0fd03g1r70jhrkiwdzdclin0dsb7"
-    },
-    "jar": {
-      "sha1": "1f27220b47669781457de0d600849a5de0e89909",
-      "sha256": "0wivsgvxlxqcha3sf1s2f8vi0a9a54798llk81sff7a60xa0wak3"
+    "path": "androidx/collection/collection/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "collection-1.1.0.pom": {
+        "sha1": "e1eba7bcd8a98744b7850e5c474edebaafba6fbb",
+        "sha256": "1lan6jd3r0g1n5q4z3hizxbq0fd03g1r70jhrkiwdzdclin0dsb7"
+      },
+      "collection-1.1.0.jar": {
+        "sha1": "1f27220b47669781457de0d600849a5de0e89909",
+        "sha256": "0wivsgvxlxqcha3sf1s2f8vi0a9a54798llk81sff7a60xa0wak3"
+      }
     }
   },
 
   {
-    "path": "androidx/constraintlayout/constraintlayout-solver/2.0.4/constraintlayout-solver-2.0.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ce642efe9f0d3ebbd1a43630140b3a85029dac20",
-      "sha256": "15qwbdfmv93qipq04fllpdjgalcn9x9i43z5756f36xg0sqz8cvz"
-    },
-    "jar": {
-      "sha1": "1f001d7db280a89a6c26b26a66eb064bb6d5efeb",
-      "sha256": "0ikvaa1kw4djb6hag32khdfabpz93fafz21lav3h34vh91a9z8cw"
+    "path": "androidx/constraintlayout/constraintlayout-solver/2.0.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "constraintlayout-solver-2.0.4.pom": {
+        "sha1": "ce642efe9f0d3ebbd1a43630140b3a85029dac20",
+        "sha256": "15qwbdfmv93qipq04fllpdjgalcn9x9i43z5756f36xg0sqz8cvz"
+      },
+      "constraintlayout-solver-2.0.4.jar": {
+        "sha1": "1f001d7db280a89a6c26b26a66eb064bb6d5efeb",
+        "sha256": "0ikvaa1kw4djb6hag32khdfabpz93fafz21lav3h34vh91a9z8cw"
+      }
     }
   },
 
   {
-    "path": "androidx/constraintlayout/constraintlayout/2.0.4/constraintlayout-2.0.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5a6761d954eaef83dafd69eddd77df09e59bcd8d",
-      "sha256": "15za4cgzjcf3axghmnd1r6hbcqijx4ps9pr34p41m15436pdnxvi"
-    },
-    "jar": {
-      "sha1": "fc11f9c864670e5e2d1b02d2092c8811804f3ec7",
-      "sha256": "13kk5cw8ka4ch0jjmaqzdcdzl2fs8xzvz8kjkhj49zycl6j7jyih"
+    "path": "androidx/constraintlayout/constraintlayout/2.0.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "constraintlayout-2.0.4.pom": {
+        "sha1": "5a6761d954eaef83dafd69eddd77df09e59bcd8d",
+        "sha256": "15za4cgzjcf3axghmnd1r6hbcqijx4ps9pr34p41m15436pdnxvi"
+      },
+      "constraintlayout-2.0.4.aar": {
+        "sha1": "fc11f9c864670e5e2d1b02d2092c8811804f3ec7",
+        "sha256": "13kk5cw8ka4ch0jjmaqzdcdzl2fs8xzvz8kjkhj49zycl6j7jyih"
+      }
     }
   },
 
   {
-    "path": "androidx/coordinatorlayout/coordinatorlayout/1.0.0/coordinatorlayout-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "7136717d5fb751f308e9f9acf25a1f89d897c67f",
-      "sha256": "14lkmcabcrxn5gh1k6vlq6rinkp50vlnwqi37p1ynvgf5zgf8i1y"
-    },
-    "jar": {
-      "sha1": "7664385a7e39112b780baf8819ee880dcd3c4094",
-      "sha256": "0wzb576xav3xwlicdi5a4lfmgxxb0bpb9xrbji6kg4wl92awc275"
+    "path": "androidx/coordinatorlayout/coordinatorlayout/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "coordinatorlayout-1.0.0.pom": {
+        "sha1": "7136717d5fb751f308e9f9acf25a1f89d897c67f",
+        "sha256": "14lkmcabcrxn5gh1k6vlq6rinkp50vlnwqi37p1ynvgf5zgf8i1y"
+      },
+      "coordinatorlayout-1.0.0.aar": {
+        "sha1": "7664385a7e39112b780baf8819ee880dcd3c4094",
+        "sha256": "0wzb576xav3xwlicdi5a4lfmgxxb0bpb9xrbji6kg4wl92awc275"
+      }
     }
   },
 
   {
-    "path": "androidx/coordinatorlayout/coordinatorlayout/1.1.0/coordinatorlayout-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "2ccdc41c50a15a5cbf1bf0e40e46a63241b1c4ea",
-      "sha256": "1bsw7sk4z87057878n4ax8vyi0m39zcprffl5zxjzzzsvp4m4z56"
-    },
-    "jar": {
-      "sha1": "8eeb7baf75b9595d017642a460df5af3bb9fa4e1",
-      "sha256": "1jz8ql8i4ifrkwpsbzaylld17i79zq3ga2iaqlji1bsnpw5f7aa4"
+    "path": "androidx/coordinatorlayout/coordinatorlayout/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "coordinatorlayout-1.1.0.pom": {
+        "sha1": "2ccdc41c50a15a5cbf1bf0e40e46a63241b1c4ea",
+        "sha256": "1bsw7sk4z87057878n4ax8vyi0m39zcprffl5zxjzzzsvp4m4z56"
+      },
+      "coordinatorlayout-1.1.0.aar": {
+        "sha1": "8eeb7baf75b9595d017642a460df5af3bb9fa4e1",
+        "sha256": "1jz8ql8i4ifrkwpsbzaylld17i79zq3ga2iaqlji1bsnpw5f7aa4"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core-ktx/1.6.0/core-ktx-1.6.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c4966cf606f084c4edea617d45043e8fe1aaacfe",
-      "sha256": "0a45zlpjs7aa6r8ppimc42qjnlzmbyysw139j6f6ddbyx4nxc569"
-    },
-    "jar": {
-      "sha1": "75bce93ea8fc2c82b012352a5672a18b9ebde366",
-      "sha256": "0qz93l78cy2sdn3hz6n51vp3p2msa0xk2zzklw2yk8gbwz705vvi"
+    "path": "androidx/core/core-ktx/1.6.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-ktx-1.6.0.pom": {
+        "sha1": "c4966cf606f084c4edea617d45043e8fe1aaacfe",
+        "sha256": "0a45zlpjs7aa6r8ppimc42qjnlzmbyysw139j6f6ddbyx4nxc569"
+      },
+      "core-ktx-1.6.0.aar": {
+        "sha1": "75bce93ea8fc2c82b012352a5672a18b9ebde366",
+        "sha256": "0qz93l78cy2sdn3hz6n51vp3p2msa0xk2zzklw2yk8gbwz705vvi"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.0.0/core-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "a0587cee2a95fb9027f0b6d4a110a2072a7f6015",
-      "sha256": "1x8hi3b9n22skap9rmqshk10f04g6jk2k6z2in0a9bb8ssd54k9q"
-    },
-    "jar": {
-      "sha1": "48ad5ac253f1478cd7643ab4eef497a376098886",
-      "sha256": "1xblxk7icqdifws7b6i9fj2n3qfz7gyxvg38i5kxwihdzic26ryp"
+    "path": "androidx/core/core/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.0.0.pom": {
+        "sha1": "a0587cee2a95fb9027f0b6d4a110a2072a7f6015",
+        "sha256": "1x8hi3b9n22skap9rmqshk10f04g6jk2k6z2in0a9bb8ssd54k9q"
+      },
+      "core-1.0.0.aar": {
+        "sha1": "48ad5ac253f1478cd7643ab4eef497a376098886",
+        "sha256": "1xblxk7icqdifws7b6i9fj2n3qfz7gyxvg38i5kxwihdzic26ryp"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.0.1/core-1.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "4ca2f7d0a090f143876b04f4be8e746ac5921a39",
-      "sha256": "1nps3559fc6j54rkcfkwkwr5kg7hkyn61aa4zph98ir54s6mkcn0"
-    },
-    "jar": {
-      "sha1": "263deba7f9c24bd0cefb93c0aaaf402cc50828ee",
-      "sha256": "167rc0s7c8wlzf6i9d1pd8y4dpmw7m4i5yd4nxgqrb9cq8i0badi"
+    "path": "androidx/core/core/1.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.0.1.pom": {
+        "sha1": "4ca2f7d0a090f143876b04f4be8e746ac5921a39",
+        "sha256": "1nps3559fc6j54rkcfkwkwr5kg7hkyn61aa4zph98ir54s6mkcn0"
+      },
+      "core-1.0.1.aar": {
+        "sha1": "263deba7f9c24bd0cefb93c0aaaf402cc50828ee",
+        "sha256": "167rc0s7c8wlzf6i9d1pd8y4dpmw7m4i5yd4nxgqrb9cq8i0badi"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.1.0/core-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "2a6d529fdea6d3525bd70f46b6f1fc1a580a8513",
-      "sha256": "0k3ma57ilij3rp6iq416dndqd42qss7vfz2z8acbfindrlr63r6s"
-    },
-    "jar": {
-      "sha1": "b9addd897d6b9c8634fe789bdb82f993171432ae",
-      "sha256": "0zk4av88i842a7754fwsmh49qac9x24irgw3d6dc1qvgb6zczivn"
+    "path": "androidx/core/core/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.1.0.pom": {
+        "sha1": "2a6d529fdea6d3525bd70f46b6f1fc1a580a8513",
+        "sha256": "0k3ma57ilij3rp6iq416dndqd42qss7vfz2z8acbfindrlr63r6s"
+      },
+      "core-1.1.0.aar": {
+        "sha1": "b9addd897d6b9c8634fe789bdb82f993171432ae",
+        "sha256": "0zk4av88i842a7754fwsmh49qac9x24irgw3d6dc1qvgb6zczivn"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.2.0/core-1.2.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "01d5f5eb5224254e598a939cceb7e03aa7c209eb",
-      "sha256": "19kr7wmn9hwifha6dw5xpjc6fw1grss0l14shx9j7nbxnwvlw7rx"
-    },
-    "jar": {
-      "sha1": "745ff33409507e50cae5be800dea412470f8af5a",
-      "sha256": "1ci0d0bf2nzfpwcb4k4hk4bj23v66nhngdg68iz4m9xnrs48njsj"
+    "path": "androidx/core/core/1.2.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.2.0.pom": {
+        "sha1": "01d5f5eb5224254e598a939cceb7e03aa7c209eb",
+        "sha256": "19kr7wmn9hwifha6dw5xpjc6fw1grss0l14shx9j7nbxnwvlw7rx"
+      },
+      "core-1.2.0.aar": {
+        "sha1": "745ff33409507e50cae5be800dea412470f8af5a",
+        "sha256": "1ci0d0bf2nzfpwcb4k4hk4bj23v66nhngdg68iz4m9xnrs48njsj"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.3.0/core-1.3.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5b07a2d6dcf49b2a3080b5163d9d8f690947c7a6",
-      "sha256": "1mf29clk2cl6vg4ip4xhf7zdlxgvg7bhdb7pqp2zpn9rn46xd99y"
-    },
-    "jar": {
-      "sha1": "7b02249f15f9366a6d98dd5d6bf613c34810982e",
-      "sha256": "0qyvmgfgmffrhxim5xzca7lbc6ia85cwgakwpksdi1aiy4k6csqw"
+    "path": "androidx/core/core/1.3.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.3.0.pom": {
+        "sha1": "5b07a2d6dcf49b2a3080b5163d9d8f690947c7a6",
+        "sha256": "1mf29clk2cl6vg4ip4xhf7zdlxgvg7bhdb7pqp2zpn9rn46xd99y"
+      },
+      "core-1.3.0.aar": {
+        "sha1": "7b02249f15f9366a6d98dd5d6bf613c34810982e",
+        "sha256": "0qyvmgfgmffrhxim5xzca7lbc6ia85cwgakwpksdi1aiy4k6csqw"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.3.1/core-1.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "094f0ae90fc01f22fe2ee64545e280d351d4c3cb",
-      "sha256": "1yzayk6s11ahacyh9z20z3skqagaafs3k57wsdc7r1yhcx9hz1dc"
-    },
-    "jar": {
-      "sha1": "33ef11f8b162514f0520ebb7f454664eea7911eb",
-      "sha256": "1dpgh5gda7ai3vjc89lgjhjs44lxpv8m8sjs80yr92fm6xdacbp9"
+    "path": "androidx/core/core/1.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.3.1.pom": {
+        "sha1": "094f0ae90fc01f22fe2ee64545e280d351d4c3cb",
+        "sha256": "1yzayk6s11ahacyh9z20z3skqagaafs3k57wsdc7r1yhcx9hz1dc"
+      },
+      "core-1.3.1.aar": {
+        "sha1": "33ef11f8b162514f0520ebb7f454664eea7911eb",
+        "sha256": "1dpgh5gda7ai3vjc89lgjhjs44lxpv8m8sjs80yr92fm6xdacbp9"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.5.0/core-1.5.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "57d35949ae075717fb6bea8bf103a2bc35400523",
-      "sha256": "17ycj0vyhlz7s1njjwmkwwka9nf2bba9vq5cm9sxpcv7i0rlx8yr"
-    },
-    "jar": {
-      "sha1": "592da26c6f1263a51134546204033e0964e3c540",
-      "sha256": "0q91lyhiry5q5r44r96xkdjaaciwnqx8pr33zff0d2ang499f9rb"
+    "path": "androidx/core/core/1.5.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.5.0.pom": {
+        "sha1": "57d35949ae075717fb6bea8bf103a2bc35400523",
+        "sha256": "17ycj0vyhlz7s1njjwmkwwka9nf2bba9vq5cm9sxpcv7i0rlx8yr"
+      },
+      "core-1.5.0.aar": {
+        "sha1": "592da26c6f1263a51134546204033e0964e3c540",
+        "sha256": "0q91lyhiry5q5r44r96xkdjaaciwnqx8pr33zff0d2ang499f9rb"
+      }
     }
   },
 
   {
-    "path": "androidx/core/core/1.6.0/core-1.6.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "94a35cc5a7ff820b8fabad1283164da40e6a6909",
-      "sha256": "1s36z93ccl6csqiy2mn610ncz761a47l6h08qvfd0b6y7mg4f29j"
-    },
-    "jar": {
-      "sha1": "10775f024a338475a5e374033f4532a7b3d8994f",
-      "sha256": "1waf44jni7ag3ckb041bs72d4948q061izbm2m90a6y9i34bwpc7"
+    "path": "androidx/core/core/1.6.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "core-1.6.0.pom": {
+        "sha1": "94a35cc5a7ff820b8fabad1283164da40e6a6909",
+        "sha256": "1s36z93ccl6csqiy2mn610ncz761a47l6h08qvfd0b6y7mg4f29j"
+      },
+      "core-1.6.0.aar": {
+        "sha1": "10775f024a338475a5e374033f4532a7b3d8994f",
+        "sha256": "1waf44jni7ag3ckb041bs72d4948q061izbm2m90a6y9i34bwpc7"
+      }
     }
   },
 
   {
-    "path": "androidx/cursoradapter/cursoradapter/1.0.0/cursoradapter-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b1d8c36333871395c98e157e903881d44a509899",
-      "sha256": "0041mk5295n95q05jk01lg4vrn6nxkvxa54zn4q11whahn4mrnb2"
-    },
-    "jar": {
-      "sha1": "74014983a86b83cbce534dec4e7aa9312f5f5d82",
-      "sha256": "0r45w88jrszl2xhb2n6sjy9izlbsf99fp7blbgglgyhmi3kqy758"
+    "path": "androidx/cursoradapter/cursoradapter/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "cursoradapter-1.0.0.pom": {
+        "sha1": "b1d8c36333871395c98e157e903881d44a509899",
+        "sha256": "0041mk5295n95q05jk01lg4vrn6nxkvxa54zn4q11whahn4mrnb2"
+      },
+      "cursoradapter-1.0.0.aar": {
+        "sha1": "74014983a86b83cbce534dec4e7aa9312f5f5d82",
+        "sha256": "0r45w88jrszl2xhb2n6sjy9izlbsf99fp7blbgglgyhmi3kqy758"
+      }
     }
   },
 
   {
-    "path": "androidx/customview/customview/1.0.0/customview-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "53c54220d41f17dcb79d4d7f39432a328df544b2",
-      "sha256": "0jddp50wnyn3xpyz46y3g0nx8xk4nbayr6wy2dgbvxc4f6w4g7nf"
-    },
-    "jar": {
-      "sha1": "30f5ff6075d112f8076e733b24410e68159735b6",
-      "sha256": "1wjdb7r66mimm9ysb53s1asc0rqim26p2mjgc1d5jd3aabvbir90"
+    "path": "androidx/customview/customview/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "customview-1.0.0.pom": {
+        "sha1": "53c54220d41f17dcb79d4d7f39432a328df544b2",
+        "sha256": "0jddp50wnyn3xpyz46y3g0nx8xk4nbayr6wy2dgbvxc4f6w4g7nf"
+      },
+      "customview-1.0.0.aar": {
+        "sha1": "30f5ff6075d112f8076e733b24410e68159735b6",
+        "sha256": "1wjdb7r66mimm9ysb53s1asc0rqim26p2mjgc1d5jd3aabvbir90"
+      }
     }
   },
 
   {
-    "path": "androidx/databinding/databinding-common/3.2.1/databinding-common-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9191d0e28f6349d5754483edbab6e60513666176",
-      "sha256": "19pz16l1kdxklkgsf5vndjcyvvhkz1a02q12nm4h700gabxbdv45"
-    },
-    "jar": {
-      "sha1": "91c10c7ce255ab29ec4aea8a469d6c8ffa60bd53",
-      "sha256": "14y6shybpr9vh64swh44v38hnnrfm5xy2mcyzfp68qn6jgkrsi2c"
+    "path": "androidx/databinding/databinding-common/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "databinding-common-3.2.1.pom": {
+        "sha1": "9191d0e28f6349d5754483edbab6e60513666176",
+        "sha256": "19pz16l1kdxklkgsf5vndjcyvvhkz1a02q12nm4h700gabxbdv45"
+      },
+      "databinding-common-3.2.1.jar": {
+        "sha1": "91c10c7ce255ab29ec4aea8a469d6c8ffa60bd53",
+        "sha256": "14y6shybpr9vh64swh44v38hnnrfm5xy2mcyzfp68qn6jgkrsi2c"
+      }
     }
   },
 
   {
-    "path": "androidx/databinding/databinding-common/3.3.1/databinding-common-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2e932d3219ea5f6d1078b24a8a3ce24b209c9309",
-      "sha256": "0p8pxgc65wamx93f7dvhnq1nqq53wlglfyf3yhsy6i5wdkn2z517"
-    },
-    "jar": {
-      "sha1": "45795e2f688474b219d37beb7f9f6756578e6454",
-      "sha256": "0b4kk2c8ypjxyc8srl7r8zn0zad2vbgllxgjlah90hdppx963bws"
+    "path": "androidx/databinding/databinding-common/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "databinding-common-3.3.1.pom": {
+        "sha1": "2e932d3219ea5f6d1078b24a8a3ce24b209c9309",
+        "sha256": "0p8pxgc65wamx93f7dvhnq1nqq53wlglfyf3yhsy6i5wdkn2z517"
+      },
+      "databinding-common-3.3.1.jar": {
+        "sha1": "45795e2f688474b219d37beb7f9f6756578e6454",
+        "sha256": "0b4kk2c8ypjxyc8srl7r8zn0zad2vbgllxgjlah90hdppx963bws"
+      }
     }
   },
 
   {
-    "path": "androidx/databinding/databinding-common/3.5.4/databinding-common-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "77802aaa543731f35a9779eba2a2809e1df2bb42",
-      "sha256": "16zx2v83j5j3qa0vbq2nwvmjdmigqacgf2x77zhccgmdfncrl1w9"
-    },
-    "jar": {
-      "sha1": "6c02f6a4a55b3ee69345055fb9c63acf931bc972",
-      "sha256": "0vfyc1db4cjrj18j7jpsr7f8fkncas9iv6ccpribfbhdqwl6f245"
+    "path": "androidx/databinding/databinding-common/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "databinding-common-3.5.4.pom": {
+        "sha1": "77802aaa543731f35a9779eba2a2809e1df2bb42",
+        "sha256": "16zx2v83j5j3qa0vbq2nwvmjdmigqacgf2x77zhccgmdfncrl1w9"
+      },
+      "databinding-common-3.5.4.jar": {
+        "sha1": "6c02f6a4a55b3ee69345055fb9c63acf931bc972",
+        "sha256": "0vfyc1db4cjrj18j7jpsr7f8fkncas9iv6ccpribfbhdqwl6f245"
+      }
     }
   },
 
   {
-    "path": "androidx/databinding/databinding-compiler-common/3.2.1/databinding-compiler-common-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4bae47f040933df0c02a0dbd783a0cd852b4cc91",
-      "sha256": "0vi88mm7g6wnnk21gi48prrxvx29w4vmg7va8z56gp00bnj14hni"
-    },
-    "jar": {
-      "sha1": "dee402009966fb2d3bb03e3186f3f16b9c503c86",
-      "sha256": "1dlpkpsfpmb3hcjj462svpg4h0d0vz8raj70abikpm04lzfslica"
+    "path": "androidx/databinding/databinding-compiler-common/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "databinding-compiler-common-3.2.1.pom": {
+        "sha1": "4bae47f040933df0c02a0dbd783a0cd852b4cc91",
+        "sha256": "0vi88mm7g6wnnk21gi48prrxvx29w4vmg7va8z56gp00bnj14hni"
+      },
+      "databinding-compiler-common-3.2.1.jar": {
+        "sha1": "dee402009966fb2d3bb03e3186f3f16b9c503c86",
+        "sha256": "1dlpkpsfpmb3hcjj462svpg4h0d0vz8raj70abikpm04lzfslica"
+      }
     }
   },
 
   {
-    "path": "androidx/databinding/databinding-compiler-common/3.3.1/databinding-compiler-common-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "123c2b1dd44ec6e2441be9441bdf393462936928",
-      "sha256": "0cnb2xwnzaw83k7gjj8z53bsnvypdkqi5yyl1gfc94dix8ys3bcx"
-    },
-    "jar": {
-      "sha1": "e96aa159e1ed5c5a3461d15adfc42ef5b1f68b59",
-      "sha256": "07f65wbm83ki752gmk677ynwa8c4ilhg3awx6b3bsxxli2pcxwmi"
+    "path": "androidx/databinding/databinding-compiler-common/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "databinding-compiler-common-3.3.1.pom": {
+        "sha1": "123c2b1dd44ec6e2441be9441bdf393462936928",
+        "sha256": "0cnb2xwnzaw83k7gjj8z53bsnvypdkqi5yyl1gfc94dix8ys3bcx"
+      },
+      "databinding-compiler-common-3.3.1.jar": {
+        "sha1": "e96aa159e1ed5c5a3461d15adfc42ef5b1f68b59",
+        "sha256": "07f65wbm83ki752gmk677ynwa8c4ilhg3awx6b3bsxxli2pcxwmi"
+      }
     }
   },
 
   {
-    "path": "androidx/databinding/databinding-compiler-common/3.5.4/databinding-compiler-common-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "062e8d8f0b6efd6bd452f10e707d3ed59ae94b57",
-      "sha256": "0513vhf4m46ks9jflcins5b2idmyx161hv1gvcnc0jy6x23wjrc2"
-    },
-    "jar": {
-      "sha1": "e3a2ee3bc2c0295d9d2b4519c1bba5786e8a5435",
-      "sha256": "0j5w7a7hdjp1sfwww6114ki30q8mgdi5wrx4jxv8r1g4xfwilscw"
+    "path": "androidx/databinding/databinding-compiler-common/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "databinding-compiler-common-3.5.4.pom": {
+        "sha1": "062e8d8f0b6efd6bd452f10e707d3ed59ae94b57",
+        "sha256": "0513vhf4m46ks9jflcins5b2idmyx161hv1gvcnc0jy6x23wjrc2"
+      },
+      "databinding-compiler-common-3.5.4.jar": {
+        "sha1": "e3a2ee3bc2c0295d9d2b4519c1bba5786e8a5435",
+        "sha256": "0j5w7a7hdjp1sfwww6114ki30q8mgdi5wrx4jxv8r1g4xfwilscw"
+      }
     }
   },
 
   {
-    "path": "androidx/documentfile/documentfile/1.0.0/documentfile-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "8cb912559da493946f05d1b5aa17a4b409a3e6eb",
-      "sha256": "1r8nkjpaamgqiibyq8wjaa4348p8jd2b4pv2rq32fmbs66lqhch1"
-    },
-    "jar": {
-      "sha1": "66104345c90cd8c2fd5ad2d3aad692b280e10c32",
-      "sha256": "11wlhs0v9vm1vybm2x67yxpw823jsjw3cda3z0i6blgsy8g0cnl6"
+    "path": "androidx/documentfile/documentfile/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "documentfile-1.0.0.pom": {
+        "sha1": "8cb912559da493946f05d1b5aa17a4b409a3e6eb",
+        "sha256": "1r8nkjpaamgqiibyq8wjaa4348p8jd2b4pv2rq32fmbs66lqhch1"
+      },
+      "documentfile-1.0.0.aar": {
+        "sha1": "66104345c90cd8c2fd5ad2d3aad692b280e10c32",
+        "sha256": "11wlhs0v9vm1vybm2x67yxpw823jsjw3cda3z0i6blgsy8g0cnl6"
+      }
     }
   },
 
   {
-    "path": "androidx/drawerlayout/drawerlayout/1.0.0/drawerlayout-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "436d14f0b503b411431a0c38e5368ba4ec4b1e62",
-      "sha256": "193gdhww06fx1xamipb8qvbzwi93100p5ykq122wxxc3b9136rys"
-    },
-    "jar": {
-      "sha1": "dd02c7e207136e1272b33815cc61e57676ed13a2",
-      "sha256": "1hcsfh1fixvc7h1wh1dqv7cx8hikqscczy0lzdicyhssvhn480ll"
+    "path": "androidx/drawerlayout/drawerlayout/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "drawerlayout-1.0.0.pom": {
+        "sha1": "436d14f0b503b411431a0c38e5368ba4ec4b1e62",
+        "sha256": "193gdhww06fx1xamipb8qvbzwi93100p5ykq122wxxc3b9136rys"
+      },
+      "drawerlayout-1.0.0.aar": {
+        "sha1": "dd02c7e207136e1272b33815cc61e57676ed13a2",
+        "sha256": "1hcsfh1fixvc7h1wh1dqv7cx8hikqscczy0lzdicyhssvhn480ll"
+      }
     }
   },
 
   {
-    "path": "androidx/exifinterface/exifinterface/1.1.0-beta01/exifinterface-1.1.0-beta01",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "113ca4bcf7feed9865496b8980cb92dec0d99d12",
-      "sha256": "1hxg57hchc87vzzwc7a5n7jdfa82zwycl38scds957crxap57sah"
-    },
-    "jar": {
-      "sha1": "3a3ae85030468e63b28989401fe69db581e40c82",
-      "sha256": "174rrl18rq5yrrmjcvl3chjhqs051dlf2j1fipwcgv0v737jk67w"
+    "path": "androidx/exifinterface/exifinterface/1.1.0-beta01",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "exifinterface-1.1.0-beta01.pom": {
+        "sha1": "113ca4bcf7feed9865496b8980cb92dec0d99d12",
+        "sha256": "1hxg57hchc87vzzwc7a5n7jdfa82zwycl38scds957crxap57sah"
+      },
+      "exifinterface-1.1.0-beta01.aar": {
+        "sha1": "3a3ae85030468e63b28989401fe69db581e40c82",
+        "sha256": "174rrl18rq5yrrmjcvl3chjhqs051dlf2j1fipwcgv0v737jk67w"
+      }
     }
   },
 
   {
-    "path": "androidx/exifinterface/exifinterface/1.1.0-rc01/exifinterface-1.1.0-rc01",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5aeae1be812a6eda52d9f2794b0bab6da4bfa40b",
-      "sha256": "0n0x32xrs9hd34s3ir4530pirnnb5vb8h4bvmc6i9krpwiz7qw0x"
-    },
-    "jar": {
-      "sha1": "00dc0a481d0dea36957eab478d53e98c378144ed",
-      "sha256": "098f9m5x90j8ngcr07gx63v14sq7l6l07yghx8lfshkg0m3anvql"
+    "path": "androidx/exifinterface/exifinterface/1.1.0-rc01",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "exifinterface-1.1.0-rc01.pom": {
+        "sha1": "5aeae1be812a6eda52d9f2794b0bab6da4bfa40b",
+        "sha256": "0n0x32xrs9hd34s3ir4530pirnnb5vb8h4bvmc6i9krpwiz7qw0x"
+      },
+      "exifinterface-1.1.0-rc01.aar": {
+        "sha1": "00dc0a481d0dea36957eab478d53e98c378144ed",
+        "sha256": "098f9m5x90j8ngcr07gx63v14sq7l6l07yghx8lfshkg0m3anvql"
+      }
     }
   },
 
   {
-    "path": "androidx/exifinterface/exifinterface/1.2.0/exifinterface-1.2.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "34832395bc9a4fe2aafdd73605ddf9da9f842e7a",
-      "sha256": "1qi9p1nmdw8d0wpy0nmakvnpj4hgb0xf3aicd8qzn0nclszr2zkg"
-    },
-    "jar": {
-      "sha1": "e8a2f661f33bbfa8e9d226aa5dacae90aedf2fc9",
-      "sha256": "19xf8zwzxlvq2l4qfwfijasjpv3jlz5ylmh5cykpbr4m618qxrma"
+    "path": "androidx/exifinterface/exifinterface/1.2.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "exifinterface-1.2.0.pom": {
+        "sha1": "34832395bc9a4fe2aafdd73605ddf9da9f842e7a",
+        "sha256": "1qi9p1nmdw8d0wpy0nmakvnpj4hgb0xf3aicd8qzn0nclszr2zkg"
+      },
+      "exifinterface-1.2.0.aar": {
+        "sha1": "e8a2f661f33bbfa8e9d226aa5dacae90aedf2fc9",
+        "sha256": "19xf8zwzxlvq2l4qfwfijasjpv3jlz5ylmh5cykpbr4m618qxrma"
+      }
     }
   },
 
   {
-    "path": "androidx/fragment/fragment/1.0.0/fragment-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "3f74765ebe6789c38bcfb2e06640a43a0d7d5252",
-      "sha256": "0qnirjy9hx6fcrbzv7mi7za8ndl60lglxlflykld550y6rrxcag3"
-    },
-    "jar": {
-      "sha1": "0b40f6a2ae814f72d1e71a5df6dc1283c00cd52f",
-      "sha256": "1y0qnp8644b1qx0ag0kzj8w70c09mnqwz9l9g7kk4np63zbk5pb5"
+    "path": "androidx/fragment/fragment/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "fragment-1.0.0.pom": {
+        "sha1": "3f74765ebe6789c38bcfb2e06640a43a0d7d5252",
+        "sha256": "0qnirjy9hx6fcrbzv7mi7za8ndl60lglxlflykld550y6rrxcag3"
+      },
+      "fragment-1.0.0.aar": {
+        "sha1": "0b40f6a2ae814f72d1e71a5df6dc1283c00cd52f",
+        "sha256": "1y0qnp8644b1qx0ag0kzj8w70c09mnqwz9l9g7kk4np63zbk5pb5"
+      }
     }
   },
 
   {
-    "path": "androidx/fragment/fragment/1.1.0/fragment-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "753e03826c6efdace71d94ed9d04bf008fa6ad3d",
-      "sha256": "0i15nlfh2lbjyzydby2k32h3fa1sqxbki2jzbmag7p82mhkyny7g"
-    },
-    "jar": {
-      "sha1": "5f9efc7569e651415a0958d6b3e6226ef2825c24",
-      "sha256": "15hlv03x61fcs9qcb7m2h8wjh75bpsk6dlpv03l2iwak467qnk51"
+    "path": "androidx/fragment/fragment/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "fragment-1.1.0.pom": {
+        "sha1": "753e03826c6efdace71d94ed9d04bf008fa6ad3d",
+        "sha256": "0i15nlfh2lbjyzydby2k32h3fa1sqxbki2jzbmag7p82mhkyny7g"
+      },
+      "fragment-1.1.0.aar": {
+        "sha1": "5f9efc7569e651415a0958d6b3e6226ef2825c24",
+        "sha256": "15hlv03x61fcs9qcb7m2h8wjh75bpsk6dlpv03l2iwak467qnk51"
+      }
     }
   },
 
   {
-    "path": "androidx/fragment/fragment/1.3.6/fragment-1.3.6",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "27c5fdad4300b48d2fd1ebc0e5694081f3f52472",
-      "sha256": "0mawx2v0lsky5yc5nyvirww4kz971l5074vi8ydv12mz9isgcw54"
-    },
-    "jar": {
-      "sha1": "6391fc504e7c0f24051ac8b9da3f0ba4d1241dff",
-      "sha256": "07hwinxj27km07ld7zpg1kr2y0hsq4iijb17v9fjs2889wdq7w0j"
+    "path": "androidx/fragment/fragment/1.3.6",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "fragment-1.3.6.pom": {
+        "sha1": "27c5fdad4300b48d2fd1ebc0e5694081f3f52472",
+        "sha256": "0mawx2v0lsky5yc5nyvirww4kz971l5074vi8ydv12mz9isgcw54"
+      },
+      "fragment-1.3.6.aar": {
+        "sha1": "6391fc504e7c0f24051ac8b9da3f0ba4d1241dff",
+        "sha256": "07hwinxj27km07ld7zpg1kr2y0hsq4iijb17v9fjs2889wdq7w0j"
+      }
     }
   },
 
   {
-    "path": "androidx/interpolator/interpolator/1.0.0/interpolator-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "dfa9c6b5826fbf2f910e1720ce2b0421d7aafec3",
-      "sha256": "0ywbr0j7489pvx72jn99x0i9xw6061c4p2gcv7n4i7v97760gp0d"
-    },
-    "jar": {
-      "sha1": "8a01fa254a23b9388571eb6334b03707c7d122d7",
-      "sha256": "0akksynkg7k83gf87z600qk52vm7y646dv2yqfi1zqjglqsk269k"
+    "path": "androidx/interpolator/interpolator/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "interpolator-1.0.0.pom": {
+        "sha1": "dfa9c6b5826fbf2f910e1720ce2b0421d7aafec3",
+        "sha256": "0ywbr0j7489pvx72jn99x0i9xw6061c4p2gcv7n4i7v97760gp0d"
+      },
+      "interpolator-1.0.0.aar": {
+        "sha1": "8a01fa254a23b9388571eb6334b03707c7d122d7",
+        "sha256": "0akksynkg7k83gf87z600qk52vm7y646dv2yqfi1zqjglqsk269k"
+      }
     }
   },
 
   {
-    "path": "androidx/legacy/legacy-support-core-ui/1.0.0/legacy-support-core-ui-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "6bda132303af80266ef7f6d8e86b0712f76f8d28",
-      "sha256": "0cb9wr0lnzcbp94zb7032ahph09a9aajyk8yplj5axjifpqzgaib"
-    },
-    "jar": {
-      "sha1": "61a264f996046e059f889914050fae1e75d3b702",
-      "sha256": "0iyrqddgl81srlbri24hdrqkyw0yjcbbawfzfpw3g8z6wz3604hd"
+    "path": "androidx/legacy/legacy-support-core-ui/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "legacy-support-core-ui-1.0.0.pom": {
+        "sha1": "6bda132303af80266ef7f6d8e86b0712f76f8d28",
+        "sha256": "0cb9wr0lnzcbp94zb7032ahph09a9aajyk8yplj5axjifpqzgaib"
+      },
+      "legacy-support-core-ui-1.0.0.aar": {
+        "sha1": "61a264f996046e059f889914050fae1e75d3b702",
+        "sha256": "0iyrqddgl81srlbri24hdrqkyw0yjcbbawfzfpw3g8z6wz3604hd"
+      }
     }
   },
 
   {
-    "path": "androidx/legacy/legacy-support-core-utils/1.0.0/legacy-support-core-utils-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "838c7839cc6df6d56f594ddc2050bd36f7f0c1f3",
-      "sha256": "0f0al3vndx3smlfsjzwnkfv4fyqak2ps53f7a9pc1rryic097l4g"
-    },
-    "jar": {
-      "sha1": "9b9570042115da8629519090dfeb71df75da59fc",
-      "sha256": "1iyiipfrm0hwss8vn0k2pdj4g2mpfm3vq9rh0ws30axmsl0wzvd7"
+    "path": "androidx/legacy/legacy-support-core-utils/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "legacy-support-core-utils-1.0.0.pom": {
+        "sha1": "838c7839cc6df6d56f594ddc2050bd36f7f0c1f3",
+        "sha256": "0f0al3vndx3smlfsjzwnkfv4fyqak2ps53f7a9pc1rryic097l4g"
+      },
+      "legacy-support-core-utils-1.0.0.aar": {
+        "sha1": "9b9570042115da8629519090dfeb71df75da59fc",
+        "sha256": "1iyiipfrm0hwss8vn0k2pdj4g2mpfm3vq9rh0ws30axmsl0wzvd7"
+      }
     }
   },
 
   {
-    "path": "androidx/legacy/legacy-support-v4/1.0.0/legacy-support-v4-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "a0c16ebb4d57f6ec356dd8756285537c0d8b67dd",
-      "sha256": "0n3wza06dp618jbnvjqvi12slx23hxbi7plfjaxz4w7v9h9gp27d"
-    },
-    "jar": {
-      "sha1": "03e1271b351e1209661b9fd769cd6681a31678fe",
-      "sha256": "1c40ah2qjrdis0zirbj44p6jfwc52qadab82953qlf0gbx4c3zkq"
+    "path": "androidx/legacy/legacy-support-v4/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "legacy-support-v4-1.0.0.pom": {
+        "sha1": "a0c16ebb4d57f6ec356dd8756285537c0d8b67dd",
+        "sha256": "0n3wza06dp618jbnvjqvi12slx23hxbi7plfjaxz4w7v9h9gp27d"
+      },
+      "legacy-support-v4-1.0.0.aar": {
+        "sha1": "03e1271b351e1209661b9fd769cd6681a31678fe",
+        "sha256": "1c40ah2qjrdis0zirbj44p6jfwc52qadab82953qlf0gbx4c3zkq"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-common/2.0.0/lifecycle-common-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "23b760e7668836e3afa3e63608dde9e747a3e1cc",
-      "sha256": "03bhvwlh5ibb6bcani99p0rblj6mbn3sl6p8k464s8b96h3jbm84"
-    },
-    "jar": {
-      "sha1": "e070ffae07452331bc5684734fce6831d531785c",
-      "sha256": "1z7y6nsqdzv08x4dxbgcjfyj0pvhkgwmwpgkl5pymb84i0c7mbbv"
+    "path": "androidx/lifecycle/lifecycle-common/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-common-2.0.0.pom": {
+        "sha1": "23b760e7668836e3afa3e63608dde9e747a3e1cc",
+        "sha256": "03bhvwlh5ibb6bcani99p0rblj6mbn3sl6p8k464s8b96h3jbm84"
+      },
+      "lifecycle-common-2.0.0.jar": {
+        "sha1": "e070ffae07452331bc5684734fce6831d531785c",
+        "sha256": "1z7y6nsqdzv08x4dxbgcjfyj0pvhkgwmwpgkl5pymb84i0c7mbbv"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-common/2.1.0/lifecycle-common-2.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "de2b915adafa394edd5eadcab6b5089d08fb71f6",
-      "sha256": "0xpjh83m6ikc9rqmhz0sbm9my9bg351qjvmviw6255bs8dh2lb39"
-    },
-    "jar": {
-      "sha1": "c67e7807d9cd6c329b9d0218b2ec4e505dd340b7",
-      "sha256": "0hr610gzh7k0hbd4fs3l4hl9bn965hmb3zn2c6rhywxx6gjnpnvn"
+    "path": "androidx/lifecycle/lifecycle-common/2.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-common-2.1.0.pom": {
+        "sha1": "de2b915adafa394edd5eadcab6b5089d08fb71f6",
+        "sha256": "0xpjh83m6ikc9rqmhz0sbm9my9bg351qjvmviw6255bs8dh2lb39"
+      },
+      "lifecycle-common-2.1.0.jar": {
+        "sha1": "c67e7807d9cd6c329b9d0218b2ec4e505dd340b7",
+        "sha256": "0hr610gzh7k0hbd4fs3l4hl9bn965hmb3zn2c6rhywxx6gjnpnvn"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-common/2.3.1/lifecycle-common-2.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0ed381b5d87316483120f3328b489056246e6730",
-      "sha256": "0lf33ff4cvadklqc2i2i25ggm2333adx4h38w5n5q28lka43vllc"
-    },
-    "jar": {
-      "sha1": "fc466261d52f4433863642fb40d12441ae274a98",
-      "sha256": "1d9rs63zbiwaf2z0kgynhi42mmc364029cvjviy4qbxkdnsqz10m"
+    "path": "androidx/lifecycle/lifecycle-common/2.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-common-2.3.1.pom": {
+        "sha1": "0ed381b5d87316483120f3328b489056246e6730",
+        "sha256": "0lf33ff4cvadklqc2i2i25ggm2333adx4h38w5n5q28lka43vllc"
+      },
+      "lifecycle-common-2.3.1.jar": {
+        "sha1": "fc466261d52f4433863642fb40d12441ae274a98",
+        "sha256": "1d9rs63zbiwaf2z0kgynhi42mmc364029cvjviy4qbxkdnsqz10m"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-livedata-core/2.0.0/lifecycle-livedata-core-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b78b5eea709c488e36f0d4cb8932bbb5757649f5",
-      "sha256": "1j42p52d3j4v2w10zar52aklfbxdriq1ams045s6jmig4cddl3v5"
-    },
-    "jar": {
-      "sha1": "1a7cee84b43fa935231b016f0665cd56a72fa9db",
-      "sha256": "1g7pqhg95ggrpmvhah24f0r1gmy9hhdayz7ybc7lqx12gvn39qzx"
+    "path": "androidx/lifecycle/lifecycle-livedata-core/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-livedata-core-2.0.0.pom": {
+        "sha1": "b78b5eea709c488e36f0d4cb8932bbb5757649f5",
+        "sha256": "1j42p52d3j4v2w10zar52aklfbxdriq1ams045s6jmig4cddl3v5"
+      },
+      "lifecycle-livedata-core-2.0.0.aar": {
+        "sha1": "1a7cee84b43fa935231b016f0665cd56a72fa9db",
+        "sha256": "1g7pqhg95ggrpmvhah24f0r1gmy9hhdayz7ybc7lqx12gvn39qzx"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-livedata-core/2.3.1/lifecycle-livedata-core-2.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "33a214022e333d8cd6d8c94b759eeaf2b7e3de79",
-      "sha256": "1ys3l41k2p9nhyhqs4zrf97qm28iih5mjdlbxfyz2iyywci656gv"
-    },
-    "jar": {
-      "sha1": "d6d9279495dc234dc37cecf461b3b626825086ef",
-      "sha256": "1c8sv0y6aacxv4s8ckyp1ws12x92cw69bp3xk41hl3s6fb1khpg5"
+    "path": "androidx/lifecycle/lifecycle-livedata-core/2.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-livedata-core-2.3.1.pom": {
+        "sha1": "33a214022e333d8cd6d8c94b759eeaf2b7e3de79",
+        "sha256": "1ys3l41k2p9nhyhqs4zrf97qm28iih5mjdlbxfyz2iyywci656gv"
+      },
+      "lifecycle-livedata-core-2.3.1.aar": {
+        "sha1": "d6d9279495dc234dc37cecf461b3b626825086ef",
+        "sha256": "1c8sv0y6aacxv4s8ckyp1ws12x92cw69bp3xk41hl3s6fb1khpg5"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-livedata/2.0.0/lifecycle-livedata-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b1987c65a98cb0d6f43048be0c20f20f932fc1aa",
-      "sha256": "08wl8d53121dwddkjy7scjhs9a404q8wq1awny6m2kpiq3zl4j58"
-    },
-    "jar": {
-      "sha1": "c17007cd0b21d6401910b0becdd16c438c68a9af",
-      "sha256": "0fdsyznqdvl118pdi17fv9h0hj5p3dvvc3x306kz1664v370j9n8"
+    "path": "androidx/lifecycle/lifecycle-livedata/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-livedata-2.0.0.pom": {
+        "sha1": "b1987c65a98cb0d6f43048be0c20f20f932fc1aa",
+        "sha256": "08wl8d53121dwddkjy7scjhs9a404q8wq1awny6m2kpiq3zl4j58"
+      },
+      "lifecycle-livedata-2.0.0.aar": {
+        "sha1": "c17007cd0b21d6401910b0becdd16c438c68a9af",
+        "sha256": "0fdsyznqdvl118pdi17fv9h0hj5p3dvvc3x306kz1664v370j9n8"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-runtime/2.0.0/lifecycle-runtime-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "46f0c189fc05bc4a80ab5399919d5ba0b5d71a33",
-      "sha256": "1pmn19dv6wg1r839wswrfrlj0qsv5m576y6mllkc72pcgbx4cam9"
-    },
-    "jar": {
-      "sha1": "ea27e9e79e9a0fbedfa4dbbef5ddccf0e1d9d73f",
-      "sha256": "1yrwsjfskismgyq5n1vkqv9gz4m445hz876z1qz6ygqq6vkckbz4"
+    "path": "androidx/lifecycle/lifecycle-runtime/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-runtime-2.0.0.pom": {
+        "sha1": "46f0c189fc05bc4a80ab5399919d5ba0b5d71a33",
+        "sha256": "1pmn19dv6wg1r839wswrfrlj0qsv5m576y6mllkc72pcgbx4cam9"
+      },
+      "lifecycle-runtime-2.0.0.aar": {
+        "sha1": "ea27e9e79e9a0fbedfa4dbbef5ddccf0e1d9d73f",
+        "sha256": "1yrwsjfskismgyq5n1vkqv9gz4m445hz876z1qz6ygqq6vkckbz4"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-runtime/2.1.0/lifecycle-runtime-2.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "87fefa0cd4644709a2afc1f2da09397694bfe8b1",
-      "sha256": "1jwzjl6nwxnqpgmwmpx170ms6ybxygdyhsrxnpabqy9dvc1cz3dg"
-    },
-    "jar": {
-      "sha1": "24af6c5162c83b5bf073e16608fd87821422fe48",
-      "sha256": "0arir2aa3qqc74x24qw8slrgbls22ypxbnc33rjp1s35p6bkh5z5"
+    "path": "androidx/lifecycle/lifecycle-runtime/2.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-runtime-2.1.0.pom": {
+        "sha1": "87fefa0cd4644709a2afc1f2da09397694bfe8b1",
+        "sha256": "1jwzjl6nwxnqpgmwmpx170ms6ybxygdyhsrxnpabqy9dvc1cz3dg"
+      },
+      "lifecycle-runtime-2.1.0.aar": {
+        "sha1": "24af6c5162c83b5bf073e16608fd87821422fe48",
+        "sha256": "0arir2aa3qqc74x24qw8slrgbls22ypxbnc33rjp1s35p6bkh5z5"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-runtime/2.3.1/lifecycle-runtime-2.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "06991b67903c152737d17c12fa53610f1e3e049c",
-      "sha256": "07rk1ghqxv0h7phrx821fsld7rva7iqxy7waj0pdnzirzj22li5l"
-    },
-    "jar": {
-      "sha1": "5786c819df8bcc1f050e9a752d2d0d85f87c4aed",
-      "sha256": "004gkmbc67qg2gk21r2csih7fbx6ldkkn7ylgy3zywcwd154yafx"
+    "path": "androidx/lifecycle/lifecycle-runtime/2.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-runtime-2.3.1.pom": {
+        "sha1": "06991b67903c152737d17c12fa53610f1e3e049c",
+        "sha256": "07rk1ghqxv0h7phrx821fsld7rva7iqxy7waj0pdnzirzj22li5l"
+      },
+      "lifecycle-runtime-2.3.1.aar": {
+        "sha1": "5786c819df8bcc1f050e9a752d2d0d85f87c4aed",
+        "sha256": "004gkmbc67qg2gk21r2csih7fbx6ldkkn7ylgy3zywcwd154yafx"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-viewmodel-savedstate/2.3.1/lifecycle-viewmodel-savedstate-2.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "67c0adcbc0ca42eb784b7eeffb3f23cdcf7e8593",
-      "sha256": "0p7lwiqv51y74wa438x3qykab3xfdccpp5sqyagb5bzxhkp40pi1"
-    },
-    "jar": {
-      "sha1": "ef1df1036fc803ab3eaf0c298ee256e0b9fdad01",
-      "sha256": "1h34fm06cgnqpf4cgnsb90dpj2kwij0anrj89shpc5x3ys57l4wp"
+    "path": "androidx/lifecycle/lifecycle-viewmodel-savedstate/2.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-viewmodel-savedstate-2.3.1.pom": {
+        "sha1": "67c0adcbc0ca42eb784b7eeffb3f23cdcf7e8593",
+        "sha256": "0p7lwiqv51y74wa438x3qykab3xfdccpp5sqyagb5bzxhkp40pi1"
+      },
+      "lifecycle-viewmodel-savedstate-2.3.1.aar": {
+        "sha1": "ef1df1036fc803ab3eaf0c298ee256e0b9fdad01",
+        "sha256": "1h34fm06cgnqpf4cgnsb90dpj2kwij0anrj89shpc5x3ys57l4wp"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-viewmodel/2.0.0/lifecycle-viewmodel-2.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5ff80c640672babaf445983797eaefc3104bd1af",
-      "sha256": "09q87rriyn86l5xay80n5d5c2mbrzza8w08w5pw8jh363kymidv0"
-    },
-    "jar": {
-      "sha1": "6417c576c458137456d996914c50591e7f4acc24",
-      "sha256": "0qn0pkzk70jh5j7w5rf3hy6xxgs3krz2k26g2jmq1bbb3gm0linn"
+    "path": "androidx/lifecycle/lifecycle-viewmodel/2.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-viewmodel-2.0.0.pom": {
+        "sha1": "5ff80c640672babaf445983797eaefc3104bd1af",
+        "sha256": "09q87rriyn86l5xay80n5d5c2mbrzza8w08w5pw8jh363kymidv0"
+      },
+      "lifecycle-viewmodel-2.0.0.aar": {
+        "sha1": "6417c576c458137456d996914c50591e7f4acc24",
+        "sha256": "0qn0pkzk70jh5j7w5rf3hy6xxgs3krz2k26g2jmq1bbb3gm0linn"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-viewmodel/2.1.0/lifecycle-viewmodel-2.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b95d38b7236e5bb4249d74fdab5044c292158342",
-      "sha256": "1d54r4vs36ad9zcixdip1mpr575pqy2lqflp9kkjgqn377ip5ai9"
-    },
-    "jar": {
-      "sha1": "682d06cc95e0632efdb9cfcc18828840ac941148",
-      "sha256": "0gajp14n4s37m9n37vs39hmhp6ax13vsra6d4x9qv0mjq5xgnmds"
+    "path": "androidx/lifecycle/lifecycle-viewmodel/2.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-viewmodel-2.1.0.pom": {
+        "sha1": "b95d38b7236e5bb4249d74fdab5044c292158342",
+        "sha256": "1d54r4vs36ad9zcixdip1mpr575pqy2lqflp9kkjgqn377ip5ai9"
+      },
+      "lifecycle-viewmodel-2.1.0.aar": {
+        "sha1": "682d06cc95e0632efdb9cfcc18828840ac941148",
+        "sha256": "0gajp14n4s37m9n37vs39hmhp6ax13vsra6d4x9qv0mjq5xgnmds"
+      }
     }
   },
 
   {
-    "path": "androidx/lifecycle/lifecycle-viewmodel/2.3.1/lifecycle-viewmodel-2.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "319f1b60575b6ba81aa588084b903aece6b33aa5",
-      "sha256": "06j1ikq3nal4kpgq7arqnv6fn2zma75zkan3v61860ws1fnmxx13"
-    },
-    "jar": {
-      "sha1": "9b96f5276783647e1436154c7ae393b2a4e9c2c4",
-      "sha256": "0f78gi0vx9kg38grvkhsayifz2p9qxlnc7kyfjj8bzqj98klrnxn"
+    "path": "androidx/lifecycle/lifecycle-viewmodel/2.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lifecycle-viewmodel-2.3.1.pom": {
+        "sha1": "319f1b60575b6ba81aa588084b903aece6b33aa5",
+        "sha256": "06j1ikq3nal4kpgq7arqnv6fn2zma75zkan3v61860ws1fnmxx13"
+      },
+      "lifecycle-viewmodel-2.3.1.aar": {
+        "sha1": "9b96f5276783647e1436154c7ae393b2a4e9c2c4",
+        "sha256": "0f78gi0vx9kg38grvkhsayifz2p9qxlnc7kyfjj8bzqj98klrnxn"
+      }
     }
   },
 
   {
-    "path": "androidx/loader/loader/1.0.0/loader-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "4b1418669a3392afe77045f85ba870f0c3148f67",
-      "sha256": "0plcvw852zg3la9hl5n6pjq5a2x5210icqwsli546iwbh18day69"
-    },
-    "jar": {
-      "sha1": "8af8b6cec0da85c207d03e15840e0722cbc71e70",
-      "sha256": "09ah1zdjcw1sg0k6kb8v9f5m2nrpai9f5ndyf3a5ii2m7g5kbxqi"
+    "path": "androidx/loader/loader/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "loader-1.0.0.pom": {
+        "sha1": "4b1418669a3392afe77045f85ba870f0c3148f67",
+        "sha256": "0plcvw852zg3la9hl5n6pjq5a2x5210icqwsli546iwbh18day69"
+      },
+      "loader-1.0.0.aar": {
+        "sha1": "8af8b6cec0da85c207d03e15840e0722cbc71e70",
+        "sha256": "09ah1zdjcw1sg0k6kb8v9f5m2nrpai9f5ndyf3a5ii2m7g5kbxqi"
+      }
     }
   },
 
   {
-    "path": "androidx/localbroadcastmanager/localbroadcastmanager/1.0.0/localbroadcastmanager-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "afb1a15f5669db4cc43e19ec2e67e6fb77500234",
-      "sha256": "1ybgz99i4xg9zcs9sshw807pi0rnrxhbpqbma4y2hy8zb8gh8050"
-    },
-    "jar": {
-      "sha1": "2734f31c8321e83ce6b60570d14777fc33cc2ece",
-      "sha256": "1n46c4rk8gsav3ps9cb8z2nf4pyncldxz1iddzbsgi7mxs634777"
+    "path": "androidx/localbroadcastmanager/localbroadcastmanager/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "localbroadcastmanager-1.0.0.pom": {
+        "sha1": "afb1a15f5669db4cc43e19ec2e67e6fb77500234",
+        "sha256": "1ybgz99i4xg9zcs9sshw807pi0rnrxhbpqbma4y2hy8zb8gh8050"
+      },
+      "localbroadcastmanager-1.0.0.aar": {
+        "sha1": "2734f31c8321e83ce6b60570d14777fc33cc2ece",
+        "sha256": "1n46c4rk8gsav3ps9cb8z2nf4pyncldxz1iddzbsgi7mxs634777"
+      }
     }
   },
 
   {
-    "path": "androidx/media/media/1.0.0/media-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "86e15c4ec92837de49486f1ad9827d689a6186d8",
-      "sha256": "04blvk2wipmqznwd4vynsci8ryvp6rxl1c2gvj2asschhkvybpww"
-    },
-    "jar": {
-      "sha1": "7f92bbaf670497a9a1105124122fb20cee61e58c",
-      "sha256": "1vnr1ir0lr673zmxn9vzipl17r1jf4nrirjifi50r1xc5dxm4fxj"
+    "path": "androidx/media/media/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "media-1.0.0.pom": {
+        "sha1": "86e15c4ec92837de49486f1ad9827d689a6186d8",
+        "sha256": "04blvk2wipmqznwd4vynsci8ryvp6rxl1c2gvj2asschhkvybpww"
+      },
+      "media-1.0.0.aar": {
+        "sha1": "7f92bbaf670497a9a1105124122fb20cee61e58c",
+        "sha256": "1vnr1ir0lr673zmxn9vzipl17r1jf4nrirjifi50r1xc5dxm4fxj"
+      }
     }
   },
 
   {
-    "path": "androidx/multidex/multidex/2.0.1/multidex-2.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "afb1726bf3ab700c7a2147342125a69812bf1c95",
-      "sha256": "0vqhya9q5ri6zh0w8dhrh0rbhirl6rwdnyq7g1kd34jjzlybc40g"
-    },
-    "jar": {
-      "sha1": "c5c10c06f82ec4b4fcccc5ee4ea64ecc48254f33",
-      "sha256": "02fvjck77q1c65j8jcmsnjvqmxkhilx0081ap1qmgy4pkzzk5pa2"
+    "path": "androidx/multidex/multidex/2.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "multidex-2.0.1.pom": {
+        "sha1": "afb1726bf3ab700c7a2147342125a69812bf1c95",
+        "sha256": "0vqhya9q5ri6zh0w8dhrh0rbhirl6rwdnyq7g1kd34jjzlybc40g"
+      },
+      "multidex-2.0.1.aar": {
+        "sha1": "c5c10c06f82ec4b4fcccc5ee4ea64ecc48254f33",
+        "sha256": "02fvjck77q1c65j8jcmsnjvqmxkhilx0081ap1qmgy4pkzzk5pa2"
+      }
     }
   },
 
   {
-    "path": "androidx/print/print/1.0.0/print-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f0031001c95427f3e6a85661f5c3560131ef8145",
-      "sha256": "19qaagjkpzm41c59zjkxnyisc85knxnbnslrpcjfw6w4jh2jqj32"
-    },
-    "jar": {
-      "sha1": "7722094652c48ebe27acc94d74a55e759e4635ff",
-      "sha256": "1pcybl6ikr6qdn18frrrngdll2pb24pdfgrpzihsdfx16lqpyp0x"
+    "path": "androidx/print/print/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "print-1.0.0.pom": {
+        "sha1": "f0031001c95427f3e6a85661f5c3560131ef8145",
+        "sha256": "19qaagjkpzm41c59zjkxnyisc85knxnbnslrpcjfw6w4jh2jqj32"
+      },
+      "print-1.0.0.aar": {
+        "sha1": "7722094652c48ebe27acc94d74a55e759e4635ff",
+        "sha256": "1pcybl6ikr6qdn18frrrngdll2pb24pdfgrpzihsdfx16lqpyp0x"
+      }
     }
   },
 
   {
-    "path": "androidx/recyclerview/recyclerview/1.0.0/recyclerview-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f703fc85e864a92fb72e4bd5996b8024a824e20a",
-      "sha256": "0siyn9zmprspkjz3fwylyqyc1s5j8yry9xi51ilskdps2xjc0cc8"
-    },
-    "jar": {
-      "sha1": "ee3a2ad35bcfa91ab9eeebe991b0893ab40009cf",
-      "sha256": "0j25mc0jfdgzw541icbvjns63aj29fd4ch1bkp52fh01mjqnz586"
+    "path": "androidx/recyclerview/recyclerview/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "recyclerview-1.0.0.pom": {
+        "sha1": "f703fc85e864a92fb72e4bd5996b8024a824e20a",
+        "sha256": "0siyn9zmprspkjz3fwylyqyc1s5j8yry9xi51ilskdps2xjc0cc8"
+      },
+      "recyclerview-1.0.0.aar": {
+        "sha1": "ee3a2ad35bcfa91ab9eeebe991b0893ab40009cf",
+        "sha256": "0j25mc0jfdgzw541icbvjns63aj29fd4ch1bkp52fh01mjqnz586"
+      }
     }
   },
 
   {
-    "path": "androidx/recyclerview/recyclerview/1.1.0/recyclerview-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "a058fa06eb843f4ef55d18eea26c0afb7b39213e",
-      "sha256": "1vvjv72dgmb8jxr05544wni891scaqvi36mkqawniqg4lri10cpy"
-    },
-    "jar": {
-      "sha1": "8b4f97752ddcbc712af46d208aebd46585cde63b",
-      "sha256": "0kvsvqlfqh8w9qfmmlfx4lwmdww1d9ijpvvk3hdyx48agnkbblph"
+    "path": "androidx/recyclerview/recyclerview/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "recyclerview-1.1.0.pom": {
+        "sha1": "a058fa06eb843f4ef55d18eea26c0afb7b39213e",
+        "sha256": "1vvjv72dgmb8jxr05544wni891scaqvi36mkqawniqg4lri10cpy"
+      },
+      "recyclerview-1.1.0.aar": {
+        "sha1": "8b4f97752ddcbc712af46d208aebd46585cde63b",
+        "sha256": "0kvsvqlfqh8w9qfmmlfx4lwmdww1d9ijpvvk3hdyx48agnkbblph"
+      }
     }
   },
 
   {
-    "path": "androidx/savedstate/savedstate/1.0.0/savedstate-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "3efaae1f3b3dc6c389a390ef716ede40ec63ef06",
-      "sha256": "0z6yiwznp9wslahfxx9nh6nrrv48myfj4nampxw8qygazhi7skc4"
-    },
-    "jar": {
-      "sha1": "6d39721808cd67e3d3d0d60f194907615fcaa69c",
-      "sha256": "10rf82xya0cgizx20kpwwbzx0g1jmzx78id0w6f9qmrpkihsa415"
+    "path": "androidx/savedstate/savedstate/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "savedstate-1.0.0.pom": {
+        "sha1": "3efaae1f3b3dc6c389a390ef716ede40ec63ef06",
+        "sha256": "0z6yiwznp9wslahfxx9nh6nrrv48myfj4nampxw8qygazhi7skc4"
+      },
+      "savedstate-1.0.0.aar": {
+        "sha1": "6d39721808cd67e3d3d0d60f194907615fcaa69c",
+        "sha256": "10rf82xya0cgizx20kpwwbzx0g1jmzx78id0w6f9qmrpkihsa415"
+      }
     }
   },
 
   {
-    "path": "androidx/savedstate/savedstate/1.1.0/savedstate-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "a1223b1e7d6c7a4a351376c3756eb44816346178",
-      "sha256": "1p5ngp5q79p35p7rlz5sdp5aav8c5y3km0kx2gwbk6s9rdslny29"
-    },
-    "jar": {
-      "sha1": "8d4785f699f93e4020b185e2b7de37cb1f58753c",
-      "sha256": "1dv31alvx704bjmid045ckba5l5lssk7iijxgjhq7060q92bw2yn"
+    "path": "androidx/savedstate/savedstate/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "savedstate-1.1.0.pom": {
+        "sha1": "a1223b1e7d6c7a4a351376c3756eb44816346178",
+        "sha256": "1p5ngp5q79p35p7rlz5sdp5aav8c5y3km0kx2gwbk6s9rdslny29"
+      },
+      "savedstate-1.1.0.aar": {
+        "sha1": "8d4785f699f93e4020b185e2b7de37cb1f58753c",
+        "sha256": "1dv31alvx704bjmid045ckba5l5lssk7iijxgjhq7060q92bw2yn"
+      }
     }
   },
 
   {
-    "path": "androidx/slidingpanelayout/slidingpanelayout/1.0.0/slidingpanelayout-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "aa7576cffbc8658b758a4b5e0f80dfc44e7af8d4",
-      "sha256": "0nvln02r4g9d85g6k37cghw9y1370x083caimdb82alchfb0zsa0"
-    },
-    "jar": {
-      "sha1": "37eba9ccbf09b75cc4aa78a5e182d5b8ba79ad6a",
-      "sha256": "1ppf1aryvj014kb4dxx9q0kkwbsns7d04w41v2a0fy5zxxygpgvn"
+    "path": "androidx/slidingpanelayout/slidingpanelayout/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "slidingpanelayout-1.0.0.pom": {
+        "sha1": "aa7576cffbc8658b758a4b5e0f80dfc44e7af8d4",
+        "sha256": "0nvln02r4g9d85g6k37cghw9y1370x083caimdb82alchfb0zsa0"
+      },
+      "slidingpanelayout-1.0.0.aar": {
+        "sha1": "37eba9ccbf09b75cc4aa78a5e182d5b8ba79ad6a",
+        "sha256": "1ppf1aryvj014kb4dxx9q0kkwbsns7d04w41v2a0fy5zxxygpgvn"
+      }
     }
   },
 
   {
-    "path": "androidx/swiperefreshlayout/swiperefreshlayout/1.0.0/swiperefreshlayout-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "96828e94bba119dabf4bff993f79f2fa45351efa",
-      "sha256": "16c2x9aa9b7d02v3lk8i72z7gnbahvp739cvi7g3rwra6gdvbr4g"
-    },
-    "jar": {
-      "sha1": "4fd265b80a2b0fbeb062ab2bc4b1487521507762",
-      "sha256": "13bf0brs7wn9kd0xmjdmjl7fqvbm8p3bpi530vyr7c6916lb6qcp"
+    "path": "androidx/swiperefreshlayout/swiperefreshlayout/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "swiperefreshlayout-1.0.0.pom": {
+        "sha1": "96828e94bba119dabf4bff993f79f2fa45351efa",
+        "sha256": "16c2x9aa9b7d02v3lk8i72z7gnbahvp739cvi7g3rwra6gdvbr4g"
+      },
+      "swiperefreshlayout-1.0.0.aar": {
+        "sha1": "4fd265b80a2b0fbeb062ab2bc4b1487521507762",
+        "sha256": "13bf0brs7wn9kd0xmjdmjl7fqvbm8p3bpi530vyr7c6916lb6qcp"
+      }
     }
   },
 
   {
-    "path": "androidx/swiperefreshlayout/swiperefreshlayout/1.1.0/swiperefreshlayout-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "73f3b16b59f1a72ad4a71424490e2340d6acce19",
-      "sha256": "1b94zn7vywczzvciqdx7f1gfzq769c4nv2m97cl5l58hd775b30b"
-    },
-    "jar": {
-      "sha1": "2aeac64056fe6cc0420afad0b699a7f9257b8ebe",
-      "sha256": "14vjnbv61g28v1x55ci1bb05j8rqahnv4pcph7n5m86ys5n91rrc"
+    "path": "androidx/swiperefreshlayout/swiperefreshlayout/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "swiperefreshlayout-1.1.0.pom": {
+        "sha1": "73f3b16b59f1a72ad4a71424490e2340d6acce19",
+        "sha256": "1b94zn7vywczzvciqdx7f1gfzq769c4nv2m97cl5l58hd775b30b"
+      },
+      "swiperefreshlayout-1.1.0.aar": {
+        "sha1": "2aeac64056fe6cc0420afad0b699a7f9257b8ebe",
+        "sha256": "14vjnbv61g28v1x55ci1bb05j8rqahnv4pcph7n5m86ys5n91rrc"
+      }
     }
   },
 
   {
-    "path": "androidx/tracing/tracing/1.0.0/tracing-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "8699319903509b20b3ffa718d36b742fd11493c0",
-      "sha256": "0pm0kjjpxdylykckzqjzs1q1mg2dbx8gfpzv3j7xf8271nlrj0nd"
-    },
-    "jar": {
-      "sha1": "69cef34711dffbc517e7a0a419ec4a98f84f496a",
-      "sha256": "04l6arxlzq4a2qjvycqjhdb7y3x53j4rgkzccahq9f35jq9vdf07"
+    "path": "androidx/tracing/tracing/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracing-1.0.0.pom": {
+        "sha1": "8699319903509b20b3ffa718d36b742fd11493c0",
+        "sha256": "0pm0kjjpxdylykckzqjzs1q1mg2dbx8gfpzv3j7xf8271nlrj0nd"
+      },
+      "tracing-1.0.0.aar": {
+        "sha1": "69cef34711dffbc517e7a0a419ec4a98f84f496a",
+        "sha256": "04l6arxlzq4a2qjvycqjhdb7y3x53j4rgkzccahq9f35jq9vdf07"
+      }
     }
   },
 
   {
-    "path": "androidx/transition/transition/1.0.0/transition-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "cba38d22419c84dcf737d666ae0c980f1e521e65",
-      "sha256": "12v826hkvgrm3hzf3x5il92x50gan60gz7x47cq2ykn97ag8ljz7"
-    },
-    "jar": {
-      "sha1": "f3556ce8f251984acb24014c3ba055ff235929ff",
-      "sha256": "1380yk8978c19d0rl6hi3f0caac9fg5sy3lvvbnbq6j07xv0y2m0"
+    "path": "androidx/transition/transition/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "transition-1.0.0.pom": {
+        "sha1": "cba38d22419c84dcf737d666ae0c980f1e521e65",
+        "sha256": "12v826hkvgrm3hzf3x5il92x50gan60gz7x47cq2ykn97ag8ljz7"
+      },
+      "transition-1.0.0.aar": {
+        "sha1": "f3556ce8f251984acb24014c3ba055ff235929ff",
+        "sha256": "1380yk8978c19d0rl6hi3f0caac9fg5sy3lvvbnbq6j07xv0y2m0"
+      }
     }
   },
 
   {
-    "path": "androidx/transition/transition/1.2.0-rc01/transition-1.2.0-rc01",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "7fe296c768d13fdd86a0dcd5e15083d5b6f5290f",
-      "sha256": "1gkxz4mfa6pb5k5dz6j9hbpx1kkgp9sf33r6wcxcqg74nyn7jpd4"
-    },
-    "jar": {
-      "sha1": "40bdbe5a245edd0393b7b0e1d9dd6c446dd9008d",
-      "sha256": "1fkfzqnppj6ky7d7i42n2hjyhrlll26b5cmik85qfzqq42b1zrbj"
+    "path": "androidx/transition/transition/1.2.0-rc01",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "transition-1.2.0-rc01.pom": {
+        "sha1": "7fe296c768d13fdd86a0dcd5e15083d5b6f5290f",
+        "sha256": "1gkxz4mfa6pb5k5dz6j9hbpx1kkgp9sf33r6wcxcqg74nyn7jpd4"
+      },
+      "transition-1.2.0-rc01.aar": {
+        "sha1": "40bdbe5a245edd0393b7b0e1d9dd6c446dd9008d",
+        "sha256": "1fkfzqnppj6ky7d7i42n2hjyhrlll26b5cmik85qfzqq42b1zrbj"
+      }
     }
   },
 
   {
-    "path": "androidx/transition/transition/1.2.0/transition-1.2.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "1ceda042cf551bdede6fdb82adeda0cb6a9b63d2",
-      "sha256": "1q8dsakkw11db264dc37zv3nq09wr0qzsicl0rmp1gfag9si4zr4"
-    },
-    "jar": {
-      "sha1": "28003577e8b32f5417bfe899bbdc7a333dc81c9f",
-      "sha256": "0zhmagl4cv35ysn5psjjlnyd50lwm35cvzhfxj6sahqbpjrmkq51"
+    "path": "androidx/transition/transition/1.2.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "transition-1.2.0.pom": {
+        "sha1": "1ceda042cf551bdede6fdb82adeda0cb6a9b63d2",
+        "sha256": "1q8dsakkw11db264dc37zv3nq09wr0qzsicl0rmp1gfag9si4zr4"
+      },
+      "transition-1.2.0.aar": {
+        "sha1": "28003577e8b32f5417bfe899bbdc7a333dc81c9f",
+        "sha256": "0zhmagl4cv35ysn5psjjlnyd50lwm35cvzhfxj6sahqbpjrmkq51"
+      }
     }
   },
 
   {
-    "path": "androidx/vectordrawable/vectordrawable-animated/1.0.0/vectordrawable-animated-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "539d391719865644a3003742c0b3537d9ed4fc73",
-      "sha256": "0znl6zrk43brmcwrmvqqp70s5dx4zqfqzh3cjrgkl5mmvvmawinn"
-    },
-    "jar": {
-      "sha1": "0a41681ac4e1747f87237e489699089ad46b7a5e",
-      "sha256": "1wbc4cnbbd4hgkmy6l97jpcm47a3gvrz400bb8ipv6ls1b7s1hr6"
+    "path": "androidx/vectordrawable/vectordrawable-animated/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "vectordrawable-animated-1.0.0.pom": {
+        "sha1": "539d391719865644a3003742c0b3537d9ed4fc73",
+        "sha256": "0znl6zrk43brmcwrmvqqp70s5dx4zqfqzh3cjrgkl5mmvvmawinn"
+      },
+      "vectordrawable-animated-1.0.0.aar": {
+        "sha1": "0a41681ac4e1747f87237e489699089ad46b7a5e",
+        "sha256": "1wbc4cnbbd4hgkmy6l97jpcm47a3gvrz400bb8ipv6ls1b7s1hr6"
+      }
     }
   },
 
   {
-    "path": "androidx/vectordrawable/vectordrawable-animated/1.1.0/vectordrawable-animated-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "2c40e16427f4e94ea471526868ba5ac4bd13de6d",
-      "sha256": "1ga0l1hbl7l1f8j27yvm4frx6vvgqnb99vh3j1dvfpvhdc8j0si7"
-    },
-    "jar": {
-      "sha1": "fcda1161354501471c30a4e077af6b5c4d4eddc6",
-      "sha256": "1y034igcx1xf7qvg6n6hks08gnh0ilj2npnzaj0c7nbi4d82rnkn"
+    "path": "androidx/vectordrawable/vectordrawable-animated/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "vectordrawable-animated-1.1.0.pom": {
+        "sha1": "2c40e16427f4e94ea471526868ba5ac4bd13de6d",
+        "sha256": "1ga0l1hbl7l1f8j27yvm4frx6vvgqnb99vh3j1dvfpvhdc8j0si7"
+      },
+      "vectordrawable-animated-1.1.0.aar": {
+        "sha1": "fcda1161354501471c30a4e077af6b5c4d4eddc6",
+        "sha256": "1y034igcx1xf7qvg6n6hks08gnh0ilj2npnzaj0c7nbi4d82rnkn"
+      }
     }
   },
 
   {
-    "path": "androidx/vectordrawable/vectordrawable/1.0.0/vectordrawable-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "ba44dcbfcb2c76959be21748e8b1a1e99712df85",
-      "sha256": "1an86x0richy743ww58mljvviq6mx6glpwmwcbhqzp2l53m6zdnp"
-    },
-    "jar": {
-      "sha1": "eabb75f549c6a6ee4011e15adf04bf8ca33d3762",
-      "sha256": "039jwwm1v9dp18pw1dar8xbv88zk6li2fikc1qx5x1w3cn992xah"
+    "path": "androidx/vectordrawable/vectordrawable/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "vectordrawable-1.0.0.pom": {
+        "sha1": "ba44dcbfcb2c76959be21748e8b1a1e99712df85",
+        "sha256": "1an86x0richy743ww58mljvviq6mx6glpwmwcbhqzp2l53m6zdnp"
+      },
+      "vectordrawable-1.0.0.aar": {
+        "sha1": "eabb75f549c6a6ee4011e15adf04bf8ca33d3762",
+        "sha256": "039jwwm1v9dp18pw1dar8xbv88zk6li2fikc1qx5x1w3cn992xah"
+      }
     }
   },
 
   {
-    "path": "androidx/vectordrawable/vectordrawable/1.0.1/vectordrawable-1.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "6ab5c68ce5a36e8044716b976517566fb8ff7ae6",
-      "sha256": "1v170ci8jcv4sr2h8ib07050j194icl7mbcnviyr1d0n0xwafzva"
-    },
-    "jar": {
-      "sha1": "33d1eb71849dffbad12add134a25eb63cad4a1eb",
-      "sha256": "1ljyf6gymbz9hhcygrmz0va5bmn26ffirq48qcpya44mgfami8sc"
+    "path": "androidx/vectordrawable/vectordrawable/1.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "vectordrawable-1.0.1.pom": {
+        "sha1": "6ab5c68ce5a36e8044716b976517566fb8ff7ae6",
+        "sha256": "1v170ci8jcv4sr2h8ib07050j194icl7mbcnviyr1d0n0xwafzva"
+      },
+      "vectordrawable-1.0.1.aar": {
+        "sha1": "33d1eb71849dffbad12add134a25eb63cad4a1eb",
+        "sha256": "1ljyf6gymbz9hhcygrmz0va5bmn26ffirq48qcpya44mgfami8sc"
+      }
     }
   },
 
   {
-    "path": "androidx/vectordrawable/vectordrawable/1.1.0/vectordrawable-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "8b15e03d94f7d9a07cbea653ad7f524315d1d507",
-      "sha256": "1cib94wwskg9haj7v9amvlfmwfs7bz723g2wg024irbr45djs3jv"
-    },
-    "jar": {
-      "sha1": "eac7a364fff534035a2a6cb17770a1288315f69f",
-      "sha256": "09lfvw1gn16avi726kbpd6d9x2ssih4vyqy2mgybfj8vq0x67za6"
+    "path": "androidx/vectordrawable/vectordrawable/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "vectordrawable-1.1.0.pom": {
+        "sha1": "8b15e03d94f7d9a07cbea653ad7f524315d1d507",
+        "sha256": "1cib94wwskg9haj7v9amvlfmwfs7bz723g2wg024irbr45djs3jv"
+      },
+      "vectordrawable-1.1.0.aar": {
+        "sha1": "eac7a364fff534035a2a6cb17770a1288315f69f",
+        "sha256": "09lfvw1gn16avi726kbpd6d9x2ssih4vyqy2mgybfj8vq0x67za6"
+      }
     }
   },
 
   {
-    "path": "androidx/versionedparcelable/versionedparcelable/1.0.0/versionedparcelable-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "198bc6d7ad619b76e317edcec0fdc71343d387a6",
-      "sha256": "085kzd7nw26xjaxxfi6ql8w8xazavv5104xqiwgnb6i38daprvj7"
-    },
-    "jar": {
-      "sha1": "52718baf7e51ccba173b468a1034caba8140752e",
-      "sha256": "1qqw5vnqzyc45x3s3njf8bh1008bprq0l50frbfwq5l0xn9qlhzn"
+    "path": "androidx/versionedparcelable/versionedparcelable/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "versionedparcelable-1.0.0.pom": {
+        "sha1": "198bc6d7ad619b76e317edcec0fdc71343d387a6",
+        "sha256": "085kzd7nw26xjaxxfi6ql8w8xazavv5104xqiwgnb6i38daprvj7"
+      },
+      "versionedparcelable-1.0.0.aar": {
+        "sha1": "52718baf7e51ccba173b468a1034caba8140752e",
+        "sha256": "1qqw5vnqzyc45x3s3njf8bh1008bprq0l50frbfwq5l0xn9qlhzn"
+      }
     }
   },
 
   {
-    "path": "androidx/versionedparcelable/versionedparcelable/1.1.0/versionedparcelable-1.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5860ab66f74bffbfcfd51883ddabd477a0b80dc8",
-      "sha256": "1dakq8yjjfxx8jd0h8csg4xx9nvrdrk61m19m2yj6qy01jzcfaf7"
-    },
-    "jar": {
-      "sha1": "91acce73e00a17b524f6697f6c3893efb8ea349f",
-      "sha256": "1h8hnymlblgxdbflcbgdhw4q1hcv2myywm2hdf3bf8n218a7f7cs"
+    "path": "androidx/versionedparcelable/versionedparcelable/1.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "versionedparcelable-1.1.0.pom": {
+        "sha1": "5860ab66f74bffbfcfd51883ddabd477a0b80dc8",
+        "sha256": "1dakq8yjjfxx8jd0h8csg4xx9nvrdrk61m19m2yj6qy01jzcfaf7"
+      },
+      "versionedparcelable-1.1.0.aar": {
+        "sha1": "91acce73e00a17b524f6697f6c3893efb8ea349f",
+        "sha256": "1h8hnymlblgxdbflcbgdhw4q1hcv2myywm2hdf3bf8n218a7f7cs"
+      }
     }
   },
 
   {
-    "path": "androidx/versionedparcelable/versionedparcelable/1.1.1/versionedparcelable-1.1.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "301263729256e9f19b144ce00f83d600ba14c38b",
-      "sha256": "0byvbihlvycvl68c7f9izl7093avx4p0vacghgijsqfafdcfclaz"
-    },
-    "jar": {
-      "sha1": "18e18071e7715679e0593c570217edeb5ca48b9e",
-      "sha256": "191m8m8vsz1l9b3vz7k0r28dwnfi9b3d7vn90y85p3fic0rdks2p"
+    "path": "androidx/versionedparcelable/versionedparcelable/1.1.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "versionedparcelable-1.1.1.pom": {
+        "sha1": "301263729256e9f19b144ce00f83d600ba14c38b",
+        "sha256": "0byvbihlvycvl68c7f9izl7093avx4p0vacghgijsqfafdcfclaz"
+      },
+      "versionedparcelable-1.1.1.aar": {
+        "sha1": "18e18071e7715679e0593c570217edeb5ca48b9e",
+        "sha256": "191m8m8vsz1l9b3vz7k0r28dwnfi9b3d7vn90y85p3fic0rdks2p"
+      }
     }
   },
 
   {
-    "path": "androidx/viewpager2/viewpager2/1.0.0/viewpager2-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "6c206c3aa4ba7917be9ccf200e11aa83caf01c50",
-      "sha256": "0ym113vcfcn446nd72jr901dl0hfw5xgjs21iz4nbzllzskvqqs0"
-    },
-    "jar": {
-      "sha1": "91c378a09ddff66e1bb73e90edeac53487d2832b",
-      "sha256": "1bvm08rj02f9lzz5mf3rki6ybknjb1z2iilnh7a7q96cshqh0p79"
+    "path": "androidx/viewpager2/viewpager2/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "viewpager2-1.0.0.pom": {
+        "sha1": "6c206c3aa4ba7917be9ccf200e11aa83caf01c50",
+        "sha256": "0ym113vcfcn446nd72jr901dl0hfw5xgjs21iz4nbzllzskvqqs0"
+      },
+      "viewpager2-1.0.0.aar": {
+        "sha1": "91c378a09ddff66e1bb73e90edeac53487d2832b",
+        "sha256": "1bvm08rj02f9lzz5mf3rki6ybknjb1z2iilnh7a7q96cshqh0p79"
+      }
     }
   },
 
   {
-    "path": "androidx/viewpager/viewpager/1.0.0/viewpager-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "42452223b3d46c0e3bf2c67f226144ce64551be9",
-      "sha256": "0a1i4mfkljppjm7yny3maxd0g1yafrg0fr9z07mwc0wx6cvghwhz"
-    },
-    "jar": {
-      "sha1": "1f90e13820f96c2fb868f9674079a551678d68b2",
-      "sha256": "10l6zjw2i16iw2l05vfzf0fkrw41swcmwphmiw6h310r9bhz8yhl"
+    "path": "androidx/viewpager/viewpager/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "viewpager-1.0.0.pom": {
+        "sha1": "42452223b3d46c0e3bf2c67f226144ce64551be9",
+        "sha256": "0a1i4mfkljppjm7yny3maxd0g1yafrg0fr9z07mwc0wx6cvghwhz"
+      },
+      "viewpager-1.0.0.aar": {
+        "sha1": "1f90e13820f96c2fb868f9674079a551678d68b2",
+        "sha256": "10l6zjw2i16iw2l05vfzf0fkrw41swcmwphmiw6h310r9bhz8yhl"
+      }
     }
   },
 
   {
-    "path": "androidx/webkit/webkit/1.4.0/webkit-1.4.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c67e70da5ad98b587cc030a053e3eb45b57ae2a6",
-      "sha256": "0pdmx702dmx83q6svafk1vyac9fnlbz0szxwg4ax9fnlzvc12mfb"
-    },
-    "jar": {
-      "sha1": "48e4cd9c63f7dc9fc62631d8dfbb77e890b459aa",
-      "sha256": "15wip2fimx1xpdv6mwdyn2wsd2yfh9kbfrjkv9rdwlhkmh5b448s"
+    "path": "androidx/webkit/webkit/1.4.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "webkit-1.4.0.pom": {
+        "sha1": "c67e70da5ad98b587cc030a053e3eb45b57ae2a6",
+        "sha256": "0pdmx702dmx83q6svafk1vyac9fnlbz0szxwg4ax9fnlzvc12mfb"
+      },
+      "webkit-1.4.0.aar": {
+        "sha1": "48e4cd9c63f7dc9fc62631d8dfbb77e890b459aa",
+        "sha256": "15wip2fimx1xpdv6mwdyn2wsd2yfh9kbfrjkv9rdwlhkmh5b448s"
+      }
     }
   },
 
   {
-    "path": "android/arch/core/common/1.0.0/common-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "914227d3f5f7829f1677917b5438dd64984fac3f",
-      "sha256": "0ph3sysddlxxj7sh9d4wf9nnrg7mpykvh1wvrraxr23w9ghspam2"
-    },
-    "jar": {
-      "sha1": "a2d487452376193fc8c103dd2b9bd5f2b1b44563",
-      "sha256": "1qbl9vxq06nx20007bn9msx91pld93ydfbkj2ln2xwrxsx6974ji"
+    "path": "android/arch/core/common/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-1.0.0.pom": {
+        "sha1": "914227d3f5f7829f1677917b5438dd64984fac3f",
+        "sha256": "0ph3sysddlxxj7sh9d4wf9nnrg7mpykvh1wvrraxr23w9ghspam2"
+      },
+      "common-1.0.0.jar": {
+        "sha1": "a2d487452376193fc8c103dd2b9bd5f2b1b44563",
+        "sha256": "1qbl9vxq06nx20007bn9msx91pld93ydfbkj2ln2xwrxsx6974ji"
+      }
     }
   },
 
   {
-    "path": "android/arch/lifecycle/common/1.0.0/common-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c026e9d477378c67e6de0b5775a79672d68383de",
-      "sha256": "1r1yf086gzwr2v45yw3xk2yma5l54rxcpvznr771b0qm5kkj8bnq"
-    },
-    "jar": {
-      "sha1": "e414a4cb28434e25c4f6aa71426eb20cf4874ae9",
-      "sha256": "08ci46rm43gxm4zj70zzjv07a1grzgk54ap2j6ix035d40d31gw6"
+    "path": "android/arch/lifecycle/common/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-1.0.0.pom": {
+        "sha1": "c026e9d477378c67e6de0b5775a79672d68383de",
+        "sha256": "1r1yf086gzwr2v45yw3xk2yma5l54rxcpvznr771b0qm5kkj8bnq"
+      },
+      "common-1.0.0.jar": {
+        "sha1": "e414a4cb28434e25c4f6aa71426eb20cf4874ae9",
+        "sha256": "08ci46rm43gxm4zj70zzjv07a1grzgk54ap2j6ix035d40d31gw6"
+      }
     }
   },
 
   {
-    "path": "android/arch/lifecycle/runtime/1.0.0/runtime-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "1404cc3858b2271ca32a6f5259e8ea056d5f23b0",
-      "sha256": "0wds9hakp1wpi638mw42ia5rvbbr1z3w75qavbzf1kckd06jas9k"
-    },
-    "jar": {
-      "sha1": "30c60a8a357ee1321ffd0c9f08ef54b24045cd10",
-      "sha256": "1n4sa14ar5l14c13v6b7wdhmm8fqxbwjkg6x766jw45x09flxqz4"
+    "path": "android/arch/lifecycle/runtime/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "runtime-1.0.0.pom": {
+        "sha1": "1404cc3858b2271ca32a6f5259e8ea056d5f23b0",
+        "sha256": "0wds9hakp1wpi638mw42ia5rvbbr1z3w75qavbzf1kckd06jas9k"
+      },
+      "runtime-1.0.0.aar": {
+        "sha1": "30c60a8a357ee1321ffd0c9f08ef54b24045cd10",
+        "sha256": "1n4sa14ar5l14c13v6b7wdhmm8fqxbwjkg6x766jw45x09flxqz4"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.0.0/baseLibrary-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4a8ee25298c652798f2bd8a1d1aab5e943b9d601",
-      "sha256": "150bmgklpfinmsrlcg9s426pg9vs9szl1xdhz9vjmfdf6q2jpq1g"
-    },
-    "jar": {
-      "sha1": "223fbb31236b0714328c415c1475fc8f55a4416e",
-      "sha256": "18j8j2mlzg1crqk31529y8qgx0bdhr98bf8vfq6rsvv3rn49f7rf"
+    "path": "com/android/databinding/baseLibrary/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "baseLibrary-3.0.0.pom": {
+        "sha1": "4a8ee25298c652798f2bd8a1d1aab5e943b9d601",
+        "sha256": "150bmgklpfinmsrlcg9s426pg9vs9szl1xdhz9vjmfdf6q2jpq1g"
+      },
+      "baseLibrary-3.0.0.jar": {
+        "sha1": "223fbb31236b0714328c415c1475fc8f55a4416e",
+        "sha256": "18j8j2mlzg1crqk31529y8qgx0bdhr98bf8vfq6rsvv3rn49f7rf"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.0.1/baseLibrary-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "270fb083c20514f1fe06795051dafeb48762678d",
-      "sha256": "0lflcv6vcd4rmxwmq2qr6g2zgk7iimi8pg5ch5bg32z35qzhp1wb"
-    },
-    "jar": {
-      "sha1": "cc0483d84342e82c261aeb5fd0ef2f876b587489",
-      "sha256": "00b0cbxyl5lym35ncfrq4b181lpvabp21r8w3fldz3g91mnr130z"
+    "path": "com/android/databinding/baseLibrary/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "baseLibrary-3.0.1.pom": {
+        "sha1": "270fb083c20514f1fe06795051dafeb48762678d",
+        "sha256": "0lflcv6vcd4rmxwmq2qr6g2zgk7iimi8pg5ch5bg32z35qzhp1wb"
+      },
+      "baseLibrary-3.0.1.jar": {
+        "sha1": "cc0483d84342e82c261aeb5fd0ef2f876b587489",
+        "sha256": "00b0cbxyl5lym35ncfrq4b181lpvabp21r8w3fldz3g91mnr130z"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.1.4/baseLibrary-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b48baeaef73d7763fa92b847c4140f0e0ff71d99",
-      "sha256": "16c6wpphs4b8373w7jdiynv48lgl8sj8sy5gp16cf3qgqgmai4qv"
-    },
-    "jar": {
-      "sha1": "df1e7638ba852152abe964e86f60fa4ce12e6a6a",
-      "sha256": "0cn50bas33hndr7snlgwpj4vgr66dazkg7ybb04hgc0czdgl9adb"
+    "path": "com/android/databinding/baseLibrary/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "baseLibrary-3.1.4.pom": {
+        "sha1": "b48baeaef73d7763fa92b847c4140f0e0ff71d99",
+        "sha256": "16c6wpphs4b8373w7jdiynv48lgl8sj8sy5gp16cf3qgqgmai4qv"
+      },
+      "baseLibrary-3.1.4.jar": {
+        "sha1": "df1e7638ba852152abe964e86f60fa4ce12e6a6a",
+        "sha256": "0cn50bas33hndr7snlgwpj4vgr66dazkg7ybb04hgc0czdgl9adb"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.2.1/baseLibrary-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6c8596d33ec70bc00aeb92c6740a74c627be9693",
-      "sha256": "0gnk3050z33zs6s6krim68jdz7nl27shzv6gpkr2cwhvsvvdczkh"
-    },
-    "jar": {
-      "sha1": "62174ecf31e2e3e4dd7a21cbd05399e11d0a9699",
-      "sha256": "17rbz1j3ghg759fc6iq4p5pq0qkw8crcb7s136by904fli1kv6g6"
+    "path": "com/android/databinding/baseLibrary/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "baseLibrary-3.2.1.pom": {
+        "sha1": "6c8596d33ec70bc00aeb92c6740a74c627be9693",
+        "sha256": "0gnk3050z33zs6s6krim68jdz7nl27shzv6gpkr2cwhvsvvdczkh"
+      },
+      "baseLibrary-3.2.1.jar": {
+        "sha1": "62174ecf31e2e3e4dd7a21cbd05399e11d0a9699",
+        "sha256": "17rbz1j3ghg759fc6iq4p5pq0qkw8crcb7s136by904fli1kv6g6"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.3.1/baseLibrary-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "611fd96b47fdd27dd88afc23829975278d47774c",
-      "sha256": "0gsjcyw0fgdpsc4b2sr97rlx0q0yq9pj113ck4qs3cvvn2hx18kl"
-    },
-    "jar": {
-      "sha1": "702acc804e85563d3ae7b8ee49122e4f857dde83",
-      "sha256": "1i7998y6zilww6v3yg5q06bnr30b22s9dbxha02rvm39m8974175"
+    "path": "com/android/databinding/baseLibrary/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "baseLibrary-3.3.1.pom": {
+        "sha1": "611fd96b47fdd27dd88afc23829975278d47774c",
+        "sha256": "0gsjcyw0fgdpsc4b2sr97rlx0q0yq9pj113ck4qs3cvvn2hx18kl"
+      },
+      "baseLibrary-3.3.1.jar": {
+        "sha1": "702acc804e85563d3ae7b8ee49122e4f857dde83",
+        "sha256": "1i7998y6zilww6v3yg5q06bnr30b22s9dbxha02rvm39m8974175"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.5.4/baseLibrary-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "86ef5c0145af0c31feca51140da31655c96d8d57",
-      "sha256": "0p6sbzn5s00jk3ffiblrhfh6sky9gx4rki102r15qg9bpspy5rqm"
-    },
-    "jar": {
-      "sha1": "8d6e308beba7242cdae35cf4fd27e642d9c973ca",
-      "sha256": "1swgsnrsqw9f31ca0sdrpl1vyn7h4w6h4mhqsgaza3di229v6gi1"
+    "path": "com/android/databinding/baseLibrary/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "baseLibrary-3.5.4.pom": {
+        "sha1": "86ef5c0145af0c31feca51140da31655c96d8d57",
+        "sha256": "0p6sbzn5s00jk3ffiblrhfh6sky9gx4rki102r15qg9bpspy5rqm"
+      },
+      "baseLibrary-3.5.4.jar": {
+        "sha1": "8d6e308beba7242cdae35cf4fd27e642d9c973ca",
+        "sha256": "1swgsnrsqw9f31ca0sdrpl1vyn7h4w6h4mhqsgaza3di229v6gi1"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/compilerCommon/3.0.0/compilerCommon-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6d366470bcc2b81c66400a9c69bcade266cb83aa",
-      "sha256": "04591ic395xxkrvnazik9hfsavh461r2fwsfjv4mjd0riwdmz5kv"
-    },
-    "jar": {
-      "sha1": "243ebf26597dca96c60681106157e27f0762edf9",
-      "sha256": "1bpvsq8jr4hpwa771mha0mx8v9fbn00k9bs7hhizb47phfdxdpg3"
+    "path": "com/android/databinding/compilerCommon/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "compilerCommon-3.0.0.pom": {
+        "sha1": "6d366470bcc2b81c66400a9c69bcade266cb83aa",
+        "sha256": "04591ic395xxkrvnazik9hfsavh461r2fwsfjv4mjd0riwdmz5kv"
+      },
+      "compilerCommon-3.0.0.jar": {
+        "sha1": "243ebf26597dca96c60681106157e27f0762edf9",
+        "sha256": "1bpvsq8jr4hpwa771mha0mx8v9fbn00k9bs7hhizb47phfdxdpg3"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/compilerCommon/3.0.1/compilerCommon-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d312442e8d1fe2271e45bce271150005173a98a0",
-      "sha256": "0ca0d9g04ns60y2vgcrzfcfcplc6b3p8naynzavz0a11jiim99f9"
-    },
-    "jar": {
-      "sha1": "7f51b3e1636063e491131a0b0436512131cb1bdc",
-      "sha256": "0c3g3wz4fbz4ay82a0w2d5yx932gf3p8m037gf21w12b4rf96978"
+    "path": "com/android/databinding/compilerCommon/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "compilerCommon-3.0.1.pom": {
+        "sha1": "d312442e8d1fe2271e45bce271150005173a98a0",
+        "sha256": "0ca0d9g04ns60y2vgcrzfcfcplc6b3p8naynzavz0a11jiim99f9"
+      },
+      "compilerCommon-3.0.1.jar": {
+        "sha1": "7f51b3e1636063e491131a0b0436512131cb1bdc",
+        "sha256": "0c3g3wz4fbz4ay82a0w2d5yx932gf3p8m037gf21w12b4rf96978"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/compilerCommon/3.1.4/compilerCommon-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0fd23d31fe5e40ac6d203734dcc6b16328ba714c",
-      "sha256": "0sb36alvbmxv05amnc02csm73cg6aib8s16fipjlgqri58cn5yd9"
-    },
-    "jar": {
-      "sha1": "11005423fee93309c0cd512a8783647702c20c27",
-      "sha256": "0kxd2js2yk7bisiiy1j5i5zgd9h124qac10dan68y8swiddd4hlb"
+    "path": "com/android/databinding/compilerCommon/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "compilerCommon-3.1.4.pom": {
+        "sha1": "0fd23d31fe5e40ac6d203734dcc6b16328ba714c",
+        "sha256": "0sb36alvbmxv05amnc02csm73cg6aib8s16fipjlgqri58cn5yd9"
+      },
+      "compilerCommon-3.1.4.jar": {
+        "sha1": "11005423fee93309c0cd512a8783647702c20c27",
+        "sha256": "0kxd2js2yk7bisiiy1j5i5zgd9h124qac10dan68y8swiddd4hlb"
+      }
     }
   },
 
   {
-    "path": "com/android/support/animated-vector-drawable/26.0.2/animated-vector-drawable-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b45042835d6565fef6bb45395618ada3c068f082",
-      "sha256": "0r4kh83xgpfkh9470mc0v0vksvsj2vhh0rg2af3fqkffnimc2s8y"
-    },
-    "jar": {
-      "sha1": "b9b56e503d08c4246a30f281e3fe8511c6cfb430",
-      "sha256": "0mpc0w8j2f1l22qrs9z7b27l1hpw1sp0dw51c9kzkrhvyzjqyyia"
+    "path": "com/android/support/animated-vector-drawable/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "animated-vector-drawable-26.0.2.pom": {
+        "sha1": "b45042835d6565fef6bb45395618ada3c068f082",
+        "sha256": "0r4kh83xgpfkh9470mc0v0vksvsj2vhh0rg2af3fqkffnimc2s8y"
+      },
+      "animated-vector-drawable-26.0.2.aar": {
+        "sha1": "b9b56e503d08c4246a30f281e3fe8511c6cfb430",
+        "sha256": "0mpc0w8j2f1l22qrs9z7b27l1hpw1sp0dw51c9kzkrhvyzjqyyia"
+      }
     }
   },
 
   {
-    "path": "com/android/support/animated-vector-drawable/27.0.1/animated-vector-drawable-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "aa9b6a87ba80a1a9c54f352e1f2330445c9279e8",
-      "sha256": "0r4m9vq1293blhxbhsw80bp2jp8zwf3h30dd9dwz217nmqnmighm"
-    },
-    "jar": {
-      "sha1": "09da101c8b10d3f54997b3af65943d4f3256da79",
-      "sha256": "0yspib1ka7az0lchpxk7cvz7ymakmd4in446xiz6rj0i0h8m0l1n"
+    "path": "com/android/support/animated-vector-drawable/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "animated-vector-drawable-27.0.1.pom": {
+        "sha1": "aa9b6a87ba80a1a9c54f352e1f2330445c9279e8",
+        "sha256": "0r4m9vq1293blhxbhsw80bp2jp8zwf3h30dd9dwz217nmqnmighm"
+      },
+      "animated-vector-drawable-27.0.1.aar": {
+        "sha1": "09da101c8b10d3f54997b3af65943d4f3256da79",
+        "sha256": "0yspib1ka7az0lchpxk7cvz7ymakmd4in446xiz6rj0i0h8m0l1n"
+      }
     }
   },
 
   {
-    "path": "com/android/support/appcompat-v7/26.0.2/appcompat-v7-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "58184c7ab6bff1fbc4957f15feff8bf95fc9fafb",
-      "sha256": "0scr1wpvs7m5n1qmj54d9vzj3s7n63sscywa9qyi6py0fmbiqfvb"
-    },
-    "jar": {
-      "sha1": "2950c96bbe00b54626a0b00439e9b1f767518ede",
-      "sha256": "0q0k1j8b30i18bs9fn9sqcg3rzwq83kq6g5q8bfp491fjhbxi7n1"
+    "path": "com/android/support/appcompat-v7/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-v7-26.0.2.pom": {
+        "sha1": "58184c7ab6bff1fbc4957f15feff8bf95fc9fafb",
+        "sha256": "0scr1wpvs7m5n1qmj54d9vzj3s7n63sscywa9qyi6py0fmbiqfvb"
+      },
+      "appcompat-v7-26.0.2.aar": {
+        "sha1": "2950c96bbe00b54626a0b00439e9b1f767518ede",
+        "sha256": "0q0k1j8b30i18bs9fn9sqcg3rzwq83kq6g5q8bfp491fjhbxi7n1"
+      }
     }
   },
 
   {
-    "path": "com/android/support/appcompat-v7/27.0.1/appcompat-v7-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "0b082299e66b082b025f93ca37aa55fbeea4408e",
-      "sha256": "117bw203f0lzcvbbcirsc258jk772ph49341pl4i80n7n5x0siyq"
-    },
-    "jar": {
-      "sha1": "2fc21de3a59a1183bead10473a551e43c6af8cef",
-      "sha256": "0l8qna3ngiywqidxjpbghamv6r8p8qs0dm5745n38c6v96dc40hl"
+    "path": "com/android/support/appcompat-v7/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "appcompat-v7-27.0.1.pom": {
+        "sha1": "0b082299e66b082b025f93ca37aa55fbeea4408e",
+        "sha256": "117bw203f0lzcvbbcirsc258jk772ph49341pl4i80n7n5x0siyq"
+      },
+      "appcompat-v7-27.0.1.aar": {
+        "sha1": "2fc21de3a59a1183bead10473a551e43c6af8cef",
+        "sha256": "0l8qna3ngiywqidxjpbghamv6r8p8qs0dm5745n38c6v96dc40hl"
+      }
     }
   },
 
   {
-    "path": "com/android/support/recyclerview-v7/27.0.1/recyclerview-v7-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "d1e9affc536f1f7adfbd9f00f12448b4b3d03931",
-      "sha256": "00w546bb3yp5apzg38yp92wazp9ryg5vdgzfqmy9shbyw7c9ks8d"
-    },
-    "jar": {
-      "sha1": "a8eb866818e214fe71244b31ffea07dbeac3fc2a",
-      "sha256": "1j8jmc0zm50kfvik5nv5adx5zfaqzk50jzb177r01y3x51ijiblr"
+    "path": "com/android/support/recyclerview-v7/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "recyclerview-v7-27.0.1.pom": {
+        "sha1": "d1e9affc536f1f7adfbd9f00f12448b4b3d03931",
+        "sha256": "00w546bb3yp5apzg38yp92wazp9ryg5vdgzfqmy9shbyw7c9ks8d"
+      },
+      "recyclerview-v7-27.0.1.aar": {
+        "sha1": "a8eb866818e214fe71244b31ffea07dbeac3fc2a",
+        "sha256": "1j8jmc0zm50kfvik5nv5adx5zfaqzk50jzb177r01y3x51ijiblr"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-annotations/26.0.2/support-annotations-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "064ba98589b894a0d04f2b112061befbc77e03fa",
-      "sha256": "1cb4lx0lr1fa8d331v67fg2m02jkvv1j4qij3cwvzdqackprkx65"
-    },
-    "jar": {
-      "sha1": "8b68a849722b44f584e2d68c451c5e3844c10380",
-      "sha256": "1r1qz81cgkjhm826s6a5x5hkm6cq6ldbwj2mk6mkvzab3kp21wij"
+    "path": "com/android/support/support-annotations/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-annotations-26.0.2.pom": {
+        "sha1": "064ba98589b894a0d04f2b112061befbc77e03fa",
+        "sha256": "1cb4lx0lr1fa8d331v67fg2m02jkvv1j4qij3cwvzdqackprkx65"
+      },
+      "support-annotations-26.0.2.jar": {
+        "sha1": "8b68a849722b44f584e2d68c451c5e3844c10380",
+        "sha256": "1r1qz81cgkjhm826s6a5x5hkm6cq6ldbwj2mk6mkvzab3kp21wij"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-annotations/26.1.0/support-annotations-26.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "649798a9fc69aa94d4f31b528d81c05f22e44678",
-      "sha256": "03dray9xascv5glkxx2g2297y57601jnx23p2gx5w5ray3y75biy"
-    },
-    "jar": {
-      "sha1": "0814258103cf26a15fcc26ecce35f5b7d24b73f8",
-      "sha256": "0293k2pjsh93k4pymvbyzpf3sj0qz04cr929i9g0x6m0snd1kmlr"
+    "path": "com/android/support/support-annotations/26.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-annotations-26.1.0.pom": {
+        "sha1": "649798a9fc69aa94d4f31b528d81c05f22e44678",
+        "sha256": "03dray9xascv5glkxx2g2297y57601jnx23p2gx5w5ray3y75biy"
+      },
+      "support-annotations-26.1.0.jar": {
+        "sha1": "0814258103cf26a15fcc26ecce35f5b7d24b73f8",
+        "sha256": "0293k2pjsh93k4pymvbyzpf3sj0qz04cr929i9g0x6m0snd1kmlr"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-annotations/27.0.1/support-annotations-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ed47a79d643e78d1445913d22d5d1d289e08d6c8",
-      "sha256": "0pwzdzcbb69nglqnls92m0g12zhdhq76p080bm3lw95y80f28h5a"
-    },
-    "jar": {
-      "sha1": "287742f1c6cea6d9126670e9f031890b0462362a",
-      "sha256": "1h4a4w0jp575h9lhrmf4afyjkyyij8mar53wv6yi6x7yg6vi4294"
+    "path": "com/android/support/support-annotations/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-annotations-27.0.1.pom": {
+        "sha1": "ed47a79d643e78d1445913d22d5d1d289e08d6c8",
+        "sha256": "0pwzdzcbb69nglqnls92m0g12zhdhq76p080bm3lw95y80f28h5a"
+      },
+      "support-annotations-27.0.1.jar": {
+        "sha1": "287742f1c6cea6d9126670e9f031890b0462362a",
+        "sha256": "1h4a4w0jp575h9lhrmf4afyjkyyij8mar53wv6yi6x7yg6vi4294"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-compat/26.0.2/support-compat-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "cf3024436b9ebdabe6e7c3799967a7d9a2eac6cf",
-      "sha256": "10zqhw27pwaw9mza8rk6z2px72baw2ysdp67q5qnz2ik7yxd77g1"
-    },
-    "jar": {
-      "sha1": "342fa9af0dbea4a4d1d92fabd6fcf55a00528db5",
-      "sha256": "09d4znq6qrfnjy6zsaaxfh0fflyvxi2glj5y734n04v1l6nszyyc"
+    "path": "com/android/support/support-compat/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-compat-26.0.2.pom": {
+        "sha1": "cf3024436b9ebdabe6e7c3799967a7d9a2eac6cf",
+        "sha256": "10zqhw27pwaw9mza8rk6z2px72baw2ysdp67q5qnz2ik7yxd77g1"
+      },
+      "support-compat-26.0.2.aar": {
+        "sha1": "342fa9af0dbea4a4d1d92fabd6fcf55a00528db5",
+        "sha256": "09d4znq6qrfnjy6zsaaxfh0fflyvxi2glj5y734n04v1l6nszyyc"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-compat/27.0.1/support-compat-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "05bcca92e852f205f2b64dfa04280c108164999d",
-      "sha256": "17fm4yyxav8vyvyn3p71dpw30m7iwfq5ixwsw76jkcs1d05d69kz"
-    },
-    "jar": {
-      "sha1": "df3dabe358f5f29b02cd3eb182f0094fd43c7d53",
-      "sha256": "1k7d38wsm4y710yrp0qjk75cm42cr5gh9i6z2ghml7j2c4jxkpvh"
+    "path": "com/android/support/support-compat/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-compat-27.0.1.pom": {
+        "sha1": "05bcca92e852f205f2b64dfa04280c108164999d",
+        "sha256": "17fm4yyxav8vyvyn3p71dpw30m7iwfq5ixwsw76jkcs1d05d69kz"
+      },
+      "support-compat-27.0.1.aar": {
+        "sha1": "df3dabe358f5f29b02cd3eb182f0094fd43c7d53",
+        "sha256": "1k7d38wsm4y710yrp0qjk75cm42cr5gh9i6z2ghml7j2c4jxkpvh"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-core-ui/26.0.2/support-core-ui-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5aa07c751f9593c5fe7094ed941b29b46d9a9031",
-      "sha256": "1liz1g31lkmnp1jb5ckjlr1gcfysxxkwn3rigxf7zip5qm4njkxl"
-    },
-    "jar": {
-      "sha1": "0c55b19b6a499c4a78227ebc8390475d594e08d0",
-      "sha256": "0qzxkvn3kdfrfdyn37ln5vz2g7gvgpxbqd7r3l01j8x20qzavxks"
+    "path": "com/android/support/support-core-ui/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-core-ui-26.0.2.pom": {
+        "sha1": "5aa07c751f9593c5fe7094ed941b29b46d9a9031",
+        "sha256": "1liz1g31lkmnp1jb5ckjlr1gcfysxxkwn3rigxf7zip5qm4njkxl"
+      },
+      "support-core-ui-26.0.2.aar": {
+        "sha1": "0c55b19b6a499c4a78227ebc8390475d594e08d0",
+        "sha256": "0qzxkvn3kdfrfdyn37ln5vz2g7gvgpxbqd7r3l01j8x20qzavxks"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-core-ui/27.0.1/support-core-ui-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "3005122800b90643d9c400f07fb96feb5d96f021",
-      "sha256": "02cpg5v0313fnn46cpqqkwgrkcyxmh5d8wyhvdi7yizmj8rhn4bn"
-    },
-    "jar": {
-      "sha1": "5b078bf46dc9a209977ecbc805e26378c70da96d",
-      "sha256": "1w6mf4izg6nxndlggk82mcjj489m4zm5iz4fsb11yvwaky14yqci"
+    "path": "com/android/support/support-core-ui/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-core-ui-27.0.1.pom": {
+        "sha1": "3005122800b90643d9c400f07fb96feb5d96f021",
+        "sha256": "02cpg5v0313fnn46cpqqkwgrkcyxmh5d8wyhvdi7yizmj8rhn4bn"
+      },
+      "support-core-ui-27.0.1.aar": {
+        "sha1": "5b078bf46dc9a209977ecbc805e26378c70da96d",
+        "sha256": "1w6mf4izg6nxndlggk82mcjj489m4zm5iz4fsb11yvwaky14yqci"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-core-utils/26.0.2/support-core-utils-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b1d45292e499eea2ccea51e7caf204fd878eca88",
-      "sha256": "10yhp22gxc5kyqbnm5hv9yp0nih9l509snzgisi6pxi8dmjla009"
-    },
-    "jar": {
-      "sha1": "641bb56a309f50fe37ca6c5e48e7665f739e7c19",
-      "sha256": "1q3l10lk5bk8qwdw16lw0d7q79fpwfk556y6cmakzwrn5nlc5gaj"
+    "path": "com/android/support/support-core-utils/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-core-utils-26.0.2.pom": {
+        "sha1": "b1d45292e499eea2ccea51e7caf204fd878eca88",
+        "sha256": "10yhp22gxc5kyqbnm5hv9yp0nih9l509snzgisi6pxi8dmjla009"
+      },
+      "support-core-utils-26.0.2.aar": {
+        "sha1": "641bb56a309f50fe37ca6c5e48e7665f739e7c19",
+        "sha256": "1q3l10lk5bk8qwdw16lw0d7q79fpwfk556y6cmakzwrn5nlc5gaj"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-core-utils/27.0.1/support-core-utils-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "9787db3f91ff0ef98c6ed255e06d722c5c56d877",
-      "sha256": "0ckwnqj91ggih3wlrkd5hfiarqxjyfar74f4yqfv51qkg7d8z51b"
-    },
-    "jar": {
-      "sha1": "810bdd1d47d61e537bba0c1252f92e5f564b1edc",
-      "sha256": "0wja0d2igbqfh9wj21764fzmg497g4bncxcqhb4adgxqcxfmlg5k"
+    "path": "com/android/support/support-core-utils/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-core-utils-27.0.1.pom": {
+        "sha1": "9787db3f91ff0ef98c6ed255e06d722c5c56d877",
+        "sha256": "0ckwnqj91ggih3wlrkd5hfiarqxjyfar74f4yqfv51qkg7d8z51b"
+      },
+      "support-core-utils-27.0.1.aar": {
+        "sha1": "810bdd1d47d61e537bba0c1252f92e5f564b1edc",
+        "sha256": "0wja0d2igbqfh9wj21764fzmg497g4bncxcqhb4adgxqcxfmlg5k"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-fragment/26.0.2/support-fragment-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "af31d1e645360844fe83db8a0927b3a7f8f4edda",
-      "sha256": "19ll3iy53h2q1jjq1pjnfl5iny0lil3fkxk81wnw0pq7rzwssjda"
-    },
-    "jar": {
-      "sha1": "26cf0203b3dbb19862c462b7a711b759580a3393",
-      "sha256": "1ncaacawivi868gr048iqlhd5q0rpw5g0lp6g29x0l2pvm2ff5v2"
+    "path": "com/android/support/support-fragment/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-fragment-26.0.2.pom": {
+        "sha1": "af31d1e645360844fe83db8a0927b3a7f8f4edda",
+        "sha256": "19ll3iy53h2q1jjq1pjnfl5iny0lil3fkxk81wnw0pq7rzwssjda"
+      },
+      "support-fragment-26.0.2.aar": {
+        "sha1": "26cf0203b3dbb19862c462b7a711b759580a3393",
+        "sha256": "1ncaacawivi868gr048iqlhd5q0rpw5g0lp6g29x0l2pvm2ff5v2"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-fragment/27.0.1/support-fragment-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b9266f3eecaf9e8c0c02b8f2607bbd79832a6429",
-      "sha256": "00fvdzi2mlzq83wqks3yhjs16wr0jclk0zhgnhzzbd284gj74hgy"
-    },
-    "jar": {
-      "sha1": "6bdb260a2a656c2ed593dcf841f1518890ee4b7a",
-      "sha256": "1vfr156g55c4dk55a153d7xmnvxq8895x1n9sp38b8p479w5ka05"
+    "path": "com/android/support/support-fragment/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-fragment-27.0.1.pom": {
+        "sha1": "b9266f3eecaf9e8c0c02b8f2607bbd79832a6429",
+        "sha256": "00fvdzi2mlzq83wqks3yhjs16wr0jclk0zhgnhzzbd284gj74hgy"
+      },
+      "support-fragment-27.0.1.aar": {
+        "sha1": "6bdb260a2a656c2ed593dcf841f1518890ee4b7a",
+        "sha256": "1vfr156g55c4dk55a153d7xmnvxq8895x1n9sp38b8p479w5ka05"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-media-compat/26.0.2/support-media-compat-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f65317b491650d9e2e7af18aad837bd54a65778e",
-      "sha256": "07d6mr3c6hrfy915ikllh2fi4gnwlmxmnkzyp7pm8z61zv8cyj73"
-    },
-    "jar": {
-      "sha1": "c7912532b36588f54933bc03b109e5b5f24e0b0d",
-      "sha256": "1cgxldggq8nrsgjxdr379a10r77gwj1w1wrr5ppgmbxqw4g61dbh"
+    "path": "com/android/support/support-media-compat/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-media-compat-26.0.2.pom": {
+        "sha1": "f65317b491650d9e2e7af18aad837bd54a65778e",
+        "sha256": "07d6mr3c6hrfy915ikllh2fi4gnwlmxmnkzyp7pm8z61zv8cyj73"
+      },
+      "support-media-compat-26.0.2.aar": {
+        "sha1": "c7912532b36588f54933bc03b109e5b5f24e0b0d",
+        "sha256": "1cgxldggq8nrsgjxdr379a10r77gwj1w1wrr5ppgmbxqw4g61dbh"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-v4/26.0.2/support-v4-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f3417d10effa8d6bafae4e78a7fd09b16067f699",
-      "sha256": "0mcj4pyq02mcnql5v2255jm489fccgd8lz98asbw7ykszyhkywfx"
-    },
-    "jar": {
-      "sha1": "762902b1aa5eb48bdb1a1f84b1be19a7b1285708",
-      "sha256": "0krc2hrw3ipm83krcqs9kvyj94f795v26c38slikf92bjydnnzdr"
+    "path": "com/android/support/support-v4/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-v4-26.0.2.pom": {
+        "sha1": "f3417d10effa8d6bafae4e78a7fd09b16067f699",
+        "sha256": "0mcj4pyq02mcnql5v2255jm489fccgd8lz98asbw7ykszyhkywfx"
+      },
+      "support-v4-26.0.2.aar": {
+        "sha1": "762902b1aa5eb48bdb1a1f84b1be19a7b1285708",
+        "sha256": "0krc2hrw3ipm83krcqs9kvyj94f795v26c38slikf92bjydnnzdr"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-vector-drawable/26.0.2/support-vector-drawable-26.0.2",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c55de7d06fcd692a786f190056dfca8b394ba56c",
-      "sha256": "025i07q58kn56apmqmj81bcmn5dy3xi34f7r2xsri31qcpca632l"
-    },
-    "jar": {
-      "sha1": "89ebac92d36ee264233136fb473d4f61d17d570d",
-      "sha256": "056xydnbx4kxrnv6q6r52ajw32zz9pxn79wpvjfrz9n938zpkxdl"
+    "path": "com/android/support/support-vector-drawable/26.0.2",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-vector-drawable-26.0.2.pom": {
+        "sha1": "c55de7d06fcd692a786f190056dfca8b394ba56c",
+        "sha256": "025i07q58kn56apmqmj81bcmn5dy3xi34f7r2xsri31qcpca632l"
+      },
+      "support-vector-drawable-26.0.2.aar": {
+        "sha1": "89ebac92d36ee264233136fb473d4f61d17d570d",
+        "sha256": "056xydnbx4kxrnv6q6r52ajw32zz9pxn79wpvjfrz9n938zpkxdl"
+      }
     }
   },
 
   {
-    "path": "com/android/support/support-vector-drawable/27.0.1/support-vector-drawable-27.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "70faf3e360e770cfb5adea12a901ac671322c7bc",
-      "sha256": "1rp9x06dzc7xgnpg8icd8ysihlqia8w63ixb4j9gka3gq9n346dm"
-    },
-    "jar": {
-      "sha1": "ad85b9cd7f3a8095e9d011f7467ba7f47da79724",
-      "sha256": "177iqyi31q518a09xmg9m0lqhwwmc7dccjr109jljdgpj6hlw5b7"
+    "path": "com/android/support/support-vector-drawable/27.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "support-vector-drawable-27.0.1.pom": {
+        "sha1": "70faf3e360e770cfb5adea12a901ac671322c7bc",
+        "sha256": "1rp9x06dzc7xgnpg8icd8ysihlqia8w63ixb4j9gka3gq9n346dm"
+      },
+      "support-vector-drawable-27.0.1.aar": {
+        "sha1": "ad85b9cd7f3a8095e9d011f7467ba7f47da79724",
+        "sha256": "177iqyi31q518a09xmg9m0lqhwwmc7dccjr109jljdgpj6hlw5b7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/crash/26.2.1/crash-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e74c00c94a05aca89f4e1515718e886f47e87a9b",
-      "sha256": "0nvyjigdq10vy15qq3ypad7rxpvxz29jcq8b15jvh1zwan8dfwwz"
-    },
-    "jar": {
-      "sha1": "ca7e89eebc7c27af8f7aea2ec070873fcd90602a",
-      "sha256": "1gb504zxf8c7fc3q5phbdjgprlnbpzha52c3clmmx2yfck465lqk"
+    "path": "com/android/tools/analytics-library/crash/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "crash-26.2.1.pom": {
+        "sha1": "e74c00c94a05aca89f4e1515718e886f47e87a9b",
+        "sha256": "0nvyjigdq10vy15qq3ypad7rxpvxz29jcq8b15jvh1zwan8dfwwz"
+      },
+      "crash-26.2.1.jar": {
+        "sha1": "ca7e89eebc7c27af8f7aea2ec070873fcd90602a",
+        "sha256": "1gb504zxf8c7fc3q5phbdjgprlnbpzha52c3clmmx2yfck465lqk"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/crash/26.3.1/crash-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7b667eb48f02b8ba2a981a962e9c1137e251c1e0",
-      "sha256": "0mykqlwc4g7p2z5dmbzrjxc49gs37c7fpia5rnq6axpq2gi4fhcv"
-    },
-    "jar": {
-      "sha1": "46163f2cf0e16a1ba9be2ad6dddc39f1a1d6b613",
-      "sha256": "14v2jnpqz59qn5n95pl6y4ykp6k99qjg6g955iw9dypkw8yai4wk"
+    "path": "com/android/tools/analytics-library/crash/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "crash-26.3.1.pom": {
+        "sha1": "7b667eb48f02b8ba2a981a962e9c1137e251c1e0",
+        "sha256": "0mykqlwc4g7p2z5dmbzrjxc49gs37c7fpia5rnq6axpq2gi4fhcv"
+      },
+      "crash-26.3.1.jar": {
+        "sha1": "46163f2cf0e16a1ba9be2ad6dddc39f1a1d6b613",
+        "sha256": "14v2jnpqz59qn5n95pl6y4ykp6k99qjg6g955iw9dypkw8yai4wk"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/crash/26.5.4/crash-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ebe45156d5b63fd80ab2a31fefd9af18ef243cd6",
-      "sha256": "13db26llnw84s1cjvd1g6jzvf308kimv0cypd635f7l482kcji82"
-    },
-    "jar": {
-      "sha1": "04020841b8009414df8663161527d035528686e2",
-      "sha256": "0zsyjyd9yxjy9c4si39n0hqc28038z7lrkpg53x2q7fwmfgqk75v"
+    "path": "com/android/tools/analytics-library/crash/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "crash-26.5.4.pom": {
+        "sha1": "ebe45156d5b63fd80ab2a31fefd9af18ef243cd6",
+        "sha256": "13db26llnw84s1cjvd1g6jzvf308kimv0cypd635f7l482kcji82"
+      },
+      "crash-26.5.4.jar": {
+        "sha1": "04020841b8009414df8663161527d035528686e2",
+        "sha256": "0zsyjyd9yxjy9c4si39n0hqc28038z7lrkpg53x2q7fwmfgqk75v"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/protos/26.0.0/protos-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "04fc6ffa9c1e43cbd58c62d81c55a55da5baf80c",
-      "sha256": "1sw6pjch8qqhydwqmwwb84cwxmxrbb04x2bj5q0igg98rm2b83vc"
-    },
-    "jar": {
-      "sha1": "9700759196d267fc7cf3c85806c157050ea37dc9",
-      "sha256": "1c5dj1iygs8mv09qi6djwsb5ywsxb56yacpfg7k8pvrjx3ayncj2"
+    "path": "com/android/tools/analytics-library/protos/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "protos-26.0.0.pom": {
+        "sha1": "04fc6ffa9c1e43cbd58c62d81c55a55da5baf80c",
+        "sha256": "1sw6pjch8qqhydwqmwwb84cwxmxrbb04x2bj5q0igg98rm2b83vc"
+      },
+      "protos-26.0.0.jar": {
+        "sha1": "9700759196d267fc7cf3c85806c157050ea37dc9",
+        "sha256": "1c5dj1iygs8mv09qi6djwsb5ywsxb56yacpfg7k8pvrjx3ayncj2"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/protos/26.0.1/protos-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cf5b7d86e8a5c471cdb6c6615f6e26589b6b3e63",
-      "sha256": "1qzy02yznfk941jgkazdiqap8rsarxkn303vg5al5vzdiwbhch4d"
-    },
-    "jar": {
-      "sha1": "07719e7ed7498e25ec555bdfcb7a4de0e88a47ea",
-      "sha256": "13r27dq4sp4rdw35nbl9v7h8fzyby8xpwkjsxm4xxp1ddm5mwpyz"
+    "path": "com/android/tools/analytics-library/protos/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "protos-26.0.1.pom": {
+        "sha1": "cf5b7d86e8a5c471cdb6c6615f6e26589b6b3e63",
+        "sha256": "1qzy02yznfk941jgkazdiqap8rsarxkn303vg5al5vzdiwbhch4d"
+      },
+      "protos-26.0.1.jar": {
+        "sha1": "07719e7ed7498e25ec555bdfcb7a4de0e88a47ea",
+        "sha256": "13r27dq4sp4rdw35nbl9v7h8fzyby8xpwkjsxm4xxp1ddm5mwpyz"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/protos/26.1.4/protos-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0c9e7fe6c7c2b0156a87aa626f5463af34669f99",
-      "sha256": "11wnpnlb0ixck525g1qi6lgrjcsca9281kpmwkm3m3r8y1fnl86c"
-    },
-    "jar": {
-      "sha1": "dc5876bb894d87d2088b0a4447b13fdc13ad82fc",
-      "sha256": "1dy9pd8sjkhhip8xqz681i9q66m43iigmnwhdkmk6xm33j0d6cf7"
+    "path": "com/android/tools/analytics-library/protos/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "protos-26.1.4.pom": {
+        "sha1": "0c9e7fe6c7c2b0156a87aa626f5463af34669f99",
+        "sha256": "11wnpnlb0ixck525g1qi6lgrjcsca9281kpmwkm3m3r8y1fnl86c"
+      },
+      "protos-26.1.4.jar": {
+        "sha1": "dc5876bb894d87d2088b0a4447b13fdc13ad82fc",
+        "sha256": "1dy9pd8sjkhhip8xqz681i9q66m43iigmnwhdkmk6xm33j0d6cf7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/protos/26.2.1/protos-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5ba0bf99a124c6370336fa345b871f05e610bf64",
-      "sha256": "0gifp743ymw6d4ackqwfyb3q7gpzyhr4bwafzqk3pl51ldy8lxf7"
-    },
-    "jar": {
-      "sha1": "db637f20d2c56d74a1b504d4e39a0bc8817fcaf4",
-      "sha256": "07v9pybbgwwq6amgdsyimx23s6s7fcl6lkdy12mqa7jm3xdiydrg"
+    "path": "com/android/tools/analytics-library/protos/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "protos-26.2.1.pom": {
+        "sha1": "5ba0bf99a124c6370336fa345b871f05e610bf64",
+        "sha256": "0gifp743ymw6d4ackqwfyb3q7gpzyhr4bwafzqk3pl51ldy8lxf7"
+      },
+      "protos-26.2.1.jar": {
+        "sha1": "db637f20d2c56d74a1b504d4e39a0bc8817fcaf4",
+        "sha256": "07v9pybbgwwq6amgdsyimx23s6s7fcl6lkdy12mqa7jm3xdiydrg"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/protos/26.3.1/protos-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d6015a3a017dcb62d9a9a56c28b5c47bb6727a91",
-      "sha256": "0ybkvzn634bs69sgykdq9wkzqbjvqha18jx7xrh4j85vssanmz90"
-    },
-    "jar": {
-      "sha1": "f35a0accd93cfbb4306268ea748e1ac49920a0a8",
-      "sha256": "0k4xim3pgmwn0qh1q6kcz9v5fn4pg44c3hbq4dmz9zyq2bvz8kzg"
+    "path": "com/android/tools/analytics-library/protos/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "protos-26.3.1.pom": {
+        "sha1": "d6015a3a017dcb62d9a9a56c28b5c47bb6727a91",
+        "sha256": "0ybkvzn634bs69sgykdq9wkzqbjvqha18jx7xrh4j85vssanmz90"
+      },
+      "protos-26.3.1.jar": {
+        "sha1": "f35a0accd93cfbb4306268ea748e1ac49920a0a8",
+        "sha256": "0k4xim3pgmwn0qh1q6kcz9v5fn4pg44c3hbq4dmz9zyq2bvz8kzg"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/protos/26.5.4/protos-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "448847b74ed14339ce2f4a225b38e71df5a640a8",
-      "sha256": "115jvli8sib71ii3an67inb4v11a0yvshnqhp2ldkzfkp9w3330x"
-    },
-    "jar": {
-      "sha1": "60c319aa5d271e400787987ae15e61e1e73dc4c5",
-      "sha256": "1lizp6wk9f7yl9qppl79vddcdj139jcpy904gmma7q1l8gd8kc28"
+    "path": "com/android/tools/analytics-library/protos/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "protos-26.5.4.pom": {
+        "sha1": "448847b74ed14339ce2f4a225b38e71df5a640a8",
+        "sha256": "115jvli8sib71ii3an67inb4v11a0yvshnqhp2ldkzfkp9w3330x"
+      },
+      "protos-26.5.4.jar": {
+        "sha1": "60c319aa5d271e400787987ae15e61e1e73dc4c5",
+        "sha256": "1lizp6wk9f7yl9qppl79vddcdj139jcpy904gmma7q1l8gd8kc28"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.0.0/shared-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c41a448d5cd94b349b12a4ca13005cb2470181be",
-      "sha256": "0cqymxirzrwpnjwnkagfgf9xx8wyf3w73wj8hs5dmyaznjwds02z"
-    },
-    "jar": {
-      "sha1": "bf1943bf2ff33b50f8f18e25353cd82d70ab24ba",
-      "sha256": "0i3pr82km4pm22fdhw7nyr0cvwp92jnw9wvi6s38frlc2cj40ac9"
+    "path": "com/android/tools/analytics-library/shared/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "shared-26.0.0.pom": {
+        "sha1": "c41a448d5cd94b349b12a4ca13005cb2470181be",
+        "sha256": "0cqymxirzrwpnjwnkagfgf9xx8wyf3w73wj8hs5dmyaznjwds02z"
+      },
+      "shared-26.0.0.jar": {
+        "sha1": "bf1943bf2ff33b50f8f18e25353cd82d70ab24ba",
+        "sha256": "0i3pr82km4pm22fdhw7nyr0cvwp92jnw9wvi6s38frlc2cj40ac9"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.0.1/shared-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6702994a364e97efd9f8d98c9cb3a6759a6efb46",
-      "sha256": "1mjpx8jpr8bg11jbry0nhy4kzj2wib1hynzyn64rvxmsbhmnknrq"
-    },
-    "jar": {
-      "sha1": "5cfc3811c2fd6cddfce2ec1bb5fbbec87e0fc462",
-      "sha256": "0laz70kx25p8223vixw7sknzq0c3lilsam66rqjfkpi9120sb9z7"
+    "path": "com/android/tools/analytics-library/shared/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "shared-26.0.1.pom": {
+        "sha1": "6702994a364e97efd9f8d98c9cb3a6759a6efb46",
+        "sha256": "1mjpx8jpr8bg11jbry0nhy4kzj2wib1hynzyn64rvxmsbhmnknrq"
+      },
+      "shared-26.0.1.jar": {
+        "sha1": "5cfc3811c2fd6cddfce2ec1bb5fbbec87e0fc462",
+        "sha256": "0laz70kx25p8223vixw7sknzq0c3lilsam66rqjfkpi9120sb9z7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.1.4/shared-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "18ef89a0e8844559433bf6c085b4b86faecb87b6",
-      "sha256": "1m4g32q62mjwmg0z23fvzf40gaf4dgm0jb5cbcv4j36jpgp0yrmm"
-    },
-    "jar": {
-      "sha1": "02a285c67f4b421145e47849d4114f7534707156",
-      "sha256": "08h7w0fwky1mr5j7v4yb4afa3kvvw56bnj4926m4zi62p1qfdxsn"
+    "path": "com/android/tools/analytics-library/shared/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "shared-26.1.4.pom": {
+        "sha1": "18ef89a0e8844559433bf6c085b4b86faecb87b6",
+        "sha256": "1m4g32q62mjwmg0z23fvzf40gaf4dgm0jb5cbcv4j36jpgp0yrmm"
+      },
+      "shared-26.1.4.jar": {
+        "sha1": "02a285c67f4b421145e47849d4114f7534707156",
+        "sha256": "08h7w0fwky1mr5j7v4yb4afa3kvvw56bnj4926m4zi62p1qfdxsn"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.2.1/shared-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7dbecc3aa0a180f166d671c9324535ecf4644b43",
-      "sha256": "00gglcwhcv6ykl4ll2gjmb72f7hy8gmpcarjga60jlnb8c2wmb2f"
-    },
-    "jar": {
-      "sha1": "2e79154b4a5d2e6c1816811db6ab00cf41886737",
-      "sha256": "0nkzm4k7n7bwg0vn6acw5l0mb0ahyrbha8zam8imzm54bxq4w7jc"
+    "path": "com/android/tools/analytics-library/shared/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "shared-26.2.1.pom": {
+        "sha1": "7dbecc3aa0a180f166d671c9324535ecf4644b43",
+        "sha256": "00gglcwhcv6ykl4ll2gjmb72f7hy8gmpcarjga60jlnb8c2wmb2f"
+      },
+      "shared-26.2.1.jar": {
+        "sha1": "2e79154b4a5d2e6c1816811db6ab00cf41886737",
+        "sha256": "0nkzm4k7n7bwg0vn6acw5l0mb0ahyrbha8zam8imzm54bxq4w7jc"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.3.1/shared-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "af1e1e7d120696bfee452247b5224290d91d828f",
-      "sha256": "1knaxl0kc14lbzfyry2l9m6n4729i5ri2nk4d36m563rdb36cz6w"
-    },
-    "jar": {
-      "sha1": "3457faee7a68d84dcbd258889567153acfc731a2",
-      "sha256": "1w1vmpypfbdrpyv4mk1hgqgsx9gkc5kyz4a4hwnvrqk3wambj9vd"
+    "path": "com/android/tools/analytics-library/shared/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "shared-26.3.1.pom": {
+        "sha1": "af1e1e7d120696bfee452247b5224290d91d828f",
+        "sha256": "1knaxl0kc14lbzfyry2l9m6n4729i5ri2nk4d36m563rdb36cz6w"
+      },
+      "shared-26.3.1.jar": {
+        "sha1": "3457faee7a68d84dcbd258889567153acfc731a2",
+        "sha256": "1w1vmpypfbdrpyv4mk1hgqgsx9gkc5kyz4a4hwnvrqk3wambj9vd"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.5.4/shared-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "12791d9597c430c22a10c0ea9dda65e17f7ad1fe",
-      "sha256": "1slang8qrjfsarzyilxdjyx23s5mvc1pwal1gmm3sbddnr90va88"
-    },
-    "jar": {
-      "sha1": "1a0f988f591d492d82b1bc30d5771f074037bd58",
-      "sha256": "0wvjp4h4j0jhnbc2qynhkp0pm01lylnc4yrd3hq6js1k94mvjbqv"
+    "path": "com/android/tools/analytics-library/shared/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "shared-26.5.4.pom": {
+        "sha1": "12791d9597c430c22a10c0ea9dda65e17f7ad1fe",
+        "sha256": "1slang8qrjfsarzyilxdjyx23s5mvc1pwal1gmm3sbddnr90va88"
+      },
+      "shared-26.5.4.jar": {
+        "sha1": "1a0f988f591d492d82b1bc30d5771f074037bd58",
+        "sha256": "0wvjp4h4j0jhnbc2qynhkp0pm01lylnc4yrd3hq6js1k94mvjbqv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.0.0/tracker-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "70bbb640b9c8d187263a03fbf9858fc638c2c11b",
-      "sha256": "17id91rl0rg2xvvglqllrldjl7yxbcz4s8qwpw8zqp4vqf2mc9x9"
-    },
-    "jar": {
-      "sha1": "f75df0e15d6db4ed1ba42e9d22bde29868db3f0f",
-      "sha256": "1cigmc4s4hav70g7ly8q0ml3awnqaja20xvrv6clrgcppikl49m6"
+    "path": "com/android/tools/analytics-library/tracker/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracker-26.0.0.pom": {
+        "sha1": "70bbb640b9c8d187263a03fbf9858fc638c2c11b",
+        "sha256": "17id91rl0rg2xvvglqllrldjl7yxbcz4s8qwpw8zqp4vqf2mc9x9"
+      },
+      "tracker-26.0.0.jar": {
+        "sha1": "f75df0e15d6db4ed1ba42e9d22bde29868db3f0f",
+        "sha256": "1cigmc4s4hav70g7ly8q0ml3awnqaja20xvrv6clrgcppikl49m6"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.0.1/tracker-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4f77d3c5867728241b7b71115a8dc147611d8441",
-      "sha256": "1pk8qmljrcxfwfd45gmswjl4wb6pqazv2h9a0krfya8ik6c7h40h"
-    },
-    "jar": {
-      "sha1": "15f0c0560c8a97700651d2dd5219937baa80c166",
-      "sha256": "0j14icndz0nyyc52d3vx74zhfllkn85k1pwcqwl885jrz9lf75b8"
+    "path": "com/android/tools/analytics-library/tracker/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracker-26.0.1.pom": {
+        "sha1": "4f77d3c5867728241b7b71115a8dc147611d8441",
+        "sha256": "1pk8qmljrcxfwfd45gmswjl4wb6pqazv2h9a0krfya8ik6c7h40h"
+      },
+      "tracker-26.0.1.jar": {
+        "sha1": "15f0c0560c8a97700651d2dd5219937baa80c166",
+        "sha256": "0j14icndz0nyyc52d3vx74zhfllkn85k1pwcqwl885jrz9lf75b8"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.1.4/tracker-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0949ee22e49c32374aa3227b76efdf6b69a85cb0",
-      "sha256": "0077291y8qj555nwqg1ssykdg7cjqgf8866hz9y7rw6sj95h9flw"
-    },
-    "jar": {
-      "sha1": "fd48066d6c78b78abf5baa335dc2124060e8371c",
-      "sha256": "1yggkx8f5a3w3z924rmc01y06vn4ppz5541s88y6qkd0xbxbdmb6"
+    "path": "com/android/tools/analytics-library/tracker/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracker-26.1.4.pom": {
+        "sha1": "0949ee22e49c32374aa3227b76efdf6b69a85cb0",
+        "sha256": "0077291y8qj555nwqg1ssykdg7cjqgf8866hz9y7rw6sj95h9flw"
+      },
+      "tracker-26.1.4.jar": {
+        "sha1": "fd48066d6c78b78abf5baa335dc2124060e8371c",
+        "sha256": "1yggkx8f5a3w3z924rmc01y06vn4ppz5541s88y6qkd0xbxbdmb6"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.2.1/tracker-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9de8a29b54977e7fb674fa9d783799a5d4112912",
-      "sha256": "142zs2n27fs70jjx2dy55sw1bjs0s67j30r46sqwvrlh6b3266gx"
-    },
-    "jar": {
-      "sha1": "6b9eca42be508a8d87c287ad280a27f802f0e40a",
-      "sha256": "0xgvlwf703ypvfca0ngcrwk87l6k5py8vfxhvmazffb5jz64wqja"
+    "path": "com/android/tools/analytics-library/tracker/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracker-26.2.1.pom": {
+        "sha1": "9de8a29b54977e7fb674fa9d783799a5d4112912",
+        "sha256": "142zs2n27fs70jjx2dy55sw1bjs0s67j30r46sqwvrlh6b3266gx"
+      },
+      "tracker-26.2.1.jar": {
+        "sha1": "6b9eca42be508a8d87c287ad280a27f802f0e40a",
+        "sha256": "0xgvlwf703ypvfca0ngcrwk87l6k5py8vfxhvmazffb5jz64wqja"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.3.1/tracker-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6775a4eeafd2ef5270750388ee53503eeafa688b",
-      "sha256": "021bwl8qvshd9lkgd4wvbfbn7hlrwiin8dalb7bnj543gc51as7s"
-    },
-    "jar": {
-      "sha1": "26248cad2525e003752322cfc6bd86182df7daac",
-      "sha256": "124xjvkc2zb173dppk191hfx82lfjh99syys33ihqdj09f080vi4"
+    "path": "com/android/tools/analytics-library/tracker/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracker-26.3.1.pom": {
+        "sha1": "6775a4eeafd2ef5270750388ee53503eeafa688b",
+        "sha256": "021bwl8qvshd9lkgd4wvbfbn7hlrwiin8dalb7bnj543gc51as7s"
+      },
+      "tracker-26.3.1.jar": {
+        "sha1": "26248cad2525e003752322cfc6bd86182df7daac",
+        "sha256": "124xjvkc2zb173dppk191hfx82lfjh99syys33ihqdj09f080vi4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.5.4/tracker-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "871a2762da5f41af5544d48a9aa10ee5dab8a21d",
-      "sha256": "1krnr85xc72dv4lqg86qw4anac6frw7764kj3gvsvf55ss9kh0ga"
-    },
-    "jar": {
-      "sha1": "7ebda91f709dcd3234d948ad3f5c04c1be38fe83",
-      "sha256": "0zv9asvbc2gr1ajb972yyns9b3m6qds1bpf9sdasnmm4f1a7miaq"
+    "path": "com/android/tools/analytics-library/tracker/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "tracker-26.5.4.pom": {
+        "sha1": "871a2762da5f41af5544d48a9aa10ee5dab8a21d",
+        "sha256": "1krnr85xc72dv4lqg86qw4anac6frw7764kj3gvsvf55ss9kh0ga"
+      },
+      "tracker-26.5.4.jar": {
+        "sha1": "7ebda91f709dcd3234d948ad3f5c04c1be38fe83",
+        "sha256": "0zv9asvbc2gr1ajb972yyns9b3m6qds1bpf9sdasnmm4f1a7miaq"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/26.0.0/annotations-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "36a4991057a688236cca1b1b55e575bfa979a4e4",
-      "sha256": "14n97s6yw56cyb4xy6mxlr3xah65ayd8wydp7fxh8sg9320172lh"
-    },
-    "jar": {
-      "sha1": "fc587b91f1d2390a90d0b02a3e41a0bed140e9c1",
-      "sha256": "0iyqms07qadihcnha4li2gk88x2504w7xvdmichjqc52hsq47kik"
+    "path": "com/android/tools/annotations/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotations-26.0.0.pom": {
+        "sha1": "36a4991057a688236cca1b1b55e575bfa979a4e4",
+        "sha256": "14n97s6yw56cyb4xy6mxlr3xah65ayd8wydp7fxh8sg9320172lh"
+      },
+      "annotations-26.0.0.jar": {
+        "sha1": "fc587b91f1d2390a90d0b02a3e41a0bed140e9c1",
+        "sha256": "0iyqms07qadihcnha4li2gk88x2504w7xvdmichjqc52hsq47kik"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/26.0.1/annotations-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d4d92709c9b15a5a1fb33a78e041533fdfdd1577",
-      "sha256": "0dyq765sdf7sxl2nygkfym6nksb68rchjipq0qwz0jy68a8si22g"
-    },
-    "jar": {
-      "sha1": "29012758503f56c7dc0714eda494f7f140fd3db8",
-      "sha256": "11ck1rmwdvxhh5wnwq05w0ip8n7v96n4cqlkf9rskz2srjn5vmm9"
+    "path": "com/android/tools/annotations/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotations-26.0.1.pom": {
+        "sha1": "d4d92709c9b15a5a1fb33a78e041533fdfdd1577",
+        "sha256": "0dyq765sdf7sxl2nygkfym6nksb68rchjipq0qwz0jy68a8si22g"
+      },
+      "annotations-26.0.1.jar": {
+        "sha1": "29012758503f56c7dc0714eda494f7f140fd3db8",
+        "sha256": "11ck1rmwdvxhh5wnwq05w0ip8n7v96n4cqlkf9rskz2srjn5vmm9"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/26.1.4/annotations-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d5e8ea57c56cd1f5b6e1e676ab0d489d88b59826",
-      "sha256": "1i6qhh6b5nppvbc465hzjd29ip8j698cs1873yv42dhakc325cyz"
-    },
-    "jar": {
-      "sha1": "817d5238d9ea07b4b26d04e29e9bada2aacb7245",
-      "sha256": "102r2z2wh3pmaar7f0d3nxksk265m5plbd8cjjvbgll9jkw972k0"
+    "path": "com/android/tools/annotations/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotations-26.1.4.pom": {
+        "sha1": "d5e8ea57c56cd1f5b6e1e676ab0d489d88b59826",
+        "sha256": "1i6qhh6b5nppvbc465hzjd29ip8j698cs1873yv42dhakc325cyz"
+      },
+      "annotations-26.1.4.jar": {
+        "sha1": "817d5238d9ea07b4b26d04e29e9bada2aacb7245",
+        "sha256": "102r2z2wh3pmaar7f0d3nxksk265m5plbd8cjjvbgll9jkw972k0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/26.2.1/annotations-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "63dc441eca9b0d9aeb259ed2e33f080760ec651a",
-      "sha256": "1v7xxmyxgcbfvd1q8nrs24iwlbrsv6ym2q0lb3n1zz6zwa1rgmv4"
-    },
-    "jar": {
-      "sha1": "5f9b112634e53890e16cc2947989bc2bc048734e",
-      "sha256": "090gz4k2285ycpnf1znjlbcf876kmn6hgsscwsb4n5w0w2hwd4bk"
+    "path": "com/android/tools/annotations/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotations-26.2.1.pom": {
+        "sha1": "63dc441eca9b0d9aeb259ed2e33f080760ec651a",
+        "sha256": "1v7xxmyxgcbfvd1q8nrs24iwlbrsv6ym2q0lb3n1zz6zwa1rgmv4"
+      },
+      "annotations-26.2.1.jar": {
+        "sha1": "5f9b112634e53890e16cc2947989bc2bc048734e",
+        "sha256": "090gz4k2285ycpnf1znjlbcf876kmn6hgsscwsb4n5w0w2hwd4bk"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/26.3.1/annotations-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bce2159e811cceee12498cb34812cbae1e7b8eda",
-      "sha256": "1c94f7ykykk1fwkc6nksw2q5j73igr6mwkxwsfkq62vhpl5dddb3"
-    },
-    "jar": {
-      "sha1": "3d46d5da6d5dd17df682a22b914cdc6b84677731",
-      "sha256": "08f7s1rccfn48wmhw00f6336i3xkapm39g3mr7wd8adq1vjxqjjk"
+    "path": "com/android/tools/annotations/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotations-26.3.1.pom": {
+        "sha1": "bce2159e811cceee12498cb34812cbae1e7b8eda",
+        "sha256": "1c94f7ykykk1fwkc6nksw2q5j73igr6mwkxwsfkq62vhpl5dddb3"
+      },
+      "annotations-26.3.1.jar": {
+        "sha1": "3d46d5da6d5dd17df682a22b914cdc6b84677731",
+        "sha256": "08f7s1rccfn48wmhw00f6336i3xkapm39g3mr7wd8adq1vjxqjjk"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/26.5.4/annotations-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "754b6bad3451ae01952f028ad1810c7ce3394cf9",
-      "sha256": "0hxqqpsk1sxj7v122fddzvmnni6z087ijcgqrvw0d9dwc3a0pg6i"
-    },
-    "jar": {
-      "sha1": "f3165077d2dc34a2fed93ed248f3b958fec162af",
-      "sha256": "0g5iwpwfzx5vb6hzqwxni3ix9snki8iw9hi484lzk748nqdzbdqa"
+    "path": "com/android/tools/annotations/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "annotations-26.5.4.pom": {
+        "sha1": "754b6bad3451ae01952f028ad1810c7ce3394cf9",
+        "sha256": "0hxqqpsk1sxj7v122fddzvmnni6z087ijcgqrvw0d9dwc3a0pg6i"
+      },
+      "annotations-26.5.4.jar": {
+        "sha1": "f3165077d2dc34a2fed93ed248f3b958fec162af",
+        "sha256": "0g5iwpwfzx5vb6hzqwxni3ix9snki8iw9hi484lzk748nqdzbdqa"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/aapt2-proto/0.1.0/aapt2-proto-0.1.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d3492c6cfb99d5d556cf4840c2efd63493ce2ac1",
-      "sha256": "1h9vlambl1k51nx86qm0yfyavpf9qfrh7gja1q3qsqj10jinb8kc"
-    },
-    "jar": {
-      "sha1": "d1eb93a21a8d3590c3bfac574a8b6dffb2dbd21c",
-      "sha256": "1x69zbk977hyc97hpc3bxmh19yiiq3hkl3hadjmwps08z4g13990"
+    "path": "com/android/tools/build/aapt2-proto/0.1.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "aapt2-proto-0.1.0.pom": {
+        "sha1": "d3492c6cfb99d5d556cf4840c2efd63493ce2ac1",
+        "sha256": "1h9vlambl1k51nx86qm0yfyavpf9qfrh7gja1q3qsqj10jinb8kc"
+      },
+      "aapt2-proto-0.1.0.jar": {
+        "sha1": "d1eb93a21a8d3590c3bfac574a8b6dffb2dbd21c",
+        "sha256": "1x69zbk977hyc97hpc3bxmh19yiiq3hkl3hadjmwps08z4g13990"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/aapt2-proto/0.3.1/aapt2-proto-0.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "235a6eb105ebf8b411e4d75926814cd34abd0d22",
-      "sha256": "07fhxx0czmrmw9cfpxkcxy6z53hpsrpkk85l791w39srdgjz1r9i"
-    },
-    "jar": {
-      "sha1": "8311800abb3dcd84426a0de834a6b884a173d864",
-      "sha256": "1nj9vkbz3yx43r56haq7373acmg6d5yv3cy9qsvzgamhi6dj20x5"
+    "path": "com/android/tools/build/aapt2-proto/0.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "aapt2-proto-0.3.1.pom": {
+        "sha1": "235a6eb105ebf8b411e4d75926814cd34abd0d22",
+        "sha256": "07fhxx0czmrmw9cfpxkcxy6z53hpsrpkk85l791w39srdgjz1r9i"
+      },
+      "aapt2-proto-0.3.1.jar": {
+        "sha1": "8311800abb3dcd84426a0de834a6b884a173d864",
+        "sha256": "1nj9vkbz3yx43r56haq7373acmg6d5yv3cy9qsvzgamhi6dj20x5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/aapt2-proto/0.4.0/aapt2-proto-0.4.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7dfca013cd859905a574a0c484e5c022eeccb3c3",
-      "sha256": "0fa3j2z3j019pr7xxijxyb8cqizi4fkpxmzqrvcdqkrpir7dsjx2"
-    },
-    "jar": {
-      "sha1": "d4db96aa0d2e161d08a038731e08c3ebf612cd12",
-      "sha256": "1jik85h57bc5sb70a8n12vw5y587lyz3d8lwxgp8k3w911g47h7s"
+    "path": "com/android/tools/build/aapt2-proto/0.4.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "aapt2-proto-0.4.0.pom": {
+        "sha1": "7dfca013cd859905a574a0c484e5c022eeccb3c3",
+        "sha256": "0fa3j2z3j019pr7xxijxyb8cqizi4fkpxmzqrvcdqkrpir7dsjx2"
+      },
+      "aapt2-proto-0.4.0.jar": {
+        "sha1": "d4db96aa0d2e161d08a038731e08c3ebf612cd12",
+        "sha256": "1jik85h57bc5sb70a8n12vw5y587lyz3d8lwxgp8k3w911g47h7s"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.0.0/apksig-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "23c8d16e6aac3ab71c39e37e860a8ab8cff0979c",
-      "sha256": "1ha5d3bh36q4kj0gh1qmg9ncqwbv2n209mfbfnmwxw4gnj4l9a18"
-    },
-    "jar": {
-      "sha1": "21465a36db10551cfcfd8ad39bb496511f78354c",
-      "sha256": "11jc8f5xb3i0mhr2r2sbrajlh26xkgrz4vs5l09sxi77y2iqqz3q"
+    "path": "com/android/tools/build/apksig/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apksig-3.0.0.pom": {
+        "sha1": "23c8d16e6aac3ab71c39e37e860a8ab8cff0979c",
+        "sha256": "1ha5d3bh36q4kj0gh1qmg9ncqwbv2n209mfbfnmwxw4gnj4l9a18"
+      },
+      "apksig-3.0.0.jar": {
+        "sha1": "21465a36db10551cfcfd8ad39bb496511f78354c",
+        "sha256": "11jc8f5xb3i0mhr2r2sbrajlh26xkgrz4vs5l09sxi77y2iqqz3q"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.0.1/apksig-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e5218e97587ad80f7945e20cd6db112b7aa00385",
-      "sha256": "02j0ji9hk730va4pxfdg08ka2cs2ibrmbswxf5z2cf6hnfpbd3k6"
-    },
-    "jar": {
-      "sha1": "535b9323a1bd47e3a9c860d11f4e11a80db13f2b",
-      "sha256": "08yky2gjrk4y5hd1q3jh2vyprs13ipd3v2lk63kirdr09nbpqbbi"
+    "path": "com/android/tools/build/apksig/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apksig-3.0.1.pom": {
+        "sha1": "e5218e97587ad80f7945e20cd6db112b7aa00385",
+        "sha256": "02j0ji9hk730va4pxfdg08ka2cs2ibrmbswxf5z2cf6hnfpbd3k6"
+      },
+      "apksig-3.0.1.jar": {
+        "sha1": "535b9323a1bd47e3a9c860d11f4e11a80db13f2b",
+        "sha256": "08yky2gjrk4y5hd1q3jh2vyprs13ipd3v2lk63kirdr09nbpqbbi"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.1.4/apksig-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a0d953c40691088ad3336fca80b5e2cd3fbd05ec",
-      "sha256": "1jfg6giv1mkg7j72g3w7h5gjvbmpalb03ra7lbdwk350lz76jq23"
-    },
-    "jar": {
-      "sha1": "e0c4d0059e68e9f64606dfa01e066f86dd07c6cb",
-      "sha256": "0xa5hzkmfymz5pqnrgw7bx9h13rbfnwy3h7nmmnqcrbrlqvc7bar"
+    "path": "com/android/tools/build/apksig/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apksig-3.1.4.pom": {
+        "sha1": "a0d953c40691088ad3336fca80b5e2cd3fbd05ec",
+        "sha256": "1jfg6giv1mkg7j72g3w7h5gjvbmpalb03ra7lbdwk350lz76jq23"
+      },
+      "apksig-3.1.4.jar": {
+        "sha1": "e0c4d0059e68e9f64606dfa01e066f86dd07c6cb",
+        "sha256": "0xa5hzkmfymz5pqnrgw7bx9h13rbfnwy3h7nmmnqcrbrlqvc7bar"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.2.1/apksig-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6bc273f7c6759c88a5233bcf10c2b11e12b07b67",
-      "sha256": "19iydx6q8n3wij887rybja0n9k7zxg3qwwpd2nls5z70g7s60dg2"
-    },
-    "jar": {
-      "sha1": "0ad6d930fceb350753d645f4bf66b3eb4d2ad566",
-      "sha256": "19fb5izibsqihnappybf98cr1h9k4hdjdr19mdx06rpazzzg4iib"
+    "path": "com/android/tools/build/apksig/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apksig-3.2.1.pom": {
+        "sha1": "6bc273f7c6759c88a5233bcf10c2b11e12b07b67",
+        "sha256": "19iydx6q8n3wij887rybja0n9k7zxg3qwwpd2nls5z70g7s60dg2"
+      },
+      "apksig-3.2.1.jar": {
+        "sha1": "0ad6d930fceb350753d645f4bf66b3eb4d2ad566",
+        "sha256": "19fb5izibsqihnappybf98cr1h9k4hdjdr19mdx06rpazzzg4iib"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.3.1/apksig-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e916d810d293ce4ab620435b41d2e3bc67972cd3",
-      "sha256": "1kc7qym6sff7jh5ixqn68072ma4iksdwmjf5jwd9nax114r64sbh"
-    },
-    "jar": {
-      "sha1": "5dc32667e573a18b05119685ac3f2b8c0f17182d",
-      "sha256": "0bfbk2wx9lrvkmprp961fb4l1zark309fsryjl54i3d7v3nkjyrm"
+    "path": "com/android/tools/build/apksig/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apksig-3.3.1.pom": {
+        "sha1": "e916d810d293ce4ab620435b41d2e3bc67972cd3",
+        "sha256": "1kc7qym6sff7jh5ixqn68072ma4iksdwmjf5jwd9nax114r64sbh"
+      },
+      "apksig-3.3.1.jar": {
+        "sha1": "5dc32667e573a18b05119685ac3f2b8c0f17182d",
+        "sha256": "0bfbk2wx9lrvkmprp961fb4l1zark309fsryjl54i3d7v3nkjyrm"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.5.4/apksig-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5140271d412bd3d8b90f5b7c347d1d708700bb46",
-      "sha256": "1hbxhn5x9fm411rrpccwvifkl7hwdf86f9bd1y24bik4ncpqx5gg"
-    },
-    "jar": {
-      "sha1": "25e48bdb40ac1e627248575dba64ab5fda63389a",
-      "sha256": "0339ppn14py5w6n7wwb0ypfr7xidg4pv6fy2pi6v005j9c98d3v4"
+    "path": "com/android/tools/build/apksig/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apksig-3.5.4.pom": {
+        "sha1": "5140271d412bd3d8b90f5b7c347d1d708700bb46",
+        "sha256": "1hbxhn5x9fm411rrpccwvifkl7hwdf86f9bd1y24bik4ncpqx5gg"
+      },
+      "apksig-3.5.4.jar": {
+        "sha1": "25e48bdb40ac1e627248575dba64ab5fda63389a",
+        "sha256": "0339ppn14py5w6n7wwb0ypfr7xidg4pv6fy2pi6v005j9c98d3v4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apkzlib/3.2.1/apkzlib-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "22a184ca4c2bb74b1b55f4ba8f5ed33516e4d6e8",
-      "sha256": "1cg7xrkfhy5dbca74pij3pjhy28gragsyibmcmzkjawgswngjcal"
-    },
-    "jar": {
-      "sha1": "fd288c2a8a84c8acb4e43cbbd9dc34fd442b8bfb",
-      "sha256": "1ajj2i32yhr59fmdqkkcmn94v6pk5jf8kj41zqqj94q574qx16n3"
+    "path": "com/android/tools/build/apkzlib/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apkzlib-3.2.1.pom": {
+        "sha1": "22a184ca4c2bb74b1b55f4ba8f5ed33516e4d6e8",
+        "sha256": "1cg7xrkfhy5dbca74pij3pjhy28gragsyibmcmzkjawgswngjcal"
+      },
+      "apkzlib-3.2.1.jar": {
+        "sha1": "fd288c2a8a84c8acb4e43cbbd9dc34fd442b8bfb",
+        "sha256": "1ajj2i32yhr59fmdqkkcmn94v6pk5jf8kj41zqqj94q574qx16n3"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apkzlib/3.3.1/apkzlib-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "02214cdec00c2553430192a7f36e9a28cf96bf6f",
-      "sha256": "11fhb589950sinaqy1bp3wa27nmj1zh12hjy5dyd3bys9l5lhn11"
-    },
-    "jar": {
-      "sha1": "0563a5b71668b4fe7da03a0a3054c9fdd973d3cf",
-      "sha256": "1k412fa43z2r04nqybr6kz6ns7scfkzv1yxwkc9r01gmwk06c1b4"
+    "path": "com/android/tools/build/apkzlib/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apkzlib-3.3.1.pom": {
+        "sha1": "02214cdec00c2553430192a7f36e9a28cf96bf6f",
+        "sha256": "11fhb589950sinaqy1bp3wa27nmj1zh12hjy5dyd3bys9l5lhn11"
+      },
+      "apkzlib-3.3.1.jar": {
+        "sha1": "0563a5b71668b4fe7da03a0a3054c9fdd973d3cf",
+        "sha256": "1k412fa43z2r04nqybr6kz6ns7scfkzv1yxwkc9r01gmwk06c1b4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/apkzlib/3.5.4/apkzlib-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "18b3e978362e7383a0137de5829706eb94c4fbc3",
-      "sha256": "1ihjzndpknaaf2ymb1qvb4qf50ld8g0rlzszwja8hcky12x6pa9g"
-    },
-    "jar": {
-      "sha1": "a590af8131b6b03b6b638d716cd46c6529c3dd40",
-      "sha256": "04zrkr30s1ficpxk51awa9c64v5fbqdvi19w7m5zsbhnavij4l5w"
+    "path": "com/android/tools/build/apkzlib/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "apkzlib-3.5.4.pom": {
+        "sha1": "18b3e978362e7383a0137de5829706eb94c4fbc3",
+        "sha256": "1ihjzndpknaaf2ymb1qvb4qf50ld8g0rlzszwja8hcky12x6pa9g"
+      },
+      "apkzlib-3.5.4.jar": {
+        "sha1": "a590af8131b6b03b6b638d716cd46c6529c3dd40",
+        "sha256": "04zrkr30s1ficpxk51awa9c64v5fbqdvi19w7m5zsbhnavij4l5w"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/3.0.0/builder-model-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "770e663a3729b0665f5b73bd2fbd8a196e2cb9ab",
-      "sha256": "0sv1v487fs5z5m131rpmdviqrysh7xdkwj3jga673wdd3phzm6x4"
-    },
-    "jar": {
-      "sha1": "a86b254415fded5297e1d849fa1884dfdf62ff42",
-      "sha256": "1fii28knmbd3jxvmp0b06zv403vkwv3pap4s5i180cwc0wl7789p"
+    "path": "com/android/tools/build/builder-model/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-model-3.0.0.pom": {
+        "sha1": "770e663a3729b0665f5b73bd2fbd8a196e2cb9ab",
+        "sha256": "0sv1v487fs5z5m131rpmdviqrysh7xdkwj3jga673wdd3phzm6x4"
+      },
+      "builder-model-3.0.0.jar": {
+        "sha1": "a86b254415fded5297e1d849fa1884dfdf62ff42",
+        "sha256": "1fii28knmbd3jxvmp0b06zv403vkwv3pap4s5i180cwc0wl7789p"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/3.0.1/builder-model-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a7ac3d40d7a7c001067e92869c2784bfc1b013dd",
-      "sha256": "0189i0hgjbbgxkaqa8j1cf1cxi5zv7mvjz4wkkxp6smcr0pf16g8"
-    },
-    "jar": {
-      "sha1": "e9de7e34339a8eb90fda30ac6bf580d5f2c4f282",
-      "sha256": "1d9xlr54i63f6nkva5fvflqnl8za3i82caxi09bk134gcb66bd33"
+    "path": "com/android/tools/build/builder-model/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-model-3.0.1.pom": {
+        "sha1": "a7ac3d40d7a7c001067e92869c2784bfc1b013dd",
+        "sha256": "0189i0hgjbbgxkaqa8j1cf1cxi5zv7mvjz4wkkxp6smcr0pf16g8"
+      },
+      "builder-model-3.0.1.jar": {
+        "sha1": "e9de7e34339a8eb90fda30ac6bf580d5f2c4f282",
+        "sha256": "1d9xlr54i63f6nkva5fvflqnl8za3i82caxi09bk134gcb66bd33"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/3.1.4/builder-model-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2cd8e9360a4114089d33a0ef98927f14d36c8562",
-      "sha256": "0in1yb8n7m28ppj91k5hxclq60qc9141lwm4hyllqsjl2qdns5ys"
-    },
-    "jar": {
-      "sha1": "f026c31b8228a84b62bb2fe0ac0544143e9ab27d",
-      "sha256": "0gqa2immwkl4kvg4c233ndxp2bg33ypdbmp6jah5ab0c5azqr3bf"
+    "path": "com/android/tools/build/builder-model/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-model-3.1.4.pom": {
+        "sha1": "2cd8e9360a4114089d33a0ef98927f14d36c8562",
+        "sha256": "0in1yb8n7m28ppj91k5hxclq60qc9141lwm4hyllqsjl2qdns5ys"
+      },
+      "builder-model-3.1.4.jar": {
+        "sha1": "f026c31b8228a84b62bb2fe0ac0544143e9ab27d",
+        "sha256": "0gqa2immwkl4kvg4c233ndxp2bg33ypdbmp6jah5ab0c5azqr3bf"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/3.2.1/builder-model-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5d5177ffd5079fdb4c671ca61ecc63d9a8ff2cc7",
-      "sha256": "07z3fcjgmfid0b0xmv3w1vg69z4a1wl1d35n6x6yxbxr7j1kaajd"
-    },
-    "jar": {
-      "sha1": "3984b3e65c34b5d278e434270b63802451ec3e9d",
-      "sha256": "1zv5r7110qy14m6mxafwpjn07sx30lzjsdddnnf2y4pcpim8xxm9"
+    "path": "com/android/tools/build/builder-model/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-model-3.2.1.pom": {
+        "sha1": "5d5177ffd5079fdb4c671ca61ecc63d9a8ff2cc7",
+        "sha256": "07z3fcjgmfid0b0xmv3w1vg69z4a1wl1d35n6x6yxbxr7j1kaajd"
+      },
+      "builder-model-3.2.1.jar": {
+        "sha1": "3984b3e65c34b5d278e434270b63802451ec3e9d",
+        "sha256": "1zv5r7110qy14m6mxafwpjn07sx30lzjsdddnnf2y4pcpim8xxm9"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/3.3.1/builder-model-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4011d22709777c4063e84d39dbfe4ed535a31905",
-      "sha256": "1qzvkfz9yx3shd7j9qfrnx70abljx9d0h9cizl6qd5vdhp65wlsx"
-    },
-    "jar": {
-      "sha1": "2c47cf0451da2eaad484ccd2d580a8cfd23fa064",
-      "sha256": "003z65x06q6nclscq11ylafx6xlwpyzy73g6zbgdr37yqfam4yq5"
+    "path": "com/android/tools/build/builder-model/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-model-3.3.1.pom": {
+        "sha1": "4011d22709777c4063e84d39dbfe4ed535a31905",
+        "sha256": "1qzvkfz9yx3shd7j9qfrnx70abljx9d0h9cizl6qd5vdhp65wlsx"
+      },
+      "builder-model-3.3.1.jar": {
+        "sha1": "2c47cf0451da2eaad484ccd2d580a8cfd23fa064",
+        "sha256": "003z65x06q6nclscq11ylafx6xlwpyzy73g6zbgdr37yqfam4yq5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/3.5.4/builder-model-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e6a529e2090de8d642b697b4067702b628e8ca83",
-      "sha256": "1x2a6f23z5fznmbxyh748ijzc7k5qb14s5w0nd097dn49lb7y6ps"
-    },
-    "jar": {
-      "sha1": "ce9181b0c254dba36f8a1d5ae57fd0ec56c9584c",
-      "sha256": "1pf47k4j5hjhbjh9k82x9vlg3f13v9zvjyciqa2rwy0z4rdj1935"
+    "path": "com/android/tools/build/builder-model/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-model-3.5.4.pom": {
+        "sha1": "e6a529e2090de8d642b697b4067702b628e8ca83",
+        "sha256": "1x2a6f23z5fznmbxyh748ijzc7k5qb14s5w0nd097dn49lb7y6ps"
+      },
+      "builder-model-3.5.4.jar": {
+        "sha1": "ce9181b0c254dba36f8a1d5ae57fd0ec56c9584c",
+        "sha256": "1pf47k4j5hjhbjh9k82x9vlg3f13v9zvjyciqa2rwy0z4rdj1935"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.0.0/builder-test-api-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a73df0f8a961d459e2b726b41867ffd9dd624952",
-      "sha256": "16vrjm0czd9alch5mghmfp4aldp5xnvfl1pq3xh5hr9x5rvmdc3b"
-    },
-    "jar": {
-      "sha1": "9bb354af21d8754ecc9c1c07f80bd85e3a76695f",
-      "sha256": "1kalacq30ydcivyp2pwql59j2xckifv1c6f517ll15pjdxskdnzb"
+    "path": "com/android/tools/build/builder-test-api/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-test-api-3.0.0.pom": {
+        "sha1": "a73df0f8a961d459e2b726b41867ffd9dd624952",
+        "sha256": "16vrjm0czd9alch5mghmfp4aldp5xnvfl1pq3xh5hr9x5rvmdc3b"
+      },
+      "builder-test-api-3.0.0.jar": {
+        "sha1": "9bb354af21d8754ecc9c1c07f80bd85e3a76695f",
+        "sha256": "1kalacq30ydcivyp2pwql59j2xckifv1c6f517ll15pjdxskdnzb"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.0.1/builder-test-api-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ef4ababa08f89af4c1b0a1217780ec5abcfbbea0",
-      "sha256": "0xl86xji19i4081d8gziima23s9hhn9x2yxb6gbah34r9sksh2lb"
-    },
-    "jar": {
-      "sha1": "05f084a2888a7f638c4c89c3278760345b1fb4c8",
-      "sha256": "0kc9g0sz59qy65m5mw3qxr4iclf20kjkks2p0h8l6j6vi8ja2rz7"
+    "path": "com/android/tools/build/builder-test-api/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-test-api-3.0.1.pom": {
+        "sha1": "ef4ababa08f89af4c1b0a1217780ec5abcfbbea0",
+        "sha256": "0xl86xji19i4081d8gziima23s9hhn9x2yxb6gbah34r9sksh2lb"
+      },
+      "builder-test-api-3.0.1.jar": {
+        "sha1": "05f084a2888a7f638c4c89c3278760345b1fb4c8",
+        "sha256": "0kc9g0sz59qy65m5mw3qxr4iclf20kjkks2p0h8l6j6vi8ja2rz7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.1.4/builder-test-api-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e9843c965bd3ec945ad5e94feebbfe1d47aa5a3b",
-      "sha256": "0adip5p8lvbhcqxhqrpahws9ia9f9q12dkzchf5kj44vgl0r7mbf"
-    },
-    "jar": {
-      "sha1": "e48338f64f1c8fbef8329eb6d899fb6378fca604",
-      "sha256": "1qjgvj3jmwa7gxc910vfa56rijzin33zymqpb4ikfpsvhk7g2kqz"
+    "path": "com/android/tools/build/builder-test-api/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-test-api-3.1.4.pom": {
+        "sha1": "e9843c965bd3ec945ad5e94feebbfe1d47aa5a3b",
+        "sha256": "0adip5p8lvbhcqxhqrpahws9ia9f9q12dkzchf5kj44vgl0r7mbf"
+      },
+      "builder-test-api-3.1.4.jar": {
+        "sha1": "e48338f64f1c8fbef8329eb6d899fb6378fca604",
+        "sha256": "1qjgvj3jmwa7gxc910vfa56rijzin33zymqpb4ikfpsvhk7g2kqz"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.2.1/builder-test-api-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7491225517d80b5dde854365e2d299926b3d7962",
-      "sha256": "0bg1lj9kgafw233xn9cl5mwnwsjx3mblrsw15sd51kn9x1ny5i0n"
-    },
-    "jar": {
-      "sha1": "09c0b9848b34d79d71f911ebfaf6e0d606e7a3e6",
-      "sha256": "1gmng51kvd1klcbr9wqsk33zmzcdcbr92dx3cx4vajw8np1ccfjk"
+    "path": "com/android/tools/build/builder-test-api/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-test-api-3.2.1.pom": {
+        "sha1": "7491225517d80b5dde854365e2d299926b3d7962",
+        "sha256": "0bg1lj9kgafw233xn9cl5mwnwsjx3mblrsw15sd51kn9x1ny5i0n"
+      },
+      "builder-test-api-3.2.1.jar": {
+        "sha1": "09c0b9848b34d79d71f911ebfaf6e0d606e7a3e6",
+        "sha256": "1gmng51kvd1klcbr9wqsk33zmzcdcbr92dx3cx4vajw8np1ccfjk"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.3.1/builder-test-api-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e79a310b9c89fcb62f343b727f5747783c778861",
-      "sha256": "01k4bywl2zb6f28bvhzrq7vpngxg4zna4lad8h2s35kxn1znirl5"
-    },
-    "jar": {
-      "sha1": "c1a1ce91c0f34c43a52c54c1a2f6fdbaafadd3da",
-      "sha256": "036bbx5pnwx0n4waf6iyxjywmf8m8817fd1f21l02qrry7kdb299"
+    "path": "com/android/tools/build/builder-test-api/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-test-api-3.3.1.pom": {
+        "sha1": "e79a310b9c89fcb62f343b727f5747783c778861",
+        "sha256": "01k4bywl2zb6f28bvhzrq7vpngxg4zna4lad8h2s35kxn1znirl5"
+      },
+      "builder-test-api-3.3.1.jar": {
+        "sha1": "c1a1ce91c0f34c43a52c54c1a2f6fdbaafadd3da",
+        "sha256": "036bbx5pnwx0n4waf6iyxjywmf8m8817fd1f21l02qrry7kdb299"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.5.4/builder-test-api-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b201367cc7edf91447be7cda74f26cc6b5ed3fd0",
-      "sha256": "1y3k7rdg8mdgddbwzp4jsimpqa6axmxdamj5gdbzi8qqmi52fbh7"
-    },
-    "jar": {
-      "sha1": "d7c771aebbdcf2e07dde87cec1339c6f28e12636",
-      "sha256": "1r85gcr2z8h4n6maiyamnbr3bmb8bjz3mzd207mfylbp0v8y11sq"
+    "path": "com/android/tools/build/builder-test-api/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-test-api-3.5.4.pom": {
+        "sha1": "b201367cc7edf91447be7cda74f26cc6b5ed3fd0",
+        "sha256": "1y3k7rdg8mdgddbwzp4jsimpqa6axmxdamj5gdbzi8qqmi52fbh7"
+      },
+      "builder-test-api-3.5.4.jar": {
+        "sha1": "d7c771aebbdcf2e07dde87cec1339c6f28e12636",
+        "sha256": "1r85gcr2z8h4n6maiyamnbr3bmb8bjz3mzd207mfylbp0v8y11sq"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/3.0.0/builder-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8b498ff308f743e8689f528efa56837ac5fdbde6",
-      "sha256": "0a4pal1w33v90cfpd72brb2chqfqmpqs52klg9xigwrkbyjgkp4b"
-    },
-    "jar": {
-      "sha1": "36884960f350cb29f1c2c93107f4fa27f4e7444e",
-      "sha256": "07pwrxv5igr4v1886rjdfrrqx4sa5b64yz0p41450qywzm2n880n"
+    "path": "com/android/tools/build/builder/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-3.0.0.pom": {
+        "sha1": "8b498ff308f743e8689f528efa56837ac5fdbde6",
+        "sha256": "0a4pal1w33v90cfpd72brb2chqfqmpqs52klg9xigwrkbyjgkp4b"
+      },
+      "builder-3.0.0.jar": {
+        "sha1": "36884960f350cb29f1c2c93107f4fa27f4e7444e",
+        "sha256": "07pwrxv5igr4v1886rjdfrrqx4sa5b64yz0p41450qywzm2n880n"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/3.0.1/builder-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "00bdc803975a0159610829a018c5e19fd4cb193d",
-      "sha256": "1jfi3wymgpb0pk23q53wgjxqz4zvj71wvx7rm0da2cfhj332ghsx"
-    },
-    "jar": {
-      "sha1": "1f896967507729bb35ac727c03d3b9306fe87b7d",
-      "sha256": "169b6i7rv968k1hkxw4h5hbnmy77ms2yv0w6cwg7vpdqxnaf6fw0"
+    "path": "com/android/tools/build/builder/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-3.0.1.pom": {
+        "sha1": "00bdc803975a0159610829a018c5e19fd4cb193d",
+        "sha256": "1jfi3wymgpb0pk23q53wgjxqz4zvj71wvx7rm0da2cfhj332ghsx"
+      },
+      "builder-3.0.1.jar": {
+        "sha1": "1f896967507729bb35ac727c03d3b9306fe87b7d",
+        "sha256": "169b6i7rv968k1hkxw4h5hbnmy77ms2yv0w6cwg7vpdqxnaf6fw0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/3.1.4/builder-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d33573f1d53514989682eaf85d2c2b98f37aeae2",
-      "sha256": "064y4z05s3r7x74rlb26c8m7aq5pharw5l1yk1ca76h9k0lafslp"
-    },
-    "jar": {
-      "sha1": "afbcd4b7002c61fe898b1b4c50ed9e62386125d8",
-      "sha256": "02wmahn5ibgnxqrk7nqzwdgc4j80iml01g17lmlghdhdmks3y9zy"
+    "path": "com/android/tools/build/builder/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-3.1.4.pom": {
+        "sha1": "d33573f1d53514989682eaf85d2c2b98f37aeae2",
+        "sha256": "064y4z05s3r7x74rlb26c8m7aq5pharw5l1yk1ca76h9k0lafslp"
+      },
+      "builder-3.1.4.jar": {
+        "sha1": "afbcd4b7002c61fe898b1b4c50ed9e62386125d8",
+        "sha256": "02wmahn5ibgnxqrk7nqzwdgc4j80iml01g17lmlghdhdmks3y9zy"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/3.2.1/builder-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0b2116384a9cbf80be799fa327c808ac5e9e42ad",
-      "sha256": "0kz85c6cplwsmfh1xlzhpfpj1jbs1qwgk4j80phs8fkv1m9arcv3"
-    },
-    "jar": {
-      "sha1": "1303a2feb969ac0896e7c83c1f5a0fd2496b71bc",
-      "sha256": "10xfgywcjryqn4rz3cm31a6mb6sqa3pncghinh4ivsfv2p8vzp5f"
+    "path": "com/android/tools/build/builder/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-3.2.1.pom": {
+        "sha1": "0b2116384a9cbf80be799fa327c808ac5e9e42ad",
+        "sha256": "0kz85c6cplwsmfh1xlzhpfpj1jbs1qwgk4j80phs8fkv1m9arcv3"
+      },
+      "builder-3.2.1.jar": {
+        "sha1": "1303a2feb969ac0896e7c83c1f5a0fd2496b71bc",
+        "sha256": "10xfgywcjryqn4rz3cm31a6mb6sqa3pncghinh4ivsfv2p8vzp5f"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/3.3.1/builder-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fbca96adc8069b8fcb01c7271c3b4be4f901b517",
-      "sha256": "1r032kp70fcgp1kn3c128yzs9hw50mjrpfiqbjkcga049vlxw3x6"
-    },
-    "jar": {
-      "sha1": "e4d2ad1ef694fca700b3ab1f4df4b79313d17c98",
-      "sha256": "0ljw05allv94hkh63jr8m4x0vvfnnclff0jpbfldyp2bhqyzb26f"
+    "path": "com/android/tools/build/builder/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-3.3.1.pom": {
+        "sha1": "fbca96adc8069b8fcb01c7271c3b4be4f901b517",
+        "sha256": "1r032kp70fcgp1kn3c128yzs9hw50mjrpfiqbjkcga049vlxw3x6"
+      },
+      "builder-3.3.1.jar": {
+        "sha1": "e4d2ad1ef694fca700b3ab1f4df4b79313d17c98",
+        "sha256": "0ljw05allv94hkh63jr8m4x0vvfnnclff0jpbfldyp2bhqyzb26f"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/3.5.4/builder-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ef68ad9d71bd9336d25de233d96b1b0927233d5c",
-      "sha256": "1p5zpdzgpqlahmgiw3885apvi0lm0cypv4mq1v9fz5h1j1p436jx"
-    },
-    "jar": {
-      "sha1": "287ffb45bab7531f677cb1411b1f157b43d1f4ab",
-      "sha256": "1f58gqcw1jivfifbywiaj09j02q5p9cmhwfy5f0bm9jbnnlmyyyd"
+    "path": "com/android/tools/build/builder/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "builder-3.5.4.pom": {
+        "sha1": "ef68ad9d71bd9336d25de233d96b1b0927233d5c",
+        "sha256": "1p5zpdzgpqlahmgiw3885apvi0lm0cypv4mq1v9fz5h1j1p436jx"
+      },
+      "builder-3.5.4.jar": {
+        "sha1": "287ffb45bab7531f677cb1411b1f157b43d1f4ab",
+        "sha256": "1f58gqcw1jivfifbywiaj09j02q5p9cmhwfy5f0bm9jbnnlmyyyd"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/bundletool/0.1.0-alpha01/bundletool-0.1.0-alpha01",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "834b735a36a399e2bb0276842ce97c55f6d6c072",
-      "sha256": "1271sgv8jxdgsf60chx8yjc0jsfs38xd2jhdmdv8d8h4iwrpcrvc"
-    },
-    "jar": {
-      "sha1": "f7c303e37818223bd98566fcbea29aa0964c4d06",
-      "sha256": "05bgc6sh1cz4l8mbw6jyx78pq275szq011z5cgpjdkdbpzq5dnrv"
+    "path": "com/android/tools/build/bundletool/0.1.0-alpha01",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "bundletool-0.1.0-alpha01.pom": {
+        "sha1": "834b735a36a399e2bb0276842ce97c55f6d6c072",
+        "sha256": "1271sgv8jxdgsf60chx8yjc0jsfs38xd2jhdmdv8d8h4iwrpcrvc"
+      },
+      "bundletool-0.1.0-alpha01.jar": {
+        "sha1": "f7c303e37818223bd98566fcbea29aa0964c4d06",
+        "sha256": "05bgc6sh1cz4l8mbw6jyx78pq275szq011z5cgpjdkdbpzq5dnrv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/bundletool/0.5.0/bundletool-0.5.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "37b0f576d869aab168033ee8b21a54ffc307667e",
-      "sha256": "0bqw882xwyzzxfd3hm218k448aja8m56xybaabl45k9ajsmvz6vw"
-    },
-    "jar": {
-      "sha1": "ffd6077d13937213b860c0022174ece60000eabc",
-      "sha256": "0cdqjbh78iq8ymhqzkrskhcv6symplm1pks9sysm9r0ql6077phz"
+    "path": "com/android/tools/build/bundletool/0.5.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "bundletool-0.5.0.pom": {
+        "sha1": "37b0f576d869aab168033ee8b21a54ffc307667e",
+        "sha256": "0bqw882xwyzzxfd3hm218k448aja8m56xybaabl45k9ajsmvz6vw"
+      },
+      "bundletool-0.5.0.jar": {
+        "sha1": "ffd6077d13937213b860c0022174ece60000eabc",
+        "sha256": "0cdqjbh78iq8ymhqzkrskhcv6symplm1pks9sysm9r0ql6077phz"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/bundletool/0.6.0/bundletool-0.6.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5a6e5b5af1687285125f43e00a8e5a8efe6f76a4",
-      "sha256": "08j6w1bh9n0cbwm31ams4qkiz3bnlrg07380kkr47blidkls4fk0"
-    },
-    "jar": {
-      "sha1": "fb944be26f692e6ac937924ad5be7faa4093dd80",
-      "sha256": "1fjbbj4yrjqxq3a3y0dzg1lq2spfchl4l2v6s1cikdbc7503a1a0"
+    "path": "com/android/tools/build/bundletool/0.6.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "bundletool-0.6.0.pom": {
+        "sha1": "5a6e5b5af1687285125f43e00a8e5a8efe6f76a4",
+        "sha256": "08j6w1bh9n0cbwm31ams4qkiz3bnlrg07380kkr47blidkls4fk0"
+      },
+      "bundletool-0.6.0.jar": {
+        "sha1": "fb944be26f692e6ac937924ad5be7faa4093dd80",
+        "sha256": "1fjbbj4yrjqxq3a3y0dzg1lq2spfchl4l2v6s1cikdbc7503a1a0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/bundletool/0.9.0/bundletool-0.9.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c54b8b912afb54d6393182adc99489917e3a1a7e",
-      "sha256": "1hk7sf03l39f9q7qx8b1qsscnwgzpl6hyi573nvqjdl04x114khj"
-    },
-    "jar": {
-      "sha1": "6c7492aedf12ff02ed7c634246026ac7f7372dd2",
-      "sha256": "0ggss9x7431rdq1h9sxmk9isgsqyp14acddcckinic3mr9blbi2h"
+    "path": "com/android/tools/build/bundletool/0.9.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "bundletool-0.9.0.pom": {
+        "sha1": "c54b8b912afb54d6393182adc99489917e3a1a7e",
+        "sha256": "1hk7sf03l39f9q7qx8b1qsscnwgzpl6hyi573nvqjdl04x114khj"
+      },
+      "bundletool-0.9.0.jar": {
+        "sha1": "6c7492aedf12ff02ed7c634246026ac7f7372dd2",
+        "sha256": "0ggss9x7431rdq1h9sxmk9isgsqyp14acddcckinic3mr9blbi2h"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.0.0/gradle-api-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ac9fda7c14cac6f32f55f5083eb4f05c686de023",
-      "sha256": "1f7im02c138frynchbkndrw6lrbc0pyh6vmkx7a99g4jplb1lgmn"
-    },
-    "jar": {
-      "sha1": "e98ade5c308a99980d2a61f4ce1d9286df0105e3",
-      "sha256": "1cslx6qiffrq292ka2390yk4jypd3d5f3qx6kwcrr5k6cg1idw24"
+    "path": "com/android/tools/build/gradle-api/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-api-3.0.0.pom": {
+        "sha1": "ac9fda7c14cac6f32f55f5083eb4f05c686de023",
+        "sha256": "1f7im02c138frynchbkndrw6lrbc0pyh6vmkx7a99g4jplb1lgmn"
+      },
+      "gradle-api-3.0.0.jar": {
+        "sha1": "e98ade5c308a99980d2a61f4ce1d9286df0105e3",
+        "sha256": "1cslx6qiffrq292ka2390yk4jypd3d5f3qx6kwcrr5k6cg1idw24"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.0.1/gradle-api-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f690377f3de82dfb540ee80dd6b4cd86d9cda1c1",
-      "sha256": "1kfvp0xvwkd3z35ba7fy5wafqhixpqkpd6q1bjss5w7r21vb3xz2"
-    },
-    "jar": {
-      "sha1": "92640ae3c543aa3faee7b954ce641d03949d4401",
-      "sha256": "0z8k76ah3f25wmb28rc8ni8f12dyd0fpbhg24ld4p7iawsqkyqr4"
+    "path": "com/android/tools/build/gradle-api/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-api-3.0.1.pom": {
+        "sha1": "f690377f3de82dfb540ee80dd6b4cd86d9cda1c1",
+        "sha256": "1kfvp0xvwkd3z35ba7fy5wafqhixpqkpd6q1bjss5w7r21vb3xz2"
+      },
+      "gradle-api-3.0.1.jar": {
+        "sha1": "92640ae3c543aa3faee7b954ce641d03949d4401",
+        "sha256": "0z8k76ah3f25wmb28rc8ni8f12dyd0fpbhg24ld4p7iawsqkyqr4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.1.4/gradle-api-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e18ab0b7eee6fc63e65158b4f88bf5c7ce207524",
-      "sha256": "0rjnchkvy8j8k3f12l060p4yg9c784l8j7ngdbphy6jwipvxfz2j"
-    },
-    "jar": {
-      "sha1": "eb41dfb5596afd8933c804595ca8596952fad450",
-      "sha256": "0qqsqjrgnamvzll97ylzw34f75hcp3cmh65dzksqhxgwcfcp9sni"
+    "path": "com/android/tools/build/gradle-api/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-api-3.1.4.pom": {
+        "sha1": "e18ab0b7eee6fc63e65158b4f88bf5c7ce207524",
+        "sha256": "0rjnchkvy8j8k3f12l060p4yg9c784l8j7ngdbphy6jwipvxfz2j"
+      },
+      "gradle-api-3.1.4.jar": {
+        "sha1": "eb41dfb5596afd8933c804595ca8596952fad450",
+        "sha256": "0qqsqjrgnamvzll97ylzw34f75hcp3cmh65dzksqhxgwcfcp9sni"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.2.1/gradle-api-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e1fdffe59af4366be13486055a56e95c5be928b5",
-      "sha256": "1vaf8y4vk96q246z2s1mmjwzvnss2gipqrpgrj9wqbswx9jynd0j"
-    },
-    "jar": {
-      "sha1": "825438df08a0c323b7d315071d402ff8fe700a42",
-      "sha256": "1390vs9m382kzd23ik21lv7psvkpbqk98aznngyqmjhxmk2hmksp"
+    "path": "com/android/tools/build/gradle-api/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-api-3.2.1.pom": {
+        "sha1": "e1fdffe59af4366be13486055a56e95c5be928b5",
+        "sha256": "1vaf8y4vk96q246z2s1mmjwzvnss2gipqrpgrj9wqbswx9jynd0j"
+      },
+      "gradle-api-3.2.1.jar": {
+        "sha1": "825438df08a0c323b7d315071d402ff8fe700a42",
+        "sha256": "1390vs9m382kzd23ik21lv7psvkpbqk98aznngyqmjhxmk2hmksp"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.3.1/gradle-api-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c9a6cecdb5e233c2ffde76507bddc6f26ade5528",
-      "sha256": "053m7icgnsfzfhlpipnvv2icci1sd02767f49zfx9hrqp1v145fw"
-    },
-    "jar": {
-      "sha1": "93aac19942998e480db4195212150fb30f7a78cd",
-      "sha256": "05mlws3b014ai7phc5g9mxjavymkqgg2zpbmzzvhbcscw7yb3ja8"
+    "path": "com/android/tools/build/gradle-api/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-api-3.3.1.pom": {
+        "sha1": "c9a6cecdb5e233c2ffde76507bddc6f26ade5528",
+        "sha256": "053m7icgnsfzfhlpipnvv2icci1sd02767f49zfx9hrqp1v145fw"
+      },
+      "gradle-api-3.3.1.jar": {
+        "sha1": "93aac19942998e480db4195212150fb30f7a78cd",
+        "sha256": "05mlws3b014ai7phc5g9mxjavymkqgg2zpbmzzvhbcscw7yb3ja8"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.5.4/gradle-api-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6522e0a98fdfff19d417c714957c9b8f3a8e9398",
-      "sha256": "0ggbkckyxcnyngh4f1k8pdznhsrwwq3rrypp0p1rp2a2p6a8h9j8"
-    },
-    "jar": {
-      "sha1": "b7e85ab17eee5cc049702b127512c1993a85b5bb",
-      "sha256": "0vqn9jba543pdy96cjfpxnbyvslyhx6zinnsws6bh75bk293w6xv"
+    "path": "com/android/tools/build/gradle-api/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-api-3.5.4.pom": {
+        "sha1": "6522e0a98fdfff19d417c714957c9b8f3a8e9398",
+        "sha256": "0ggbkckyxcnyngh4f1k8pdznhsrwwq3rrypp0p1rp2a2p6a8h9j8"
+      },
+      "gradle-api-3.5.4.jar": {
+        "sha1": "b7e85ab17eee5cc049702b127512c1993a85b5bb",
+        "sha256": "0vqn9jba543pdy96cjfpxnbyvslyhx6zinnsws6bh75bk293w6xv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-core/3.0.0/gradle-core-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "92aba105dcd9d8fb6e42dbc959affdbcfe5cc136",
-      "sha256": "1h4a1gfr432kxs6r3gpx7hpc4v6xrd4f48rahizmrix2dw2405i5"
-    },
-    "jar": {
-      "sha1": "b4b02fa623c5a618e68478d9a4a67e1e87c023c6",
-      "sha256": "1z6yh3aviy8hvrcihz1xnsggrzjp6yd4wipdw03l1l4f2w378x2p"
+    "path": "com/android/tools/build/gradle-core/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-core-3.0.0.pom": {
+        "sha1": "92aba105dcd9d8fb6e42dbc959affdbcfe5cc136",
+        "sha256": "1h4a1gfr432kxs6r3gpx7hpc4v6xrd4f48rahizmrix2dw2405i5"
+      },
+      "gradle-core-3.0.0.jar": {
+        "sha1": "b4b02fa623c5a618e68478d9a4a67e1e87c023c6",
+        "sha256": "1z6yh3aviy8hvrcihz1xnsggrzjp6yd4wipdw03l1l4f2w378x2p"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-core/3.0.1/gradle-core-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "13a9e82c7724e138dc6cb8cf958ca9fcbf0db8ab",
-      "sha256": "130pcxhs4bify71i3ydapjx5pmndr0qfbcl0phzb8yyhyw3d1ri3"
-    },
-    "jar": {
-      "sha1": "c2945119335b491ca56e4042f7c8c55dccf5c9c2",
-      "sha256": "09w0jxh7vkmgy6ing49l8xpyp7jrcz56g2j5sfsyipacdyahyr0a"
+    "path": "com/android/tools/build/gradle-core/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-core-3.0.1.pom": {
+        "sha1": "13a9e82c7724e138dc6cb8cf958ca9fcbf0db8ab",
+        "sha256": "130pcxhs4bify71i3ydapjx5pmndr0qfbcl0phzb8yyhyw3d1ri3"
+      },
+      "gradle-core-3.0.1.jar": {
+        "sha1": "c2945119335b491ca56e4042f7c8c55dccf5c9c2",
+        "sha256": "09w0jxh7vkmgy6ing49l8xpyp7jrcz56g2j5sfsyipacdyahyr0a"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-core/3.1.4/gradle-core-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "38efeb43831cda5d758c52cd62817c3c53ac4722",
-      "sha256": "1kiij87ybp97q5m3w81pr9gy94fpf5jm59jp67ia9h7cz9dj0kv1"
-    },
-    "jar": {
-      "sha1": "4c846d065331c2a11ed605619613833a842a7b8d",
-      "sha256": "1nhx6sjfxfqq63yr59i5j09yvkm383fim93fcfkp6s711ma54pma"
+    "path": "com/android/tools/build/gradle-core/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-core-3.1.4.pom": {
+        "sha1": "38efeb43831cda5d758c52cd62817c3c53ac4722",
+        "sha256": "1kiij87ybp97q5m3w81pr9gy94fpf5jm59jp67ia9h7cz9dj0kv1"
+      },
+      "gradle-core-3.1.4.jar": {
+        "sha1": "4c846d065331c2a11ed605619613833a842a7b8d",
+        "sha256": "1nhx6sjfxfqq63yr59i5j09yvkm383fim93fcfkp6s711ma54pma"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/3.0.0/gradle-3.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "efe9a4c336629561a04b7eafd895054908807cdb",
-      "sha256": "07qm0bfvivx0h2ww7z5sdws78j4gkn75x2hy2mhbhhwq9k20nf4d"
-    },
-    "jar": {
-      "sha1": "2356ee8e98b68c53dafc28898e7034080e5c91aa",
-      "sha256": "00ivxwq5rgrx7wfkr8g5z1n21vap9r2vaid9djdqfr9f3jygq8mb"
+    "path": "com/android/tools/build/gradle/3.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-3.0.0.pom": {
+        "sha1": "efe9a4c336629561a04b7eafd895054908807cdb",
+        "sha256": "07qm0bfvivx0h2ww7z5sdws78j4gkn75x2hy2mhbhhwq9k20nf4d"
+      },
+      "gradle-3.0.0.jar": {
+        "sha1": "2356ee8e98b68c53dafc28898e7034080e5c91aa",
+        "sha256": "00ivxwq5rgrx7wfkr8g5z1n21vap9r2vaid9djdqfr9f3jygq8mb"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/3.0.1/gradle-3.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f6941bdcc20f1efd54b55db56be1085bbe24e554",
-      "sha256": "0ya15fr2c9a842799igv6kwzs1hb9rrsa0ix0b7f0snlm4jirxqy"
-    },
-    "jar": {
-      "sha1": "cfa107d4db0c11c11f445a11e768adf61c72ce06",
-      "sha256": "0ahm0ks11x14yxzakpwbpbr8kq7j8dfxm4qbhqlk92d39sx7rmzw"
+    "path": "com/android/tools/build/gradle/3.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-3.0.1.pom": {
+        "sha1": "f6941bdcc20f1efd54b55db56be1085bbe24e554",
+        "sha256": "0ya15fr2c9a842799igv6kwzs1hb9rrsa0ix0b7f0snlm4jirxqy"
+      },
+      "gradle-3.0.1.jar": {
+        "sha1": "cfa107d4db0c11c11f445a11e768adf61c72ce06",
+        "sha256": "0ahm0ks11x14yxzakpwbpbr8kq7j8dfxm4qbhqlk92d39sx7rmzw"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/3.1.4/gradle-3.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "920f69e56d872f11136254d329ccc6825ced29a1",
-      "sha256": "1cs4sqfpwg0fhdhyqdpzq70gkyq9cy9xm11bmvpanfls2wcwyqi5"
-    },
-    "jar": {
-      "sha1": "08f9a726f69c0c8fa3f447566717a21e6b394ed9",
-      "sha256": "1dxp32ncbrvi8qd9pij9r0mzcn3l6qm7jr0rk86nq5xi0k06ak0g"
+    "path": "com/android/tools/build/gradle/3.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-3.1.4.pom": {
+        "sha1": "920f69e56d872f11136254d329ccc6825ced29a1",
+        "sha256": "1cs4sqfpwg0fhdhyqdpzq70gkyq9cy9xm11bmvpanfls2wcwyqi5"
+      },
+      "gradle-3.1.4.jar": {
+        "sha1": "08f9a726f69c0c8fa3f447566717a21e6b394ed9",
+        "sha256": "1dxp32ncbrvi8qd9pij9r0mzcn3l6qm7jr0rk86nq5xi0k06ak0g"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/3.2.1/gradle-3.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "15d3336376c1847b8c51a1d398599eb7f4aa68c4",
-      "sha256": "1jyqnv2s80dc41z0y13sva7pnsn44qx2bbqyj1s66q0m4r8jn1if"
-    },
-    "jar": {
-      "sha1": "1ce0d907aa7805e19f553807b9bbdc9bb9841dbf",
-      "sha256": "0z6cimd0lbpm6y278qg8p1nj826ncxm37nj8931j21814dw1z2hh"
+    "path": "com/android/tools/build/gradle/3.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-3.2.1.pom": {
+        "sha1": "15d3336376c1847b8c51a1d398599eb7f4aa68c4",
+        "sha256": "1jyqnv2s80dc41z0y13sva7pnsn44qx2bbqyj1s66q0m4r8jn1if"
+      },
+      "gradle-3.2.1.jar": {
+        "sha1": "1ce0d907aa7805e19f553807b9bbdc9bb9841dbf",
+        "sha256": "0z6cimd0lbpm6y278qg8p1nj826ncxm37nj8931j21814dw1z2hh"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/3.3.1/gradle-3.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1769370bffda87132eb79580bf54ccb9eb339020",
-      "sha256": "0z7z83253wq5h0aqc4nrmr0i4san6i21gapzwlmpl1rsfjksvs7m"
-    },
-    "jar": {
-      "sha1": "7d642f14aa35443dd7aeecd0600c17da37d3bccc",
-      "sha256": "1g8ivii0sc0a3a67nvgl0552sw084hpyfs2ihsp9ppriqnmrjr7m"
+    "path": "com/android/tools/build/gradle/3.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-3.3.1.pom": {
+        "sha1": "1769370bffda87132eb79580bf54ccb9eb339020",
+        "sha256": "0z7z83253wq5h0aqc4nrmr0i4san6i21gapzwlmpl1rsfjksvs7m"
+      },
+      "gradle-3.3.1.jar": {
+        "sha1": "7d642f14aa35443dd7aeecd0600c17da37d3bccc",
+        "sha256": "1g8ivii0sc0a3a67nvgl0552sw084hpyfs2ihsp9ppriqnmrjr7m"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/3.5.4/gradle-3.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "69e3655fd7c0b419cfb40b07e5cb5e9dcabfb8ac",
-      "sha256": "0gyl3i55mv38skmp26xnb2y5xy02v7nqfg9qz4n6y58pdj85q7ms"
-    },
-    "jar": {
-      "sha1": "a72c4b804b2bf0bcee270adf0bdf2e83fa9ad50f",
-      "sha256": "0gxgpi92jkrics8i0s87dkbaxgjs5h0g6nniskhyacaasgy6vf62"
+    "path": "com/android/tools/build/gradle/3.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "gradle-3.5.4.pom": {
+        "sha1": "69e3655fd7c0b419cfb40b07e5cb5e9dcabfb8ac",
+        "sha256": "0gyl3i55mv38skmp26xnb2y5xy02v7nqfg9qz4n6y58pdj85q7ms"
+      },
+      "gradle-3.5.4.jar": {
+        "sha1": "a72c4b804b2bf0bcee270adf0bdf2e83fa9ad50f",
+        "sha256": "0gxgpi92jkrics8i0s87dkbaxgjs5h0g6nniskhyacaasgy6vf62"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/jetifier/jetifier-core/1.0.0-alpha10/jetifier-core-1.0.0-alpha10",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c81a50e473499d158969ec0e041aedbce0bf49e4",
-      "sha256": "1gpvwnc67c6rh24ijnwim6c0ri51ww7syg49kqn605977bcbv5q8"
-    },
-    "jar": {
-      "sha1": "9eb7027c383061de12f93aae7a22cbeb97832d2a",
-      "sha256": "15m3hclhv9z935mcw2012j1ldzi2h7j0nqv09n8cshg49m03w1s0"
+    "path": "com/android/tools/build/jetifier/jetifier-core/1.0.0-alpha10",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "jetifier-core-1.0.0-alpha10.pom": {
+        "sha1": "c81a50e473499d158969ec0e041aedbce0bf49e4",
+        "sha256": "1gpvwnc67c6rh24ijnwim6c0ri51ww7syg49kqn605977bcbv5q8"
+      },
+      "jetifier-core-1.0.0-alpha10.jar": {
+        "sha1": "9eb7027c383061de12f93aae7a22cbeb97832d2a",
+        "sha256": "15m3hclhv9z935mcw2012j1ldzi2h7j0nqv09n8cshg49m03w1s0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/jetifier/jetifier-core/1.0.0-beta02/jetifier-core-1.0.0-beta02",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "db878af76000b681798b114a5169163b1efe59ea",
-      "sha256": "1ff3vxl3p5indy69ay2j78wqix4d6x1wkwdsg3j2hc1vas98d4ch"
-    },
-    "jar": {
-      "sha1": "fa93fdb83bdfd51e80e09a808fb2515a7134d406",
-      "sha256": "14s7b8a5c378clgkn8d0cfi79v4hg9zgrhaq7371vd7q091zhqgg"
+    "path": "com/android/tools/build/jetifier/jetifier-core/1.0.0-beta02",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "jetifier-core-1.0.0-beta02.pom": {
+        "sha1": "db878af76000b681798b114a5169163b1efe59ea",
+        "sha256": "1ff3vxl3p5indy69ay2j78wqix4d6x1wkwdsg3j2hc1vas98d4ch"
+      },
+      "jetifier-core-1.0.0-beta02.jar": {
+        "sha1": "fa93fdb83bdfd51e80e09a808fb2515a7134d406",
+        "sha256": "14s7b8a5c378clgkn8d0cfi79v4hg9zgrhaq7371vd7q091zhqgg"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/jetifier/jetifier-core/1.0.0-beta04/jetifier-core-1.0.0-beta04",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d9d79b2e0b66e7ab107f5e07fc021c6a7ff8c365",
-      "sha256": "0klffmf4f653s17pzpw706dfrdx95cia3kb71zgnx2f6pg8ml0nv"
-    },
-    "jar": {
-      "sha1": "92ae18564fc833685f30f5a20297dd32349a9f6e",
-      "sha256": "04bgfq2xvck5hgv8wpmcghb8jcp29prlfbg9mv2k3ysc2hbb1y69"
+    "path": "com/android/tools/build/jetifier/jetifier-core/1.0.0-beta04",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "jetifier-core-1.0.0-beta04.pom": {
+        "sha1": "d9d79b2e0b66e7ab107f5e07fc021c6a7ff8c365",
+        "sha256": "0klffmf4f653s17pzpw706dfrdx95cia3kb71zgnx2f6pg8ml0nv"
+      },
+      "jetifier-core-1.0.0-beta04.jar": {
+        "sha1": "92ae18564fc833685f30f5a20297dd32349a9f6e",
+        "sha256": "04bgfq2xvck5hgv8wpmcghb8jcp29prlfbg9mv2k3ysc2hbb1y69"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/jetifier/jetifier-processor/1.0.0-alpha10/jetifier-processor-1.0.0-alpha10",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2a59ae1bc830ad76a588eb20b6d58be93ca97399",
-      "sha256": "065fw0x0mwki888adbawnmjm8d0d9fsv8smnlga91pyh1ddhxkm0"
-    },
-    "jar": {
-      "sha1": "6d494a04e0af27ecd4ec7a35c93759dd9c7443bc",
-      "sha256": "00kng40zp8j1v4mvfzbzvj5nfds5vq66bhmd6jgxyqyszi9z0qbw"
+    "path": "com/android/tools/build/jetifier/jetifier-processor/1.0.0-alpha10",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "jetifier-processor-1.0.0-alpha10.pom": {
+        "sha1": "2a59ae1bc830ad76a588eb20b6d58be93ca97399",
+        "sha256": "065fw0x0mwki888adbawnmjm8d0d9fsv8smnlga91pyh1ddhxkm0"
+      },
+      "jetifier-processor-1.0.0-alpha10.jar": {
+        "sha1": "6d494a04e0af27ecd4ec7a35c93759dd9c7443bc",
+        "sha256": "00kng40zp8j1v4mvfzbzvj5nfds5vq66bhmd6jgxyqyszi9z0qbw"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/jetifier/jetifier-processor/1.0.0-beta02/jetifier-processor-1.0.0-beta02",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3bf006f5a449806a9ad493a99c9f9417b3040ef0",
-      "sha256": "1bx1483qlxflrkia3q3syqcdqjy6v2m8hmd52c7yzp5pgn4k0dpv"
-    },
-    "jar": {
-      "sha1": "624d187319c8dfd6bc8281b4afbab87c39bbb005",
-      "sha256": "037l3v6659ra4djlhkhd9l40nm193r0zqcklc14b6d75ddjhbr97"
+    "path": "com/android/tools/build/jetifier/jetifier-processor/1.0.0-beta02",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "jetifier-processor-1.0.0-beta02.pom": {
+        "sha1": "3bf006f5a449806a9ad493a99c9f9417b3040ef0",
+        "sha256": "1bx1483qlxflrkia3q3syqcdqjy6v2m8hmd52c7yzp5pgn4k0dpv"
+      },
+      "jetifier-processor-1.0.0-beta02.jar": {
+        "sha1": "624d187319c8dfd6bc8281b4afbab87c39bbb005",
+        "sha256": "037l3v6659ra4djlhkhd9l40nm193r0zqcklc14b6d75ddjhbr97"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/jetifier/jetifier-processor/1.0.0-beta04/jetifier-processor-1.0.0-beta04",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "39f80028bc2d7c4fe6740c80d68f3ff7dce9c62d",
-      "sha256": "17xqab07mmqdl2pr56d4njrksax7rqiwcmparyhrg4pqsz3acws9"
-    },
-    "jar": {
-      "sha1": "8ed1fee7b1d03709dd8bd0224f21ef243e5c4a4c",
-      "sha256": "1ysf9z2k3mqyv4mm74pphal5n73xya0axn88i6331jvcc3kq3m0x"
+    "path": "com/android/tools/build/jetifier/jetifier-processor/1.0.0-beta04",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "jetifier-processor-1.0.0-beta04.pom": {
+        "sha1": "39f80028bc2d7c4fe6740c80d68f3ff7dce9c62d",
+        "sha256": "17xqab07mmqdl2pr56d4njrksax7rqiwcmparyhrg4pqsz3acws9"
+      },
+      "jetifier-processor-1.0.0-beta04.jar": {
+        "sha1": "8ed1fee7b1d03709dd8bd0224f21ef243e5c4a4c",
+        "sha256": "1ysf9z2k3mqyv4mm74pphal5n73xya0axn88i6331jvcc3kq3m0x"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.0.0/manifest-merger-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2f38803314752b67d1f3ee093b400bb6c5f3b0ee",
-      "sha256": "1s8gfdlhb08cg7g5lxibh9m9pkanyffv4qih488pkn2036pf1256"
-    },
-    "jar": {
-      "sha1": "f625bcad5f5dc0cb373e6b62595d64a552a8d073",
-      "sha256": "02bmi5s1vd8n6a38fifhsva0ijqs0c6100k72cl8aa2fcc67dmf9"
+    "path": "com/android/tools/build/manifest-merger/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "manifest-merger-26.0.0.pom": {
+        "sha1": "2f38803314752b67d1f3ee093b400bb6c5f3b0ee",
+        "sha256": "1s8gfdlhb08cg7g5lxibh9m9pkanyffv4qih488pkn2036pf1256"
+      },
+      "manifest-merger-26.0.0.jar": {
+        "sha1": "f625bcad5f5dc0cb373e6b62595d64a552a8d073",
+        "sha256": "02bmi5s1vd8n6a38fifhsva0ijqs0c6100k72cl8aa2fcc67dmf9"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.0.1/manifest-merger-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2ad9aa17965bac57ce06539375ffdb5905943ffb",
-      "sha256": "1wx8dcqn62ybi66qyzql23x6qgs72iadyjznwhq4zpz5b0mhsaq5"
-    },
-    "jar": {
-      "sha1": "0700cbb1ed4066f48d4970f5669c44a51bd03142",
-      "sha256": "1x9v755fa6dlqaj8kxdyaihpbl2vc93nxk46yqbbj4n89q477pmy"
+    "path": "com/android/tools/build/manifest-merger/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "manifest-merger-26.0.1.pom": {
+        "sha1": "2ad9aa17965bac57ce06539375ffdb5905943ffb",
+        "sha256": "1wx8dcqn62ybi66qyzql23x6qgs72iadyjznwhq4zpz5b0mhsaq5"
+      },
+      "manifest-merger-26.0.1.jar": {
+        "sha1": "0700cbb1ed4066f48d4970f5669c44a51bd03142",
+        "sha256": "1x9v755fa6dlqaj8kxdyaihpbl2vc93nxk46yqbbj4n89q477pmy"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.1.4/manifest-merger-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8b025ca5a54d8e27600470f841f87a77d0a93f56",
-      "sha256": "0xxjj1frb9fqyv6d6kmfhxsy7xqjas8nkv7y0hpk1726q0kqi81v"
-    },
-    "jar": {
-      "sha1": "ddb4dcb3bb44c7053fa583967dfa9030f43f1c01",
-      "sha256": "1cccgadv0varzj48cpwbk3c0y7hpkl5nxa7v7sds9xd2smkv8q9x"
+    "path": "com/android/tools/build/manifest-merger/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "manifest-merger-26.1.4.pom": {
+        "sha1": "8b025ca5a54d8e27600470f841f87a77d0a93f56",
+        "sha256": "0xxjj1frb9fqyv6d6kmfhxsy7xqjas8nkv7y0hpk1726q0kqi81v"
+      },
+      "manifest-merger-26.1.4.jar": {
+        "sha1": "ddb4dcb3bb44c7053fa583967dfa9030f43f1c01",
+        "sha256": "1cccgadv0varzj48cpwbk3c0y7hpkl5nxa7v7sds9xd2smkv8q9x"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.2.1/manifest-merger-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fe714f42f14c16ac5f75820a0e6c239e50aa1b64",
-      "sha256": "06dy9pahh78npcpp72k691f3xb48j4n514ssxisd3hmdnzq4pi2n"
-    },
-    "jar": {
-      "sha1": "6a6542caf30fbc4091dffea76c602e97bc9d8949",
-      "sha256": "19l18ac2g2mzbx7k68avhs9rq0llvgi53jzxik9ka41nccr5fc48"
+    "path": "com/android/tools/build/manifest-merger/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "manifest-merger-26.2.1.pom": {
+        "sha1": "fe714f42f14c16ac5f75820a0e6c239e50aa1b64",
+        "sha256": "06dy9pahh78npcpp72k691f3xb48j4n514ssxisd3hmdnzq4pi2n"
+      },
+      "manifest-merger-26.2.1.jar": {
+        "sha1": "6a6542caf30fbc4091dffea76c602e97bc9d8949",
+        "sha256": "19l18ac2g2mzbx7k68avhs9rq0llvgi53jzxik9ka41nccr5fc48"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.3.1/manifest-merger-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1aad18d13e7389cf148b1c6c468b2947ca23cbbd",
-      "sha256": "1xd45wnv47mxvxjblp3fi9ns0n870pr3ls8wcrg0b9k5l8s4pn30"
-    },
-    "jar": {
-      "sha1": "aa94f738e318fc73059d9207f433f13556072d05",
-      "sha256": "1dbjfpkbrf9lk8ih902szaqa18cibmjgykpcg419h125prmxpnl4"
+    "path": "com/android/tools/build/manifest-merger/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "manifest-merger-26.3.1.pom": {
+        "sha1": "1aad18d13e7389cf148b1c6c468b2947ca23cbbd",
+        "sha256": "1xd45wnv47mxvxjblp3fi9ns0n870pr3ls8wcrg0b9k5l8s4pn30"
+      },
+      "manifest-merger-26.3.1.jar": {
+        "sha1": "aa94f738e318fc73059d9207f433f13556072d05",
+        "sha256": "1dbjfpkbrf9lk8ih902szaqa18cibmjgykpcg419h125prmxpnl4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.5.4/manifest-merger-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1f2b10961ea26a90e51148d8ef9d85448984bb10",
-      "sha256": "0jq3xnsw7jjidmls8kb6c0h8mka8aajsnzivn4jv31fn1chds7hx"
-    },
-    "jar": {
-      "sha1": "ee71136e9023cd90b3e431e506e4f5d0386ad55d",
-      "sha256": "1xnmax351m9hjxjg264mcirbp13y2v0731wnaz29cpaazdly440a"
+    "path": "com/android/tools/build/manifest-merger/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "manifest-merger-26.5.4.pom": {
+        "sha1": "1f2b10961ea26a90e51148d8ef9d85448984bb10",
+        "sha256": "0jq3xnsw7jjidmls8kb6c0h8mka8aajsnzivn4jv31fn1chds7hx"
+      },
+      "manifest-merger-26.5.4.jar": {
+        "sha1": "ee71136e9023cd90b3e431e506e4f5d0386ad55d",
+        "sha256": "1xnmax351m9hjxjg264mcirbp13y2v0731wnaz29cpaazdly440a"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/26.0.0/common-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f479fa906584db620744108a4a94fe86cbeaad1b",
-      "sha256": "1xklng15h3pfafldlx36zm1w2y7a78nlxi7dxfhfzgqyxxv0bdr6"
-    },
-    "jar": {
-      "sha1": "a75e1cbf30e55dd23f73801c32cd565b6eb5fb3f",
-      "sha256": "0701n8yyfya6f931vv5jg5y4fafkhvrciv6pdbj3y3gp0hvmlmi8"
+    "path": "com/android/tools/common/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-26.0.0.pom": {
+        "sha1": "f479fa906584db620744108a4a94fe86cbeaad1b",
+        "sha256": "1xklng15h3pfafldlx36zm1w2y7a78nlxi7dxfhfzgqyxxv0bdr6"
+      },
+      "common-26.0.0.jar": {
+        "sha1": "a75e1cbf30e55dd23f73801c32cd565b6eb5fb3f",
+        "sha256": "0701n8yyfya6f931vv5jg5y4fafkhvrciv6pdbj3y3gp0hvmlmi8"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/26.0.1/common-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "29ca7df177eab0ed8dba3f3d22802f216ad29ab2",
-      "sha256": "0sifm4h7cnhn09p4r7kxgihprcpckgw0kwrf24k5yx4g0nv1s3z3"
-    },
-    "jar": {
-      "sha1": "38e362a43a905b6745d609bea37faddb0c5bffab",
-      "sha256": "0xvwx56xn3dvzj85vw3g5vv57af9147hqj5cy27vx5ws4sfvnyxj"
+    "path": "com/android/tools/common/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-26.0.1.pom": {
+        "sha1": "29ca7df177eab0ed8dba3f3d22802f216ad29ab2",
+        "sha256": "0sifm4h7cnhn09p4r7kxgihprcpckgw0kwrf24k5yx4g0nv1s3z3"
+      },
+      "common-26.0.1.jar": {
+        "sha1": "38e362a43a905b6745d609bea37faddb0c5bffab",
+        "sha256": "0xvwx56xn3dvzj85vw3g5vv57af9147hqj5cy27vx5ws4sfvnyxj"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/26.1.4/common-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0ba42432d38a56a205e7a5f39a67701277c6d818",
-      "sha256": "0xdgznbm17brc3x99p9y4jc082ql0svvxcm36yzlr840iywcl5iy"
-    },
-    "jar": {
-      "sha1": "b70b6ef7188fe5a6ad6186f0efb22e536e483b9b",
-      "sha256": "0irdsr5kppk7mw0wjnfpj8h5lixh2p7v4v1ly8z0np95wd6mfnrx"
+    "path": "com/android/tools/common/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-26.1.4.pom": {
+        "sha1": "0ba42432d38a56a205e7a5f39a67701277c6d818",
+        "sha256": "0xdgznbm17brc3x99p9y4jc082ql0svvxcm36yzlr840iywcl5iy"
+      },
+      "common-26.1.4.jar": {
+        "sha1": "b70b6ef7188fe5a6ad6186f0efb22e536e483b9b",
+        "sha256": "0irdsr5kppk7mw0wjnfpj8h5lixh2p7v4v1ly8z0np95wd6mfnrx"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/26.2.1/common-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e952e8a80fcb28ce040645f27b75e116a9faf120",
-      "sha256": "07xjg2nzhf3fv6cg7vz0733qv4n1ap8rb5s6qikrbydsjyjq7gf5"
-    },
-    "jar": {
-      "sha1": "b1b9e1a6efa7b64cba484e9f6562b5f63bf23e22",
-      "sha256": "1rbq5pm9g62l8qi3afzcl20fkn477plwg1sa03s6izqichnsn2m5"
+    "path": "com/android/tools/common/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-26.2.1.pom": {
+        "sha1": "e952e8a80fcb28ce040645f27b75e116a9faf120",
+        "sha256": "07xjg2nzhf3fv6cg7vz0733qv4n1ap8rb5s6qikrbydsjyjq7gf5"
+      },
+      "common-26.2.1.jar": {
+        "sha1": "b1b9e1a6efa7b64cba484e9f6562b5f63bf23e22",
+        "sha256": "1rbq5pm9g62l8qi3afzcl20fkn477plwg1sa03s6izqichnsn2m5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/26.3.1/common-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b79360c83ea68ba7f0ac0fadf7c48e1a53511352",
-      "sha256": "0ly5ilg4k0bkfydr9vjd3mgxvwj15q1zdlzhg9261x4p6xic3yls"
-    },
-    "jar": {
-      "sha1": "b0e3aa846dd94f9608018f7ef6501d1069f6488c",
-      "sha256": "1mikqzg43swdf5zzvnbpcdkd7g6n8clmb6r4fbc1q6yqcb523as1"
+    "path": "com/android/tools/common/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-26.3.1.pom": {
+        "sha1": "b79360c83ea68ba7f0ac0fadf7c48e1a53511352",
+        "sha256": "0ly5ilg4k0bkfydr9vjd3mgxvwj15q1zdlzhg9261x4p6xic3yls"
+      },
+      "common-26.3.1.jar": {
+        "sha1": "b0e3aa846dd94f9608018f7ef6501d1069f6488c",
+        "sha256": "1mikqzg43swdf5zzvnbpcdkd7g6n8clmb6r4fbc1q6yqcb523as1"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/26.5.4/common-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3e47b19f02478c9dea70fba422429a12447d7ce6",
-      "sha256": "07wpx2fai88wkgv3gsk15cdrhyqjvqx00zgj5if31b7xzjk53ksw"
-    },
-    "jar": {
-      "sha1": "354eee31a9c52abc71a9b49969ef40da9afc5bd8",
-      "sha256": "05k2l4fl2572wdzay1slp8m90z6jkpjdmgii9w7qs4mk9hsffbjj"
+    "path": "com/android/tools/common/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "common-26.5.4.pom": {
+        "sha1": "3e47b19f02478c9dea70fba422429a12447d7ce6",
+        "sha256": "07wpx2fai88wkgv3gsk15cdrhyqjvqx00zgj5if31b7xzjk53ksw"
+      },
+      "common-26.5.4.jar": {
+        "sha1": "354eee31a9c52abc71a9b49969ef40da9afc5bd8",
+        "sha256": "05k2l4fl2572wdzay1slp8m90z6jkpjdmgii9w7qs4mk9hsffbjj"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.0.0/ddmlib-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a8884215b3a37eb3e9a4872b80cd81b58c03e235",
-      "sha256": "125hxfgm6aczic9w6xh1ri13fa1il0rn4dn6727x987wzcp9bj55"
-    },
-    "jar": {
-      "sha1": "79daeff3eab3fc4ff963f5717392f1f2476ed788",
-      "sha256": "18smk8glkclb77rrryz416lksswlbvvd357d34di5ggqd0xap7q5"
+    "path": "com/android/tools/ddms/ddmlib/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "ddmlib-26.0.0.pom": {
+        "sha1": "a8884215b3a37eb3e9a4872b80cd81b58c03e235",
+        "sha256": "125hxfgm6aczic9w6xh1ri13fa1il0rn4dn6727x987wzcp9bj55"
+      },
+      "ddmlib-26.0.0.jar": {
+        "sha1": "79daeff3eab3fc4ff963f5717392f1f2476ed788",
+        "sha256": "18smk8glkclb77rrryz416lksswlbvvd357d34di5ggqd0xap7q5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.0.1/ddmlib-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9ba40aa301f8ad2ba19b56d0948954d7bdd6cdef",
-      "sha256": "06dn2lz2ssg2jlzp26hcjnrzwhlpd29bbqcpsklhc941bhqqpw07"
-    },
-    "jar": {
-      "sha1": "d4bcdb3a578812688ccc34f1359702601fea955d",
-      "sha256": "1yagm7jjqa748hxj6sfcd041sfk5xyy7nwir1ajgac5l4n5kzxw1"
+    "path": "com/android/tools/ddms/ddmlib/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "ddmlib-26.0.1.pom": {
+        "sha1": "9ba40aa301f8ad2ba19b56d0948954d7bdd6cdef",
+        "sha256": "06dn2lz2ssg2jlzp26hcjnrzwhlpd29bbqcpsklhc941bhqqpw07"
+      },
+      "ddmlib-26.0.1.jar": {
+        "sha1": "d4bcdb3a578812688ccc34f1359702601fea955d",
+        "sha256": "1yagm7jjqa748hxj6sfcd041sfk5xyy7nwir1ajgac5l4n5kzxw1"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.1.4/ddmlib-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e18f8f2897b429a9246e9a622608a8b347f73b94",
-      "sha256": "0bq9rr7zwfssz1m6f9qs39s88chqy3siq3hgbfp7f7jc4hgfi1mr"
-    },
-    "jar": {
-      "sha1": "c11fa14b583412aaa9262461299318207439156d",
-      "sha256": "0zzzhjjsrry77yksjdvv5k3a1nhccpnwh9k6vfv51i8mh9mi58x3"
+    "path": "com/android/tools/ddms/ddmlib/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "ddmlib-26.1.4.pom": {
+        "sha1": "e18f8f2897b429a9246e9a622608a8b347f73b94",
+        "sha256": "0bq9rr7zwfssz1m6f9qs39s88chqy3siq3hgbfp7f7jc4hgfi1mr"
+      },
+      "ddmlib-26.1.4.jar": {
+        "sha1": "c11fa14b583412aaa9262461299318207439156d",
+        "sha256": "0zzzhjjsrry77yksjdvv5k3a1nhccpnwh9k6vfv51i8mh9mi58x3"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.2.1/ddmlib-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "66a2a3ef7c801b5dd27a083e82b8e778c468add5",
-      "sha256": "1w2hy3pijxr97sxmwk7dabqk1is9shdjdn99krd9fnqx3wz9vfkr"
-    },
-    "jar": {
-      "sha1": "088fbd27836d660bbbc3823bda8da3085cef41f6",
-      "sha256": "12r10nvliqgrha7p49kwnx86frb441wcqrcl4qkvz04rl4lhmgx4"
+    "path": "com/android/tools/ddms/ddmlib/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "ddmlib-26.2.1.pom": {
+        "sha1": "66a2a3ef7c801b5dd27a083e82b8e778c468add5",
+        "sha256": "1w2hy3pijxr97sxmwk7dabqk1is9shdjdn99krd9fnqx3wz9vfkr"
+      },
+      "ddmlib-26.2.1.jar": {
+        "sha1": "088fbd27836d660bbbc3823bda8da3085cef41f6",
+        "sha256": "12r10nvliqgrha7p49kwnx86frb441wcqrcl4qkvz04rl4lhmgx4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.3.1/ddmlib-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "14405d92c982c96ace23b7a4c505b0d9de58cd8d",
-      "sha256": "1ldh7n1x8g29khq5qfz4a9mz609cck1bb2sbbxnwa9qlw7s2j59j"
-    },
-    "jar": {
-      "sha1": "61ca2873fcce1012ba9782adf7e9b0e164fb6007",
-      "sha256": "1fhy4jwpw02sm45nqa5g0h7ppji8pkhnhws2nf78zbs9b3x0jdm1"
+    "path": "com/android/tools/ddms/ddmlib/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "ddmlib-26.3.1.pom": {
+        "sha1": "14405d92c982c96ace23b7a4c505b0d9de58cd8d",
+        "sha256": "1ldh7n1x8g29khq5qfz4a9mz609cck1bb2sbbxnwa9qlw7s2j59j"
+      },
+      "ddmlib-26.3.1.jar": {
+        "sha1": "61ca2873fcce1012ba9782adf7e9b0e164fb6007",
+        "sha256": "1fhy4jwpw02sm45nqa5g0h7ppji8pkhnhws2nf78zbs9b3x0jdm1"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.5.4/ddmlib-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6911c3e30fe3e41a31b47e7e5947dce86f1e620f",
-      "sha256": "0l84918kv1fk0wq7asplz8wp9ksgbcxjzady3sa7594plv4pkg0q"
-    },
-    "jar": {
-      "sha1": "befefae046c5666818dab0d597a878960bd42c56",
-      "sha256": "1qznrc65w94zwk5fgk1cklxvn1dbkkrxxi9jkyj4f9y0rffdz3zl"
+    "path": "com/android/tools/ddms/ddmlib/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "ddmlib-26.5.4.pom": {
+        "sha1": "6911c3e30fe3e41a31b47e7e5947dce86f1e620f",
+        "sha256": "0l84918kv1fk0wq7asplz8wp9ksgbcxjzady3sa7594plv4pkg0q"
+      },
+      "ddmlib-26.5.4.jar": {
+        "sha1": "befefae046c5666818dab0d597a878960bd42c56",
+        "sha256": "1qznrc65w94zwk5fgk1cklxvn1dbkkrxxi9jkyj4f9y0rffdz3zl"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/26.0.0/dvlib-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ac0dededfd324bb533f2635fee7778f38874c025",
-      "sha256": "0na1h2kg479ikcxvdrqyxppgsxns4qjh11jlyj6grlnwqcfsv1z2"
-    },
-    "jar": {
-      "sha1": "50d8b18ccc5233c4e7ca4c98f9708d44f80ace82",
-      "sha256": "1i37rn56dw92ldsw4qq0la8xjz6hc355675c792grpm2r1gl867m"
+    "path": "com/android/tools/dvlib/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "dvlib-26.0.0.pom": {
+        "sha1": "ac0dededfd324bb533f2635fee7778f38874c025",
+        "sha256": "0na1h2kg479ikcxvdrqyxppgsxns4qjh11jlyj6grlnwqcfsv1z2"
+      },
+      "dvlib-26.0.0.jar": {
+        "sha1": "50d8b18ccc5233c4e7ca4c98f9708d44f80ace82",
+        "sha256": "1i37rn56dw92ldsw4qq0la8xjz6hc355675c792grpm2r1gl867m"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/26.0.1/dvlib-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2d0e9cdbc51c243de640d2513447c8ff0a1c4d91",
-      "sha256": "0yqpmvlsln76jyb33bfnbm1d43a5n910w3rxcb33ycbj3xs7kirf"
-    },
-    "jar": {
-      "sha1": "46f3eeaf812811374b4ea2c49ad52687a7ff6a87",
-      "sha256": "1bhxs4y9xib2jpg6rcr30xdsif027basfl6z3ns1f0q4yvf5ii3h"
+    "path": "com/android/tools/dvlib/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "dvlib-26.0.1.pom": {
+        "sha1": "2d0e9cdbc51c243de640d2513447c8ff0a1c4d91",
+        "sha256": "0yqpmvlsln76jyb33bfnbm1d43a5n910w3rxcb33ycbj3xs7kirf"
+      },
+      "dvlib-26.0.1.jar": {
+        "sha1": "46f3eeaf812811374b4ea2c49ad52687a7ff6a87",
+        "sha256": "1bhxs4y9xib2jpg6rcr30xdsif027basfl6z3ns1f0q4yvf5ii3h"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/26.1.4/dvlib-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "49d0672a46075d55b83d2e59e8a7c4af90c4e9f0",
-      "sha256": "1xxdi7fb5ixv850zfjd340ww8gx8vkmlx9jm18ib9w5gj77w4w2s"
-    },
-    "jar": {
-      "sha1": "5d443b51ad041e9599cfdb278cd2f6c9d2ccdf28",
-      "sha256": "1kh85j1spdpbd5bwcf2155hjyv7psn3b9qxry7lw0i4cldi862n5"
+    "path": "com/android/tools/dvlib/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "dvlib-26.1.4.pom": {
+        "sha1": "49d0672a46075d55b83d2e59e8a7c4af90c4e9f0",
+        "sha256": "1xxdi7fb5ixv850zfjd340ww8gx8vkmlx9jm18ib9w5gj77w4w2s"
+      },
+      "dvlib-26.1.4.jar": {
+        "sha1": "5d443b51ad041e9599cfdb278cd2f6c9d2ccdf28",
+        "sha256": "1kh85j1spdpbd5bwcf2155hjyv7psn3b9qxry7lw0i4cldi862n5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/26.2.1/dvlib-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "726bd01d91e395377f71a4b1cff2bf24dd612589",
-      "sha256": "10bj0kkfxl3bdrvg128d6h2s2r8d32py7mbwnrc5l9w1096b388w"
-    },
-    "jar": {
-      "sha1": "fa3cc125cd311f65dcae6310e381b20d4b2ec0fe",
-      "sha256": "1al82s7vxck2qwh47nklsxn9d7zv3dfs8yznzfqzj7cvhgr3pa3j"
+    "path": "com/android/tools/dvlib/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "dvlib-26.2.1.pom": {
+        "sha1": "726bd01d91e395377f71a4b1cff2bf24dd612589",
+        "sha256": "10bj0kkfxl3bdrvg128d6h2s2r8d32py7mbwnrc5l9w1096b388w"
+      },
+      "dvlib-26.2.1.jar": {
+        "sha1": "fa3cc125cd311f65dcae6310e381b20d4b2ec0fe",
+        "sha256": "1al82s7vxck2qwh47nklsxn9d7zv3dfs8yznzfqzj7cvhgr3pa3j"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/26.3.1/dvlib-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c438f3c025bd878ac3b54368e012b3792f9c8928",
-      "sha256": "1mhdlqfz0m5q2dgnpx4bbf4yn5wkxkl25qhnby8y1w2ac7lgylny"
-    },
-    "jar": {
-      "sha1": "971430b6163a834656d07434c46fee64d109ad8e",
-      "sha256": "12rkawpbi3i2w20v4v54niyas0jcw7lmk1mz2fm45ylwhhphxcvh"
+    "path": "com/android/tools/dvlib/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "dvlib-26.3.1.pom": {
+        "sha1": "c438f3c025bd878ac3b54368e012b3792f9c8928",
+        "sha256": "1mhdlqfz0m5q2dgnpx4bbf4yn5wkxkl25qhnby8y1w2ac7lgylny"
+      },
+      "dvlib-26.3.1.jar": {
+        "sha1": "971430b6163a834656d07434c46fee64d109ad8e",
+        "sha256": "12rkawpbi3i2w20v4v54niyas0jcw7lmk1mz2fm45ylwhhphxcvh"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/26.5.4/dvlib-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5d3f9c05edec8b02436ddf39b2901339a6ddfb66",
-      "sha256": "1k2jvr5frj9zq3737f13zbfs3w356gs75mzn40p2cwmi0hlh1yy1"
-    },
-    "jar": {
-      "sha1": "fc9828a5c4a02bf510b8bde2733e2eb81c34bf64",
-      "sha256": "0qbdasgr3c54r8l7sgk7fl0ykqaay8gisipamvl92kjs29s9qhba"
+    "path": "com/android/tools/dvlib/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "dvlib-26.5.4.pom": {
+        "sha1": "5d3f9c05edec8b02436ddf39b2901339a6ddfb66",
+        "sha256": "1k2jvr5frj9zq3737f13zbfs3w356gs75mzn40p2cwmi0hlh1yy1"
+      },
+      "dvlib-26.5.4.jar": {
+        "sha1": "fc9828a5c4a02bf510b8bde2733e2eb81c34bf64",
+        "sha256": "0qbdasgr3c54r8l7sgk7fl0ykqaay8gisipamvl92kjs29s9qhba"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/com-intellij/intellij-core/26.0.0/intellij-core-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ae746b3669aec380b72026deb74b4b0f82cce484",
-      "sha256": "1c3m5sd0pagay1pp1ni0s86q1gz9y5dyc9c6lyw1m211dknrgi7w"
-    },
-    "jar": {
-      "sha1": "47396aa1fead8512c246fdf4698552c1f33b1710",
-      "sha256": "1ysyx3hi0m98w9a59jw96n5fkvx9g2zwbl3839qzg1fwrmc8194c"
+    "path": "com/android/tools/external/com-intellij/intellij-core/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "intellij-core-26.0.0.pom": {
+        "sha1": "ae746b3669aec380b72026deb74b4b0f82cce484",
+        "sha256": "1c3m5sd0pagay1pp1ni0s86q1gz9y5dyc9c6lyw1m211dknrgi7w"
+      },
+      "intellij-core-26.0.0.jar": {
+        "sha1": "47396aa1fead8512c246fdf4698552c1f33b1710",
+        "sha256": "1ysyx3hi0m98w9a59jw96n5fkvx9g2zwbl3839qzg1fwrmc8194c"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d100cfbdf7500f2006ecfeeacce519a0d8e9d875",
-      "sha256": "198mnrksc5v6k49zs9yydg1wp0rl4gf6wsy15nzqnbk8xcxin17f"
-    },
-    "jar": {
-      "sha1": "a373ed549821cb9a932b87c79792790f6d018727",
-      "sha256": "136zki4af3nnf152pbiywlgwazf93r54jixwq22f945fzbw4vajq"
+    "path": "com/android/tools/external/com-intellij/intellij-core/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "intellij-core-26.0.1.pom": {
+        "sha1": "d100cfbdf7500f2006ecfeeacce519a0d8e9d875",
+        "sha256": "198mnrksc5v6k49zs9yydg1wp0rl4gf6wsy15nzqnbk8xcxin17f"
+      },
+      "intellij-core-26.0.1.jar": {
+        "sha1": "a373ed549821cb9a932b87c79792790f6d018727",
+        "sha256": "136zki4af3nnf152pbiywlgwazf93r54jixwq22f945fzbw4vajq"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/com-intellij/intellij-core/26.5.4/intellij-core-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3f58663f0c898bfbda19ad12d8cf4a05894922c5",
-      "sha256": "013cna6lp917fjzgdd3fbssq9dvhinwfrhh6nq3n85q79w8ig8ad"
-    },
-    "jar": {
-      "sha1": "b11090ad4dddaa66368b23e49c1db8904689424d",
-      "sha256": "1xwzv7rgyw4mga5k0ijqwbrmmk72xl9r8fm0yyx00rrmj8dsx8wz"
+    "path": "com/android/tools/external/com-intellij/intellij-core/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "intellij-core-26.5.4.pom": {
+        "sha1": "3f58663f0c898bfbda19ad12d8cf4a05894922c5",
+        "sha256": "013cna6lp917fjzgdd3fbssq9dvhinwfrhh6nq3n85q79w8ig8ad"
+      },
+      "intellij-core-26.5.4.jar": {
+        "sha1": "b11090ad4dddaa66368b23e49c1db8904689424d",
+        "sha256": "1xwzv7rgyw4mga5k0ijqwbrmmk72xl9r8fm0yyx00rrmj8dsx8wz"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/com-intellij/kotlin-compiler/26.5.4/kotlin-compiler-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a1dbb67a271f9328395d877ce4f4b3412b9073f9",
-      "sha256": "0zbk43b9kyicbkczbp6lrjig1myan0659lb2ddr4s85c3p0rjhh3"
-    },
-    "jar": {
-      "sha1": "08d7acc8656728c81ac141bd93ac53747a6cf5b7",
-      "sha256": "0h287r7qxmnsdsa82wnlv3xc2h8455dx6wr1761nmsbk56a0izm0"
+    "path": "com/android/tools/external/com-intellij/kotlin-compiler/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "kotlin-compiler-26.5.4.pom": {
+        "sha1": "a1dbb67a271f9328395d877ce4f4b3412b9073f9",
+        "sha256": "0zbk43b9kyicbkczbp6lrjig1myan0659lb2ddr4s85c3p0rjhh3"
+      },
+      "kotlin-compiler-26.5.4.jar": {
+        "sha1": "08d7acc8656728c81ac141bd93ac53747a6cf5b7",
+        "sha256": "0h287r7qxmnsdsa82wnlv3xc2h8455dx6wr1761nmsbk56a0izm0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/org-jetbrains/uast/26.0.0/uast-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a905919feddc68e5ebc6f0cddeaf6a2fff8b5195",
-      "sha256": "0q97i1gj5g7f3vfkldn8dyf3f6x962x3ch4gdv7irgh6p9mcs5lb"
-    },
-    "jar": {
-      "sha1": "86234f897e27e97c4aebe5686fa0e21139a1fc4e",
-      "sha256": "0wjbfnvhq1himxjj389rlxqr4cqa9ahfkjy74cad1b00mg8yjhgv"
+    "path": "com/android/tools/external/org-jetbrains/uast/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "uast-26.0.0.pom": {
+        "sha1": "a905919feddc68e5ebc6f0cddeaf6a2fff8b5195",
+        "sha256": "0q97i1gj5g7f3vfkldn8dyf3f6x962x3ch4gdv7irgh6p9mcs5lb"
+      },
+      "uast-26.0.0.jar": {
+        "sha1": "86234f897e27e97c4aebe5686fa0e21139a1fc4e",
+        "sha256": "0wjbfnvhq1himxjj389rlxqr4cqa9ahfkjy74cad1b00mg8yjhgv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/org-jetbrains/uast/26.0.1/uast-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6ecc2c2b816f6e23f5edf12e496d51b27198beee",
-      "sha256": "0hvzk9kw34i2g4y58cg9sxm9siw35k5wdk55f8xihjkbxk7w3a9b"
-    },
-    "jar": {
-      "sha1": "663906c592ce867fa2e9bcbffbe2130397078132",
-      "sha256": "1065hwagil897vshy0w30006r59g0xldnr0xn9gb64jjkz36vm7c"
+    "path": "com/android/tools/external/org-jetbrains/uast/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "uast-26.0.1.pom": {
+        "sha1": "6ecc2c2b816f6e23f5edf12e496d51b27198beee",
+        "sha256": "0hvzk9kw34i2g4y58cg9sxm9siw35k5wdk55f8xihjkbxk7w3a9b"
+      },
+      "uast-26.0.1.jar": {
+        "sha1": "663906c592ce867fa2e9bcbffbe2130397078132",
+        "sha256": "1065hwagil897vshy0w30006r59g0xldnr0xn9gb64jjkz36vm7c"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/org-jetbrains/uast/26.5.4/uast-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e2d4fee6e2e4f50316dd9084112ca1234839ad7c",
-      "sha256": "11d6zz9pj7b8qwgnsarf4xdqmp8l51b8yzb4cc8slihfg5sgvkcl"
-    },
-    "jar": {
-      "sha1": "426f7052d0ed71165556be724ec4ee12591cb49f",
-      "sha256": "1zfsnzsnam0zk8x0788cknjczhdjjyalyxa8xczq06flziqfsamq"
+    "path": "com/android/tools/external/org-jetbrains/uast/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "uast-26.5.4.pom": {
+        "sha1": "e2d4fee6e2e4f50316dd9084112ca1234839ad7c",
+        "sha256": "11d6zz9pj7b8qwgnsarf4xdqmp8l51b8yzb4cc8slihfg5sgvkcl"
+      },
+      "uast-26.5.4.jar": {
+        "sha1": "426f7052d0ed71165556be724ec4ee12591cb49f",
+        "sha256": "1zfsnzsnam0zk8x0788cknjczhdjjyalyxa8xczq06flziqfsamq"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.0.0/layoutlib-api-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d96e1f06822faea2caceaa5ff82a0f9ed344c07b",
-      "sha256": "0d9ya2bkidfl4i8nwmvzx3vvysw2fpa55m559jdgcy6mpblcngm5"
-    },
-    "jar": {
-      "sha1": "2e64aac3c6a6f201df4b7e1c0bd452d8839fb47b",
-      "sha256": "0ayxvqvr18pd7nygrkwyws6vnhscfv2g1a445zqj5zjdgw7rw3id"
+    "path": "com/android/tools/layoutlib/layoutlib-api/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "layoutlib-api-26.0.0.pom": {
+        "sha1": "d96e1f06822faea2caceaa5ff82a0f9ed344c07b",
+        "sha256": "0d9ya2bkidfl4i8nwmvzx3vvysw2fpa55m559jdgcy6mpblcngm5"
+      },
+      "layoutlib-api-26.0.0.jar": {
+        "sha1": "2e64aac3c6a6f201df4b7e1c0bd452d8839fb47b",
+        "sha256": "0ayxvqvr18pd7nygrkwyws6vnhscfv2g1a445zqj5zjdgw7rw3id"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.0.1/layoutlib-api-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f28f7a66758d9b562b4a2f07ecf5af6bb924302c",
-      "sha256": "08n748g4yrfb8c5pkf60dhp1v3dvr3r0kqsdqjz5l6yrfrg97d72"
-    },
-    "jar": {
-      "sha1": "4eb1f46803873ff996f2457d1dd64c5c305818d8",
-      "sha256": "0qdqy7gqs4xfcbqbjnfbb20q65gcdrc7chxy0i682p1sl48xjnkb"
+    "path": "com/android/tools/layoutlib/layoutlib-api/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "layoutlib-api-26.0.1.pom": {
+        "sha1": "f28f7a66758d9b562b4a2f07ecf5af6bb924302c",
+        "sha256": "08n748g4yrfb8c5pkf60dhp1v3dvr3r0kqsdqjz5l6yrfrg97d72"
+      },
+      "layoutlib-api-26.0.1.jar": {
+        "sha1": "4eb1f46803873ff996f2457d1dd64c5c305818d8",
+        "sha256": "0qdqy7gqs4xfcbqbjnfbb20q65gcdrc7chxy0i682p1sl48xjnkb"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.1.4/layoutlib-api-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "de645341e6b3b77554bd2510f13fd04513d66324",
-      "sha256": "09229jd3448xaci0xh740v902w1g8xgzrkq1py6949jidzfm814n"
-    },
-    "jar": {
-      "sha1": "dad1158a9fc38b711339960b82fd9dcf32009e46",
-      "sha256": "1a5zqp4y43jlqbdnqjw7sis2f4sqa3iixkcj31fq9s72gknwj4fr"
+    "path": "com/android/tools/layoutlib/layoutlib-api/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "layoutlib-api-26.1.4.pom": {
+        "sha1": "de645341e6b3b77554bd2510f13fd04513d66324",
+        "sha256": "09229jd3448xaci0xh740v902w1g8xgzrkq1py6949jidzfm814n"
+      },
+      "layoutlib-api-26.1.4.jar": {
+        "sha1": "dad1158a9fc38b711339960b82fd9dcf32009e46",
+        "sha256": "1a5zqp4y43jlqbdnqjw7sis2f4sqa3iixkcj31fq9s72gknwj4fr"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.2.1/layoutlib-api-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "597e3e5c746e2eaefb90a86a3dd0af1745442087",
-      "sha256": "19xw98bxnwba3jv3a44k6siqik5nvgc3sqd0csdkhpdr9y66vq11"
-    },
-    "jar": {
-      "sha1": "164c58ac8cf4b2bb08ad03acc5f963f4f70cfcaa",
-      "sha256": "1piabivkrhxg3xqr02dn4z9px4y298gwrccm2l0zlcrp2b54zgyx"
+    "path": "com/android/tools/layoutlib/layoutlib-api/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "layoutlib-api-26.2.1.pom": {
+        "sha1": "597e3e5c746e2eaefb90a86a3dd0af1745442087",
+        "sha256": "19xw98bxnwba3jv3a44k6siqik5nvgc3sqd0csdkhpdr9y66vq11"
+      },
+      "layoutlib-api-26.2.1.jar": {
+        "sha1": "164c58ac8cf4b2bb08ad03acc5f963f4f70cfcaa",
+        "sha256": "1piabivkrhxg3xqr02dn4z9px4y298gwrccm2l0zlcrp2b54zgyx"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.3.1/layoutlib-api-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0355e0146c59a91fbb303d7faaa6d2d0413f5dde",
-      "sha256": "0y1dxla4myyskcimkzc4dvflr6szn5176n45zymxbqdj9x4f2gvb"
-    },
-    "jar": {
-      "sha1": "969ef3a7c0c3b245a3efe8aff7a2f6f15ff4e824",
-      "sha256": "0pj11ask112mdfwig941gfpgasi5v50xwfnxsqjnnlqkpi5v4kjf"
+    "path": "com/android/tools/layoutlib/layoutlib-api/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "layoutlib-api-26.3.1.pom": {
+        "sha1": "0355e0146c59a91fbb303d7faaa6d2d0413f5dde",
+        "sha256": "0y1dxla4myyskcimkzc4dvflr6szn5176n45zymxbqdj9x4f2gvb"
+      },
+      "layoutlib-api-26.3.1.jar": {
+        "sha1": "969ef3a7c0c3b245a3efe8aff7a2f6f15ff4e824",
+        "sha256": "0pj11ask112mdfwig941gfpgasi5v50xwfnxsqjnnlqkpi5v4kjf"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.5.4/layoutlib-api-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d492e7833d19ddfd31e5efbe54ab4729431c2bef",
-      "sha256": "0n568gj7kd579gsra30m3gxq8bqjj2bkx2wmvw850pgzpwhk7cc0"
-    },
-    "jar": {
-      "sha1": "50e2abfb1721624c03e3f48f08f08403a425a919",
-      "sha256": "0fr9s6knbnw7qqq1ak9mlzbkpmxvmw0mkwy71i9azmjrx2akc435"
+    "path": "com/android/tools/layoutlib/layoutlib-api/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "layoutlib-api-26.5.4.pom": {
+        "sha1": "d492e7833d19ddfd31e5efbe54ab4729431c2bef",
+        "sha256": "0n568gj7kd579gsra30m3gxq8bqjj2bkx2wmvw850pgzpwhk7cc0"
+      },
+      "layoutlib-api-26.5.4.jar": {
+        "sha1": "50e2abfb1721624c03e3f48f08f08403a425a919",
+        "sha256": "0fr9s6knbnw7qqq1ak9mlzbkpmxvmw0mkwy71i9azmjrx2akc435"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-api/26.0.0/lint-api-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ae56cef8b3f46c122554ad6befbb0dc9ff359992",
-      "sha256": "0gqdixv8z2add5n30y7hq7hhrchqcmi66jffmdlpadbvn0gsmmwl"
-    },
-    "jar": {
-      "sha1": "ba8981e318f342456c77a2420b9d9f0967eaf138",
-      "sha256": "0yy2fw3ircsz38imnwwvhh6si4cc9v3w1a6s2zwacgsvniysvsil"
+    "path": "com/android/tools/lint/lint-api/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-api-26.0.0.pom": {
+        "sha1": "ae56cef8b3f46c122554ad6befbb0dc9ff359992",
+        "sha256": "0gqdixv8z2add5n30y7hq7hhrchqcmi66jffmdlpadbvn0gsmmwl"
+      },
+      "lint-api-26.0.0.jar": {
+        "sha1": "ba8981e318f342456c77a2420b9d9f0967eaf138",
+        "sha256": "0yy2fw3ircsz38imnwwvhh6si4cc9v3w1a6s2zwacgsvniysvsil"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-api/26.0.1/lint-api-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "939c08ec1fd74659d4a47d849d0376e1b1b88988",
-      "sha256": "13fx1cpi63sz9qjqc1z6ikyh1v6kjc3q777jslqqzkdl09agrc6x"
-    },
-    "jar": {
-      "sha1": "2d4dd9f4676fbb152e4baf6f6f4cbbb868521832",
-      "sha256": "03p4g8wa8g00d2ybpm16nbsa7krhgyc31f85nmxgp1ihj4ga3s2z"
+    "path": "com/android/tools/lint/lint-api/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-api-26.0.1.pom": {
+        "sha1": "939c08ec1fd74659d4a47d849d0376e1b1b88988",
+        "sha256": "13fx1cpi63sz9qjqc1z6ikyh1v6kjc3q777jslqqzkdl09agrc6x"
+      },
+      "lint-api-26.0.1.jar": {
+        "sha1": "2d4dd9f4676fbb152e4baf6f6f4cbbb868521832",
+        "sha256": "03p4g8wa8g00d2ybpm16nbsa7krhgyc31f85nmxgp1ihj4ga3s2z"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-api/26.5.4/lint-api-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "18316ed7c3bd4b45f4412058f7457120c4de45a9",
-      "sha256": "1n7djfw8d36lsb3zpm0bfdh1xjjri37pywcc1b312aas8vkjnmkl"
-    },
-    "jar": {
-      "sha1": "8b27c69be98be51a590058918ee3b13276a42e92",
-      "sha256": "1vc7q1hyzdbkiwm2y1b33698jxsy5pi8mndb7191f0ra3jic80j7"
+    "path": "com/android/tools/lint/lint-api/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-api-26.5.4.pom": {
+        "sha1": "18316ed7c3bd4b45f4412058f7457120c4de45a9",
+        "sha256": "1n7djfw8d36lsb3zpm0bfdh1xjjri37pywcc1b312aas8vkjnmkl"
+      },
+      "lint-api-26.5.4.jar": {
+        "sha1": "8b27c69be98be51a590058918ee3b13276a42e92",
+        "sha256": "1vc7q1hyzdbkiwm2y1b33698jxsy5pi8mndb7191f0ra3jic80j7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-checks/26.0.0/lint-checks-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "02c59a652ac555341479025c928f351201794868",
-      "sha256": "1cvaagg9s0lcyla4fhay31nflcjb6wj6n2qwysnpwiqd4wxba705"
-    },
-    "jar": {
-      "sha1": "fe04d508baa247a0d32cafbfd158ca439f875dbd",
-      "sha256": "0gq4h53qx2iy9a343pknbr1zj83k4qs2wrh8gzvl8d10chqjwxd0"
+    "path": "com/android/tools/lint/lint-checks/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-checks-26.0.0.pom": {
+        "sha1": "02c59a652ac555341479025c928f351201794868",
+        "sha256": "1cvaagg9s0lcyla4fhay31nflcjb6wj6n2qwysnpwiqd4wxba705"
+      },
+      "lint-checks-26.0.0.jar": {
+        "sha1": "fe04d508baa247a0d32cafbfd158ca439f875dbd",
+        "sha256": "0gq4h53qx2iy9a343pknbr1zj83k4qs2wrh8gzvl8d10chqjwxd0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-checks/26.0.1/lint-checks-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "12d4cfbea1a4815866c8edb6a9e598df0b335125",
-      "sha256": "14gdz9qdfk6lglx9da65vqpa8f1i70vj5jcngmkcsabisj2ja9ax"
-    },
-    "jar": {
-      "sha1": "a5df32c64598e190808accaa03820fb9db9f8201",
-      "sha256": "1jv651slb64v6sbq08d8lzklxkndd21g6ah8i4rm98081h14d4ll"
+    "path": "com/android/tools/lint/lint-checks/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-checks-26.0.1.pom": {
+        "sha1": "12d4cfbea1a4815866c8edb6a9e598df0b335125",
+        "sha256": "14gdz9qdfk6lglx9da65vqpa8f1i70vj5jcngmkcsabisj2ja9ax"
+      },
+      "lint-checks-26.0.1.jar": {
+        "sha1": "a5df32c64598e190808accaa03820fb9db9f8201",
+        "sha256": "1jv651slb64v6sbq08d8lzklxkndd21g6ah8i4rm98081h14d4ll"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-checks/26.5.4/lint-checks-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6a90b604d59e164ce9a3fd21ba9481f2eaa74778",
-      "sha256": "0f54b1z0m9rd02w3f9m08wnl2r21mcfxkm3hjwk7d7vp9r7pzx5v"
-    },
-    "jar": {
-      "sha1": "e79e5aeb35c10a6fd9ca902063251599e137a71f",
-      "sha256": "0pqk5s46ry81w22ijipq6c5iakdfz68006vgcvrf408m7hhb4395"
+    "path": "com/android/tools/lint/lint-checks/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-checks-26.5.4.pom": {
+        "sha1": "6a90b604d59e164ce9a3fd21ba9481f2eaa74778",
+        "sha256": "0f54b1z0m9rd02w3f9m08wnl2r21mcfxkm3hjwk7d7vp9r7pzx5v"
+      },
+      "lint-checks-26.5.4.jar": {
+        "sha1": "e79e5aeb35c10a6fd9ca902063251599e137a71f",
+        "sha256": "0pqk5s46ry81w22ijipq6c5iakdfz68006vgcvrf408m7hhb4395"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-gradle-api/26.1.4/lint-gradle-api-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8bc04a18da7f891ab4c13a010d422a14f99d8d6d",
-      "sha256": "0b8z7fsfpba2bhx2m0jaca297jgyasy5zhfsx61s40dcp80j89ff"
-    },
-    "jar": {
-      "sha1": "cbc00782604b7d0ad50e9c50b84b074af79394f0",
-      "sha256": "0nipwpq92wvzxnn2wzdff69v8ps9rznwcrj0xagwqfwd85hdkil6"
+    "path": "com/android/tools/lint/lint-gradle-api/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-gradle-api-26.1.4.pom": {
+        "sha1": "8bc04a18da7f891ab4c13a010d422a14f99d8d6d",
+        "sha256": "0b8z7fsfpba2bhx2m0jaca297jgyasy5zhfsx61s40dcp80j89ff"
+      },
+      "lint-gradle-api-26.1.4.jar": {
+        "sha1": "cbc00782604b7d0ad50e9c50b84b074af79394f0",
+        "sha256": "0nipwpq92wvzxnn2wzdff69v8ps9rznwcrj0xagwqfwd85hdkil6"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-gradle-api/26.2.1/lint-gradle-api-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ba277763a9f51be5bacd587b3cc3451f45d3b9ce",
-      "sha256": "1xllbdbfd3rzls1j9hxsg7fkvp7cc3kx7v155fhraj6az9g7flwq"
-    },
-    "jar": {
-      "sha1": "62f8362369c570266bcd4f030908ec1d237df331",
-      "sha256": "0bvcjwwfdgnxzlzznyj5gl3liin81wgm6zkr59gmc0g36apyg0r2"
+    "path": "com/android/tools/lint/lint-gradle-api/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-gradle-api-26.2.1.pom": {
+        "sha1": "ba277763a9f51be5bacd587b3cc3451f45d3b9ce",
+        "sha256": "1xllbdbfd3rzls1j9hxsg7fkvp7cc3kx7v155fhraj6az9g7flwq"
+      },
+      "lint-gradle-api-26.2.1.jar": {
+        "sha1": "62f8362369c570266bcd4f030908ec1d237df331",
+        "sha256": "0bvcjwwfdgnxzlzznyj5gl3liin81wgm6zkr59gmc0g36apyg0r2"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-gradle-api/26.3.1/lint-gradle-api-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "dbdbed4b5fa948b991335771c7005fc8aa8be73b",
-      "sha256": "0874qrmkzhjhgqrqhq5frgx0zqs9jzyhm006y8r5d4xv83pnq5zb"
-    },
-    "jar": {
-      "sha1": "d55e1bcbe4e7c0bb97f5c385a003c4339e38d07f",
-      "sha256": "1jg69n8gz73bm4pn1jws2nky9lw2gcfj5z8z7bb3bkz2kxr67h25"
+    "path": "com/android/tools/lint/lint-gradle-api/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-gradle-api-26.3.1.pom": {
+        "sha1": "dbdbed4b5fa948b991335771c7005fc8aa8be73b",
+        "sha256": "0874qrmkzhjhgqrqhq5frgx0zqs9jzyhm006y8r5d4xv83pnq5zb"
+      },
+      "lint-gradle-api-26.3.1.jar": {
+        "sha1": "d55e1bcbe4e7c0bb97f5c385a003c4339e38d07f",
+        "sha256": "1jg69n8gz73bm4pn1jws2nky9lw2gcfj5z8z7bb3bkz2kxr67h25"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-gradle-api/26.5.4/lint-gradle-api-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "59dca214745003f3932114b776df8310f058c4b9",
-      "sha256": "06y728j5jw6bh946ck6z6f08hw9n2d0gnng9i5bxg13gnv25xhvg"
-    },
-    "jar": {
-      "sha1": "5f3ddac230dc3f2cd241b3cd2d1f3fddb995bba4",
-      "sha256": "0vqffnwf4y8bk5816y3v780b0dnk4lf9s7c74ny7s7ly0vzzkw5v"
+    "path": "com/android/tools/lint/lint-gradle-api/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-gradle-api-26.5.4.pom": {
+        "sha1": "59dca214745003f3932114b776df8310f058c4b9",
+        "sha256": "06y728j5jw6bh946ck6z6f08hw9n2d0gnng9i5bxg13gnv25xhvg"
+      },
+      "lint-gradle-api-26.5.4.jar": {
+        "sha1": "5f3ddac230dc3f2cd241b3cd2d1f3fddb995bba4",
+        "sha256": "0vqffnwf4y8bk5816y3v780b0dnk4lf9s7c74ny7s7ly0vzzkw5v"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-gradle/26.5.4/lint-gradle-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "75102b831b71629f387c40b2ba14cf5890366f13",
-      "sha256": "02m55x1pcn98ywgwh9yxjqm7xnf7pb1mpjpd3gg6alyqsqaxc77v"
-    },
-    "jar": {
-      "sha1": "ec152f25d7d1f273a31b21e35661d9e3b6371abd",
-      "sha256": "0bxl7hgidmqcdcysq98xarjyhlnr7369c1c3a6mclxm8j3gpa4vs"
+    "path": "com/android/tools/lint/lint-gradle/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-gradle-26.5.4.pom": {
+        "sha1": "75102b831b71629f387c40b2ba14cf5890366f13",
+        "sha256": "02m55x1pcn98ywgwh9yxjqm7xnf7pb1mpjpd3gg6alyqsqaxc77v"
+      },
+      "lint-gradle-26.5.4.jar": {
+        "sha1": "ec152f25d7d1f273a31b21e35661d9e3b6371abd",
+        "sha256": "0bxl7hgidmqcdcysq98xarjyhlnr7369c1c3a6mclxm8j3gpa4vs"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint/26.0.0/lint-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c3b178af06d72d16de1b0e6546026c6ef80d6f09",
-      "sha256": "1n0z0ky9v8qg03k0s7rahb4zi9q6rpl3jr91yzwmv5lp1yfq3h94"
-    },
-    "jar": {
-      "sha1": "6c58c8b0066addaaffd174b78d701948b819cf23",
-      "sha256": "07ywh5pg74sw1p60g8wwcdv82azd56h11161r4dzalz300l9g6ll"
+    "path": "com/android/tools/lint/lint/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-26.0.0.pom": {
+        "sha1": "c3b178af06d72d16de1b0e6546026c6ef80d6f09",
+        "sha256": "1n0z0ky9v8qg03k0s7rahb4zi9q6rpl3jr91yzwmv5lp1yfq3h94"
+      },
+      "lint-26.0.0.jar": {
+        "sha1": "6c58c8b0066addaaffd174b78d701948b819cf23",
+        "sha256": "07ywh5pg74sw1p60g8wwcdv82azd56h11161r4dzalz300l9g6ll"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint/26.0.1/lint-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fbca22e39c4f0b04feec26b3ac78622bf39ae6d2",
-      "sha256": "1cyrkkpy9v8nndwlnz77sz21fk40i30xav5xdxzgcqdvgs7l9h8k"
-    },
-    "jar": {
-      "sha1": "541bfb082a95a3b55d0158d69b067f1d7c623122",
-      "sha256": "0h1fz04y6jcz11mjpn6vj4lghlc09y3j4gi3p4nbvdigi8argcdf"
+    "path": "com/android/tools/lint/lint/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-26.0.1.pom": {
+        "sha1": "fbca22e39c4f0b04feec26b3ac78622bf39ae6d2",
+        "sha256": "1cyrkkpy9v8nndwlnz77sz21fk40i30xav5xdxzgcqdvgs7l9h8k"
+      },
+      "lint-26.0.1.jar": {
+        "sha1": "541bfb082a95a3b55d0158d69b067f1d7c623122",
+        "sha256": "0h1fz04y6jcz11mjpn6vj4lghlc09y3j4gi3p4nbvdigi8argcdf"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint/26.5.4/lint-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c66407e2be0122b96278dd7335dbff4665484135",
-      "sha256": "0x2p9svdz4bzlbmq7fjin7wxq2px76acyf2125i4g9ndsghrn4aj"
-    },
-    "jar": {
-      "sha1": "204dc78629c43f33cd547606d2cb8d65de506282",
-      "sha256": "04l6x0y1lpabaycl728in2jfvxrdacwxr2idkm092f5fylxs1z4z"
+    "path": "com/android/tools/lint/lint/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "lint-26.5.4.pom": {
+        "sha1": "c66407e2be0122b96278dd7335dbff4665484135",
+        "sha256": "0x2p9svdz4bzlbmq7fjin7wxq2px76acyf2125i4g9ndsghrn4aj"
+      },
+      "lint-26.5.4.jar": {
+        "sha1": "204dc78629c43f33cd547606d2cb8d65de506282",
+        "sha256": "04l6x0y1lpabaycl728in2jfvxrdacwxr2idkm092f5fylxs1z4z"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/repository/26.0.0/repository-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bfc1e8e4da7822065f06e8e71f56137535842668",
-      "sha256": "0z8c67369rch3z1mc52ipfk85wsj2kcwlhk4s3jv1pmf31wzyczd"
-    },
-    "jar": {
-      "sha1": "7ad3d113c50642163badf3b8d890c6b41b1c6238",
-      "sha256": "0582xlsbbnwl6dzj67yjjjnh5ysiva5pbd10szfvdi4gcnkvn26q"
+    "path": "com/android/tools/repository/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "repository-26.0.0.pom": {
+        "sha1": "bfc1e8e4da7822065f06e8e71f56137535842668",
+        "sha256": "0z8c67369rch3z1mc52ipfk85wsj2kcwlhk4s3jv1pmf31wzyczd"
+      },
+      "repository-26.0.0.jar": {
+        "sha1": "7ad3d113c50642163badf3b8d890c6b41b1c6238",
+        "sha256": "0582xlsbbnwl6dzj67yjjjnh5ysiva5pbd10szfvdi4gcnkvn26q"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/repository/26.0.1/repository-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1ce1944d6e8602c7fd60ee462522a18f1b93fa5c",
-      "sha256": "0srpskbq3n92mz1k5f147lpzvghyy3y83rk961xgzc75imnb43x2"
-    },
-    "jar": {
-      "sha1": "bc0dfe02af8d075f6b7ad63a202ed4c63a6a647d",
-      "sha256": "1301sjifc5qcpilybgq7k0mj6c7a212j30dj65qxcyqi7a9vllkg"
+    "path": "com/android/tools/repository/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "repository-26.0.1.pom": {
+        "sha1": "1ce1944d6e8602c7fd60ee462522a18f1b93fa5c",
+        "sha256": "0srpskbq3n92mz1k5f147lpzvghyy3y83rk961xgzc75imnb43x2"
+      },
+      "repository-26.0.1.jar": {
+        "sha1": "bc0dfe02af8d075f6b7ad63a202ed4c63a6a647d",
+        "sha256": "1301sjifc5qcpilybgq7k0mj6c7a212j30dj65qxcyqi7a9vllkg"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/repository/26.1.4/repository-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1b4c88b0253140647c018cce242b688d2ff98cc3",
-      "sha256": "1yinybbnmqlkcw43bqpxi6pq5lwr7ppj8xxfwkx264jqni5phipa"
-    },
-    "jar": {
-      "sha1": "349dfc72ae53dedc32a17f5d47440838fe2527f1",
-      "sha256": "0mskx9a3qm6499415mn0nzir9jvn807pnfwaf8wpymz4gsbfh45l"
+    "path": "com/android/tools/repository/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "repository-26.1.4.pom": {
+        "sha1": "1b4c88b0253140647c018cce242b688d2ff98cc3",
+        "sha256": "1yinybbnmqlkcw43bqpxi6pq5lwr7ppj8xxfwkx264jqni5phipa"
+      },
+      "repository-26.1.4.jar": {
+        "sha1": "349dfc72ae53dedc32a17f5d47440838fe2527f1",
+        "sha256": "0mskx9a3qm6499415mn0nzir9jvn807pnfwaf8wpymz4gsbfh45l"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/repository/26.2.1/repository-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ed8a2e0c85f79d8961ddc4afb0b92e0924c4c221",
-      "sha256": "1ppj1ilijp482fb7z35p7lsq2b3a341wxl009m9fgsh8nbgql1zb"
-    },
-    "jar": {
-      "sha1": "7a72673cd6b44aeafab3ccf831fc0b95cb61f3b5",
-      "sha256": "1hcw7lmjjcp9iccxd45zs6vcai52iynm11gk7mqfzyh3j7hdlx7s"
+    "path": "com/android/tools/repository/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "repository-26.2.1.pom": {
+        "sha1": "ed8a2e0c85f79d8961ddc4afb0b92e0924c4c221",
+        "sha256": "1ppj1ilijp482fb7z35p7lsq2b3a341wxl009m9fgsh8nbgql1zb"
+      },
+      "repository-26.2.1.jar": {
+        "sha1": "7a72673cd6b44aeafab3ccf831fc0b95cb61f3b5",
+        "sha256": "1hcw7lmjjcp9iccxd45zs6vcai52iynm11gk7mqfzyh3j7hdlx7s"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/repository/26.3.1/repository-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ab5a2f6cbedccf4ff9efbd5301fe26c9d1aaea2a",
-      "sha256": "0dzbfcs8z0648fd1xzxhyprnzh3zq8xg39j8nl9hbpj7gsp5h6am"
-    },
-    "jar": {
-      "sha1": "0fe4c713437ebfb8c68e95c717c063843bd63758",
-      "sha256": "1kpgl1mmmxz2vvfq1azgy65wr9aa1jgz1gfhkpdwc941z3j7d52i"
+    "path": "com/android/tools/repository/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "repository-26.3.1.pom": {
+        "sha1": "ab5a2f6cbedccf4ff9efbd5301fe26c9d1aaea2a",
+        "sha256": "0dzbfcs8z0648fd1xzxhyprnzh3zq8xg39j8nl9hbpj7gsp5h6am"
+      },
+      "repository-26.3.1.jar": {
+        "sha1": "0fe4c713437ebfb8c68e95c717c063843bd63758",
+        "sha256": "1kpgl1mmmxz2vvfq1azgy65wr9aa1jgz1gfhkpdwc941z3j7d52i"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/repository/26.5.4/repository-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "dbc9c0fdda79c10f8c236bfbb2edf70352144c6d",
-      "sha256": "0pdjrghq3h779rjvmrgi9sra7c8wamsbn5ysd3a8k873pkhmgd28"
-    },
-    "jar": {
-      "sha1": "41dc1986340a058bcee2124128c5ba9e1b52cb1f",
-      "sha256": "0hj09jl4q147vxllr7qarfx896yp747s31lrnf1wcfx92j2mq3f5"
+    "path": "com/android/tools/repository/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "repository-26.5.4.pom": {
+        "sha1": "dbc9c0fdda79c10f8c236bfbb2edf70352144c6d",
+        "sha256": "0pdjrghq3h779rjvmrgi9sra7c8wamsbn5ysd3a8k873pkhmgd28"
+      },
+      "repository-26.5.4.jar": {
+        "sha1": "41dc1986340a058bcee2124128c5ba9e1b52cb1f",
+        "sha256": "0hj09jl4q147vxllr7qarfx896yp747s31lrnf1wcfx92j2mq3f5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/26.0.0/sdklib-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4f9acbbb89224b1731deb41d5add787c304e2097",
-      "sha256": "1zmpmzaqh4124kh4py51s12ddgpw5dx35spiq1lxv8946kn4m62v"
-    },
-    "jar": {
-      "sha1": "5bc6118beed3c516fba2057e5feea3af932c1e22",
-      "sha256": "1jyh2zzy1mnp3692c6v2lahm75wv2d87iwm9bq2rnsip3pjhzhwv"
+    "path": "com/android/tools/sdklib/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdklib-26.0.0.pom": {
+        "sha1": "4f9acbbb89224b1731deb41d5add787c304e2097",
+        "sha256": "1zmpmzaqh4124kh4py51s12ddgpw5dx35spiq1lxv8946kn4m62v"
+      },
+      "sdklib-26.0.0.jar": {
+        "sha1": "5bc6118beed3c516fba2057e5feea3af932c1e22",
+        "sha256": "1jyh2zzy1mnp3692c6v2lahm75wv2d87iwm9bq2rnsip3pjhzhwv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/26.0.1/sdklib-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "220be342eb8692d2d1b864cdf2d0c275c7aa5c19",
-      "sha256": "07dl93g9g83pg8g53wl4z7h6hh4va0q120n5sf07zhjzcb17a11a"
-    },
-    "jar": {
-      "sha1": "bdb4723f8e3791f1d3911b1f191acf25840f352a",
-      "sha256": "19hmrd4pdkr535wm4pl4qfx6wr9q0jpjc718dfdqhq2ra1wi49fg"
+    "path": "com/android/tools/sdklib/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdklib-26.0.1.pom": {
+        "sha1": "220be342eb8692d2d1b864cdf2d0c275c7aa5c19",
+        "sha256": "07dl93g9g83pg8g53wl4z7h6hh4va0q120n5sf07zhjzcb17a11a"
+      },
+      "sdklib-26.0.1.jar": {
+        "sha1": "bdb4723f8e3791f1d3911b1f191acf25840f352a",
+        "sha256": "19hmrd4pdkr535wm4pl4qfx6wr9q0jpjc718dfdqhq2ra1wi49fg"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/26.1.4/sdklib-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0e7ef3a225517e60891160d63467bc3572de7e58",
-      "sha256": "00bgvi6pq59js519i0xi4zsz3pvvfn1l6dmi50b6k428jhdcljzh"
-    },
-    "jar": {
-      "sha1": "7424640f2bd3ca3faccb6f656e29547430cd464a",
-      "sha256": "02p8gsmqk7azzvvnmjnhpc8n49v83yf3pfia2py89j1h5fy7x2bs"
+    "path": "com/android/tools/sdklib/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdklib-26.1.4.pom": {
+        "sha1": "0e7ef3a225517e60891160d63467bc3572de7e58",
+        "sha256": "00bgvi6pq59js519i0xi4zsz3pvvfn1l6dmi50b6k428jhdcljzh"
+      },
+      "sdklib-26.1.4.jar": {
+        "sha1": "7424640f2bd3ca3faccb6f656e29547430cd464a",
+        "sha256": "02p8gsmqk7azzvvnmjnhpc8n49v83yf3pfia2py89j1h5fy7x2bs"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/26.2.1/sdklib-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0a5d07fb6e3ed7ebc33032538f275aa75171213e",
-      "sha256": "0a00r1llyxg8ls00pwg0yy0dxczrdpgf6jq74v0nm6c3jv8d4cbh"
-    },
-    "jar": {
-      "sha1": "6bedd85cbf10816816e71846600ffda8d5037c8b",
-      "sha256": "0i8vp5l96wqsqb858vh5mj4pnjyyc1kwg563jrpynjmcbsnzg394"
+    "path": "com/android/tools/sdklib/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdklib-26.2.1.pom": {
+        "sha1": "0a5d07fb6e3ed7ebc33032538f275aa75171213e",
+        "sha256": "0a00r1llyxg8ls00pwg0yy0dxczrdpgf6jq74v0nm6c3jv8d4cbh"
+      },
+      "sdklib-26.2.1.jar": {
+        "sha1": "6bedd85cbf10816816e71846600ffda8d5037c8b",
+        "sha256": "0i8vp5l96wqsqb858vh5mj4pnjyyc1kwg563jrpynjmcbsnzg394"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/26.3.1/sdklib-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d6cfc0d8a0f49620138cfaea6c51201c7c678633",
-      "sha256": "08a4j6hsy6c1l5mrj0041fvjr85fbr1dcmxn5wl473582sliqxc2"
-    },
-    "jar": {
-      "sha1": "85c3c1de8824ca1f5ff491690931256c23a7297b",
-      "sha256": "02kxa3n1mw47lrxk92h17fv5b6a021qz1g4bx43fz5g6nwapshv8"
+    "path": "com/android/tools/sdklib/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdklib-26.3.1.pom": {
+        "sha1": "d6cfc0d8a0f49620138cfaea6c51201c7c678633",
+        "sha256": "08a4j6hsy6c1l5mrj0041fvjr85fbr1dcmxn5wl473582sliqxc2"
+      },
+      "sdklib-26.3.1.jar": {
+        "sha1": "85c3c1de8824ca1f5ff491690931256c23a7297b",
+        "sha256": "02kxa3n1mw47lrxk92h17fv5b6a021qz1g4bx43fz5g6nwapshv8"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/26.5.4/sdklib-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "40ed09458a36fa35cdf2efc58acebc65e9edc3f6",
-      "sha256": "11a5f9m15dmfmw9zd1vfggp0khzp9vw6zdvhlk8njygm378f8f5d"
-    },
-    "jar": {
-      "sha1": "c1a4303d0e148a08be80c9ac1d9ea1c88ee0a85f",
-      "sha256": "0p1z1hylk287azqk8dz72b4036w1bdn1ba7qqs0gmzai8pmm6wdv"
+    "path": "com/android/tools/sdklib/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdklib-26.5.4.pom": {
+        "sha1": "40ed09458a36fa35cdf2efc58acebc65e9edc3f6",
+        "sha256": "11a5f9m15dmfmw9zd1vfggp0khzp9vw6zdvhlk8njygm378f8f5d"
+      },
+      "sdklib-26.5.4.jar": {
+        "sha1": "c1a4303d0e148a08be80c9ac1d9ea1c88ee0a85f",
+        "sha256": "0p1z1hylk287azqk8dz72b4036w1bdn1ba7qqs0gmzai8pmm6wdv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/26.0.0/sdk-common-26.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8fd56dc612f1f282fcddf1d2c5b4a8a2c1878bd7",
-      "sha256": "0915xd566szrd7zkmmq3f4swgx9s55qa9ys31dqpfvbqrpb361ap"
-    },
-    "jar": {
-      "sha1": "3cf21b0652068a57852663610e8c7f0a044dc700",
-      "sha256": "1f33bn2f8y83s02nzmw124lm217bj82kp8m516r69z1k3wz9nb67"
+    "path": "com/android/tools/sdk-common/26.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdk-common-26.0.0.pom": {
+        "sha1": "8fd56dc612f1f282fcddf1d2c5b4a8a2c1878bd7",
+        "sha256": "0915xd566szrd7zkmmq3f4swgx9s55qa9ys31dqpfvbqrpb361ap"
+      },
+      "sdk-common-26.0.0.jar": {
+        "sha1": "3cf21b0652068a57852663610e8c7f0a044dc700",
+        "sha256": "1f33bn2f8y83s02nzmw124lm217bj82kp8m516r69z1k3wz9nb67"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/26.0.1/sdk-common-26.0.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4a2198af4193975c9d22884503b7bed6e42d2460",
-      "sha256": "1andaam7b2a0dxsrgkijim2arz4fglc502n74r14fkxpcj5hyrm9"
-    },
-    "jar": {
-      "sha1": "9ddd2fa552e7b49548c421c0be4e65dc9a245f69",
-      "sha256": "1zcwbcglf3rj1qvr5cm065pv82hwgy1m825892nnvjxxh6idr2vy"
+    "path": "com/android/tools/sdk-common/26.0.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdk-common-26.0.1.pom": {
+        "sha1": "4a2198af4193975c9d22884503b7bed6e42d2460",
+        "sha256": "1andaam7b2a0dxsrgkijim2arz4fglc502n74r14fkxpcj5hyrm9"
+      },
+      "sdk-common-26.0.1.jar": {
+        "sha1": "9ddd2fa552e7b49548c421c0be4e65dc9a245f69",
+        "sha256": "1zcwbcglf3rj1qvr5cm065pv82hwgy1m825892nnvjxxh6idr2vy"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/26.1.4/sdk-common-26.1.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "03b3158f1e0d5eb281d5a6a67435b97dc2d76c21",
-      "sha256": "0a6jjz7fcbky2w2bv0v5qksppgr51nd7lhawr9lva3wg2gpk36mv"
-    },
-    "jar": {
-      "sha1": "5dbdefb2dc6cb5ba1b4b059bf11c964a830c5755",
-      "sha256": "1awy7i7q22avjs8lxys3i0k3b6qdi0kzvs03p2pxvwbm7lckv7bq"
+    "path": "com/android/tools/sdk-common/26.1.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdk-common-26.1.4.pom": {
+        "sha1": "03b3158f1e0d5eb281d5a6a67435b97dc2d76c21",
+        "sha256": "0a6jjz7fcbky2w2bv0v5qksppgr51nd7lhawr9lva3wg2gpk36mv"
+      },
+      "sdk-common-26.1.4.jar": {
+        "sha1": "5dbdefb2dc6cb5ba1b4b059bf11c964a830c5755",
+        "sha256": "1awy7i7q22avjs8lxys3i0k3b6qdi0kzvs03p2pxvwbm7lckv7bq"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/26.2.1/sdk-common-26.2.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e84475bfabf0dcb1d9b587a847c183d23b13fa85",
-      "sha256": "07qbivl4x5c2h685dxb9c7drrb9ma7d9rhnpl7l08rzk10sligys"
-    },
-    "jar": {
-      "sha1": "bcc236baac9d05aee927370ccaf5785d92ed5e2b",
-      "sha256": "1x0w045fhhllk43815q8h74cd3qmaixkgjhzjv7kb6m65hllp7bm"
+    "path": "com/android/tools/sdk-common/26.2.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdk-common-26.2.1.pom": {
+        "sha1": "e84475bfabf0dcb1d9b587a847c183d23b13fa85",
+        "sha256": "07qbivl4x5c2h685dxb9c7drrb9ma7d9rhnpl7l08rzk10sligys"
+      },
+      "sdk-common-26.2.1.jar": {
+        "sha1": "bcc236baac9d05aee927370ccaf5785d92ed5e2b",
+        "sha256": "1x0w045fhhllk43815q8h74cd3qmaixkgjhzjv7kb6m65hllp7bm"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/26.3.1/sdk-common-26.3.1",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9b7b4248e21db9c342dba7c3e891f740246b97c3",
-      "sha256": "1a4a76gp4kyxfb2p05w3gf7ynj4653ivr2394qhqfski9in7anlc"
-    },
-    "jar": {
-      "sha1": "c9bed0f05024f919fe6168ef381afbe72074a272",
-      "sha256": "1j1g1v42458vxixf2vvn3ksjlgr32hchz01ngz4424brsx55qrxk"
+    "path": "com/android/tools/sdk-common/26.3.1",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdk-common-26.3.1.pom": {
+        "sha1": "9b7b4248e21db9c342dba7c3e891f740246b97c3",
+        "sha256": "1a4a76gp4kyxfb2p05w3gf7ynj4653ivr2394qhqfski9in7anlc"
+      },
+      "sdk-common-26.3.1.jar": {
+        "sha1": "c9bed0f05024f919fe6168ef381afbe72074a272",
+        "sha256": "1j1g1v42458vxixf2vvn3ksjlgr32hchz01ngz4424brsx55qrxk"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/26.5.4/sdk-common-26.5.4",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f148513aeeeadae52d1ed5fba5c22fcfb262a0f2",
-      "sha256": "1jzpr0r8jcajsr6zysz8bqp88ymz0w2rqmramal9y3brx47ypyhj"
-    },
-    "jar": {
-      "sha1": "79236d1cf1374b157a92e2fd473e572279f2551d",
-      "sha256": "0g32l7d7jvbb2lfa9hhkgfa6d3kgpvbgbaksp9b9dmwmy64l3qr7"
+    "path": "com/android/tools/sdk-common/26.5.4",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "sdk-common-26.5.4.pom": {
+        "sha1": "f148513aeeeadae52d1ed5fba5c22fcfb262a0f2",
+        "sha256": "1jzpr0r8jcajsr6zysz8bqp88ymz0w2rqmramal9y3brx47ypyhj"
+      },
+      "sdk-common-26.5.4.jar": {
+        "sha1": "79236d1cf1374b157a92e2fd473e572279f2551d",
+        "sha256": "0g32l7d7jvbb2lfa9hhkgfa6d3kgpvbgbaksp9b9dmwmy64l3qr7"
+      }
     }
   },
 
   {
-    "path": "com/google/android/material/material/1.0.0/material-1.0.0",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "2bcf783c3bc66bafc0e1c9ca721d7544659bb6c3",
-      "sha256": "1aqm6mh1448hszv9agcq85wckpyiwjzhpi85wdfij48wsm0zbzy9"
-    },
-    "jar": {
-      "sha1": "f83e012c22d2fac8fcf23880d7167832b099fa94",
-      "sha256": "1p0sq4kgxybslqj8044fh056m9fqmp543r5jk7crhdy0lf0y703n"
+    "path": "com/google/android/material/material/1.0.0",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "material-1.0.0.pom": {
+        "sha1": "2bcf783c3bc66bafc0e1c9ca721d7544659bb6c3",
+        "sha256": "1aqm6mh1448hszv9agcq85wckpyiwjzhpi85wdfij48wsm0zbzy9"
+      },
+      "material-1.0.0.aar": {
+        "sha1": "f83e012c22d2fac8fcf23880d7167832b099fa94",
+        "sha256": "1p0sq4kgxybslqj8044fh056m9fqmp543r5jk7crhdy0lf0y703n"
+      }
     }
   },
 
   {
-    "path": "com/google/android/material/material/1.2.0-alpha03/material-1.2.0-alpha03",
-    "host": "https://dl.google.com/dl/android/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "b19834fc7dba44949d5f906136911bb271a708ae",
-      "sha256": "1gcyl9gbv41jc49b63vk9w69adp63djzllzcb8ljqwbi7771viil"
-    },
-    "jar": {
-      "sha1": "05bb1d391bbed501d9ec0de96dbdb3fa1464f255",
-      "sha256": "003b0mcsdr39rkspl8ai1rxxiw0gpdf7fh930485hpwk450d0cgx"
+    "path": "com/google/android/material/material/1.2.0-alpha03",
+    "repo": "https://dl.google.com/dl/android/maven2",
+    "files": {
+      "material-1.2.0-alpha03.pom": {
+        "sha1": "b19834fc7dba44949d5f906136911bb271a708ae",
+        "sha256": "1gcyl9gbv41jc49b63vk9w69adp63djzllzcb8ljqwbi7771viil"
+      },
+      "material-1.2.0-alpha03.aar": {
+        "sha1": "05bb1d391bbed501d9ec0de96dbdb3fa1464f255",
+        "sha256": "003b0mcsdr39rkspl8ai1rxxiw0gpdf7fh930485hpwk450d0cgx"
+      }
     }
   },
 
   {
-    "path": "com/github/Dimezis/BlurView/version-2.0.2/BlurView-version-2.0.2",
-    "host": "https://jitpack.io",
-    "type": "aar",
-    "pom": {
-      "sha1": "7b29beaf53b0e649c9598b61a2ba6432e0d9f63b",
-      "sha256": "002clz76ds41wn2dz5qy57r9xl437dl75zy2nxzrhv4cp45jiypc"
-    },
-    "jar": {
-      "sha1": "519c2433da424f955c805bbc54466d3b10289466",
-      "sha256": "01rrg39davjar4hld6j0i3rjcajii66z50dpjy668431wchwxs4j"
+    "path": "com/github/Dimezis/BlurView/version-2.0.2",
+    "repo": "https://jitpack.io",
+    "files": {
+      "BlurView-version-2.0.2.pom": {
+        "sha1": "7b29beaf53b0e649c9598b61a2ba6432e0d9f63b",
+        "sha256": "002clz76ds41wn2dz5qy57r9xl437dl75zy2nxzrhv4cp45jiypc"
+      },
+      "BlurView-version-2.0.2.aar": {
+        "sha1": "519c2433da424f955c805bbc54466d3b10289466",
+        "sha256": "01rrg39davjar4hld6j0i3rjcajii66z50dpjy668431wchwxs4j"
+      }
     }
   },
 
   {
-    "path": "com/github/status-im/function/0.0.1/function-0.0.1",
-    "host": "https://jitpack.io",
-    "type": "jar",
-    "pom": {
-      "sha1": "a8732bd3d863516447a2fa335ade1ae05c01fd4d",
-      "sha256": "1v9ng0x8yd7fn6v1v2xx1ywfvkrg8qsy52470n896jbkmjdy8y2y"
-    },
-    "jar": {
-      "sha1": "b68f81d53884a85fe2c0a8386e53cc0d6c980d1b",
-      "sha256": "07w70wbin3pwx420yqwk99m2pyk52q5m9qpflfrahfrmkp3fmwdq"
+    "path": "com/github/status-im/function/0.0.1",
+    "repo": "https://jitpack.io",
+    "files": {
+      "function-0.0.1.pom": {
+        "sha1": "a8732bd3d863516447a2fa335ade1ae05c01fd4d",
+        "sha256": "1v9ng0x8yd7fn6v1v2xx1ywfvkrg8qsy52470n896jbkmjdy8y2y"
+      },
+      "function-0.0.1.jar": {
+        "sha1": "b68f81d53884a85fe2c0a8386e53cc0d6c980d1b",
+        "sha256": "07w70wbin3pwx420yqwk99m2pyk52q5m9qpflfrahfrmkp3fmwdq"
+      }
     }
   },
 
   {
-    "path": "com/github/status-im/status-keycard-java/android/3.1.1/android-3.1.1",
-    "host": "https://jitpack.io",
-    "type": "jar",
-    "pom": {
-      "sha1": "ac7e6699628e329dfc028345f32bc41c5d6c2f33",
-      "sha256": "12qh5qwncj2gbv6g1whz32rliap34mv2kxlyqv2ivg5jc6yfvyhj"
-    },
-    "jar": {
-      "sha1": "26118061c0996fff357ae30cc360e5928c8dd455",
-      "sha256": "15m0h4ri0ny7jz4vvl25blw5s65iivlv5gchw0j5n0jblr1wr270"
+    "path": "com/github/status-im/status-keycard-java/android/3.1.1",
+    "repo": "https://jitpack.io",
+    "files": {
+      "android-3.1.1.pom": {
+        "sha1": "ac7e6699628e329dfc028345f32bc41c5d6c2f33",
+        "sha256": "12qh5qwncj2gbv6g1whz32rliap34mv2kxlyqv2ivg5jc6yfvyhj"
+      },
+      "android-3.1.1.jar": {
+        "sha1": "26118061c0996fff357ae30cc360e5928c8dd455",
+        "sha256": "15m0h4ri0ny7jz4vvl25blw5s65iivlv5gchw0j5n0jblr1wr270"
+      }
     }
   },
 
   {
-    "path": "com/github/status-im/status-keycard-java/lib/3.1.1/lib-3.1.1",
-    "host": "https://jitpack.io",
-    "type": "jar",
-    "pom": {
-      "sha1": "63c7bbd55ddbf88d1b89941f78158aa07fb46873",
-      "sha256": "1x0n0xq6zgg5qj6s6j9sjpy3zbggfznr64pb6sjh2882y4d1j6qi"
-    },
-    "jar": {
-      "sha1": "07f0374f17160c8731350316226ffe0de50f6f31",
-      "sha256": "1bfvb0ynxa0ws46cqmyx6d960pyg7hjxv3xwx7mg0xw03xk2bam1"
+    "path": "com/github/status-im/status-keycard-java/lib/3.1.1",
+    "repo": "https://jitpack.io",
+    "files": {
+      "lib-3.1.1.pom": {
+        "sha1": "63c7bbd55ddbf88d1b89941f78158aa07fb46873",
+        "sha256": "1x0n0xq6zgg5qj6s6j9sjpy3zbggfznr64pb6sjh2882y4d1j6qi"
+      },
+      "lib-3.1.1.jar": {
+        "sha1": "07f0374f17160c8731350316226ffe0de50f6f31",
+        "sha256": "1bfvb0ynxa0ws46cqmyx6d960pyg7hjxv3xwx7mg0xw03xk2bam1"
+      }
     }
   },
 
   {
-    "path": "com/github/wix-playground/ahbottomnavigation/3.3.0/ahbottomnavigation-3.3.0",
-    "host": "https://jitpack.io",
-    "type": "aar",
-    "pom": {
-      "sha1": "3bd510fdc1a32189fdd7dd78f023abbef70d9653",
-      "sha256": "0yxr2kyr3hfh50hikmdah503zk76pbd8hf8z2i1mrbnk97giqqy8"
-    },
-    "jar": {
-      "sha1": "d9a85263fb7033898294b64bdd936b2d95b2c771",
-      "sha256": "1vjyg4vgblhvvyyxpad9wkxh4mdnigz0rwf0f0y23v3x4bm763sm"
+    "path": "com/github/wix-playground/ahbottomnavigation/3.3.0",
+    "repo": "https://jitpack.io",
+    "files": {
+      "ahbottomnavigation-3.3.0.pom": {
+        "sha1": "3bd510fdc1a32189fdd7dd78f023abbef70d9653",
+        "sha256": "0yxr2kyr3hfh50hikmdah503zk76pbd8hf8z2i1mrbnk97giqqy8"
+      },
+      "ahbottomnavigation-3.3.0.aar": {
+        "sha1": "d9a85263fb7033898294b64bdd936b2d95b2c771",
+        "sha256": "1vjyg4vgblhvvyyxpad9wkxh4mdnigz0rwf0f0y23v3x4bm763sm"
+      }
     }
   },
 
   {
-    "path": "com/github/wix-playground/reflow-animator/1.0.6/reflow-animator-1.0.6",
-    "host": "https://jitpack.io",
-    "type": "aar",
-    "pom": {
-      "sha1": "4fe3d33c764beebdc477d93a590f63dfa38a5f6b",
-      "sha256": "13s8bg63v2kp80gaxidsbpp7ajcq3b65li342k1s5gxwrya0shih"
-    },
-    "jar": {
-      "sha1": "36074a3fcb77c2ba12bd2de7dde81441e0c7504f",
-      "sha256": "18k3yh4cdiy0dbn7azpsi8wmkpcphf75ayvfvgc2174ff6cq9f26"
+    "path": "com/github/wix-playground/reflow-animator/1.0.6",
+    "repo": "https://jitpack.io",
+    "files": {
+      "reflow-animator-1.0.6.pom": {
+        "sha1": "4fe3d33c764beebdc477d93a590f63dfa38a5f6b",
+        "sha256": "13s8bg63v2kp80gaxidsbpp7ajcq3b65li342k1s5gxwrya0shih"
+      },
+      "reflow-animator-1.0.6.aar": {
+        "sha1": "36074a3fcb77c2ba12bd2de7dde81441e0c7504f",
+        "sha256": "18k3yh4cdiy0dbn7azpsi8wmkpcphf75ayvfvgc2174ff6cq9f26"
+      }
     }
   },
 
   {
-    "path": "com/github/yalantis/ucrop/2.2.6-native/ucrop-2.2.6-native",
-    "host": "https://jitpack.io",
-    "type": "aar",
-    "pom": {
-      "sha1": "46554329fff3cae14a7fcafb2c8388cb7fe216e7",
-      "sha256": "0jzkdas4riz9sqsv5jq91cv29ibznm5cp0a1r1qd8lk8c9zml2jq"
-    },
-    "jar": {
-      "sha1": "a248e1b729dbb512215c845ec77e890a7b63d501",
-      "sha256": "0jivk6rhphdidx8bpidlp9lpwwa2bnm8jmb3zzbd366f2xr50af1"
+    "path": "com/github/yalantis/ucrop/2.2.6-native",
+    "repo": "https://jitpack.io",
+    "files": {
+      "ucrop-2.2.6-native.pom": {
+        "sha1": "46554329fff3cae14a7fcafb2c8388cb7fe216e7",
+        "sha256": "0jzkdas4riz9sqsv5jq91cv29ibznm5cp0a1r1qd8lk8c9zml2jq"
+      },
+      "ucrop-2.2.6-native.aar": {
+        "sha1": "a248e1b729dbb512215c845ec77e890a7b63d501",
+        "sha256": "0jivk6rhphdidx8bpidlp9lpwwa2bnm8jmb3zzbd366f2xr50af1"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/drawee/2.2.0/drawee-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "e8748b720366d85dcd58ceb0c698c1b7a36674a2",
-      "sha256": "0rk86yr5i9qm4qrjkas6ncl6c9ra4cqfijkv0ws8xglcbyw7a9sl"
-    },
-    "jar": {
-      "sha1": "07d461727cf24956ca7e579e266d5ac88762c0a0",
-      "sha256": "1qnavxnh4xgybw8v9g344v3vzzmy1q7f8wn3i89icd44gmiba6wr"
+    "path": "com/facebook/fresco/drawee/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "drawee-2.2.0.pom": {
+        "sha1": "e8748b720366d85dcd58ceb0c698c1b7a36674a2",
+        "sha256": "0rk86yr5i9qm4qrjkas6ncl6c9ra4cqfijkv0ws8xglcbyw7a9sl"
+      },
+      "drawee-2.2.0.aar": {
+        "sha1": "07d461727cf24956ca7e579e266d5ac88762c0a0",
+        "sha256": "1qnavxnh4xgybw8v9g344v3vzzmy1q7f8wn3i89icd44gmiba6wr"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/fbcore/2.2.0/fbcore-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "d9e14f467d0b22d767a20bef4f6fd721987ce367",
-      "sha256": "1j68icbcf9pqpja4baw8k39mk4a93i11qwnpswv0kkq3pb1czgib"
-    },
-    "jar": {
-      "sha1": "c827447f13d268ee8c67035cf197cec04d49cfe3",
-      "sha256": "0rrlkgwg3zmhzkrlycq85bmn7w3f6c5lfgabcvy2hfmi08s5zfsp"
+    "path": "com/facebook/fresco/fbcore/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "fbcore-2.2.0.pom": {
+        "sha1": "d9e14f467d0b22d767a20bef4f6fd721987ce367",
+        "sha256": "1j68icbcf9pqpja4baw8k39mk4a93i11qwnpswv0kkq3pb1czgib"
+      },
+      "fbcore-2.2.0.aar": {
+        "sha1": "c827447f13d268ee8c67035cf197cec04d49cfe3",
+        "sha256": "0rrlkgwg3zmhzkrlycq85bmn7w3f6c5lfgabcvy2hfmi08s5zfsp"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/fresco/2.2.0/fresco-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5026c7cd65322f9e1a426c3aaa14d46280239dbe",
-      "sha256": "13hbk3nv6djzl49429in59j8pjw4g9a8dcrpw3b07qvvh0qhg1kf"
-    },
-    "jar": {
-      "sha1": "a7504c680c2582757ca5eb01cf98cbb8503e73b1",
-      "sha256": "1554s3z3bfglb34kaj2pmmsni2c8mmdziplgpcl5mb59kxnlnjzg"
+    "path": "com/facebook/fresco/fresco/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "fresco-2.2.0.pom": {
+        "sha1": "5026c7cd65322f9e1a426c3aaa14d46280239dbe",
+        "sha256": "13hbk3nv6djzl49429in59j8pjw4g9a8dcrpw3b07qvvh0qhg1kf"
+      },
+      "fresco-2.2.0.aar": {
+        "sha1": "a7504c680c2582757ca5eb01cf98cbb8503e73b1",
+        "sha256": "1554s3z3bfglb34kaj2pmmsni2c8mmdziplgpcl5mb59kxnlnjzg"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/imagepipeline-native/2.2.0/imagepipeline-native-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "720451ef7183730cc6e41e90fc2aebf082c2cd19",
-      "sha256": "0w64rgap40sbdz8nvrmgv37szh5ac9sq76cp0s40iy2pqiz2i064"
-    },
-    "jar": {
-      "sha1": "d67236389cdf4ac92b4bb754641b7aa854f5ba7a",
-      "sha256": "0b9hjbxzy73arvmzx8kfgzp9wpvxznvar5ikxibbzfmf2zzrrw31"
+    "path": "com/facebook/fresco/imagepipeline-native/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "imagepipeline-native-2.2.0.pom": {
+        "sha1": "720451ef7183730cc6e41e90fc2aebf082c2cd19",
+        "sha256": "0w64rgap40sbdz8nvrmgv37szh5ac9sq76cp0s40iy2pqiz2i064"
+      },
+      "imagepipeline-native-2.2.0.aar": {
+        "sha1": "d67236389cdf4ac92b4bb754641b7aa854f5ba7a",
+        "sha256": "0b9hjbxzy73arvmzx8kfgzp9wpvxznvar5ikxibbzfmf2zzrrw31"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/imagepipeline/2.2.0/imagepipeline-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "626e49897e7b63b9ccc0f94ae4c244029aa82aec",
-      "sha256": "0ya5qc8y00w41nxdc7s8sx8rfx94jv44yfyfzgk984pnc780kg91"
-    },
-    "jar": {
-      "sha1": "d48b1ff6e6c4ebb8f0cfeb12db702dfad10ba04f",
-      "sha256": "10gavf6db3y8i2a1nhjq5apd6940hqz6dmg7rad882j17h6az91f"
+    "path": "com/facebook/fresco/imagepipeline/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "imagepipeline-2.2.0.pom": {
+        "sha1": "626e49897e7b63b9ccc0f94ae4c244029aa82aec",
+        "sha256": "0ya5qc8y00w41nxdc7s8sx8rfx94jv44yfyfzgk984pnc780kg91"
+      },
+      "imagepipeline-2.2.0.aar": {
+        "sha1": "d48b1ff6e6c4ebb8f0cfeb12db702dfad10ba04f",
+        "sha256": "10gavf6db3y8i2a1nhjq5apd6940hqz6dmg7rad882j17h6az91f"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/memory-type-java/2.2.0/memory-type-java-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "309f508be8421f790d2109bfa870f275048e4b9f",
-      "sha256": "04y6bnxq7qzzp7v65mbyx83al6sl3g8xfnq4y75rrpmzpmd1jhd2"
-    },
-    "jar": {
-      "sha1": "af16daca2b0af42730eca0ed02b85dfa6b100602",
-      "sha256": "1w7x5v79abxkcznj9qb11fb036qii4yyp0vp8ivg3n14b7xws83i"
+    "path": "com/facebook/fresco/memory-type-java/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "memory-type-java-2.2.0.pom": {
+        "sha1": "309f508be8421f790d2109bfa870f275048e4b9f",
+        "sha256": "04y6bnxq7qzzp7v65mbyx83al6sl3g8xfnq4y75rrpmzpmd1jhd2"
+      },
+      "memory-type-java-2.2.0.aar": {
+        "sha1": "af16daca2b0af42730eca0ed02b85dfa6b100602",
+        "sha256": "1w7x5v79abxkcznj9qb11fb036qii4yyp0vp8ivg3n14b7xws83i"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/memory-type-native/2.2.0/memory-type-native-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "a4ca6c3169ccf3db11121b806c571c779c596d19",
-      "sha256": "0jbhgwqlf83fhyd2rf4w29aw72z20pwpiwab79i4qv9qn3bqmzz7"
-    },
-    "jar": {
-      "sha1": "63e9739053ada471f72af7bf2bc642f4a9a7d43b",
-      "sha256": "16qsxh2zi1vylnj3waz743zm5kvbwzrb61qngcincjzysz3jzn6x"
+    "path": "com/facebook/fresco/memory-type-native/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "memory-type-native-2.2.0.pom": {
+        "sha1": "a4ca6c3169ccf3db11121b806c571c779c596d19",
+        "sha256": "0jbhgwqlf83fhyd2rf4w29aw72z20pwpiwab79i4qv9qn3bqmzz7"
+      },
+      "memory-type-native-2.2.0.aar": {
+        "sha1": "63e9739053ada471f72af7bf2bc642f4a9a7d43b",
+        "sha256": "16qsxh2zi1vylnj3waz743zm5kvbwzrb61qngcincjzysz3jzn6x"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/nativeimagefilters/2.2.0/nativeimagefilters-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "79bb9b688df382eeb4f76b878f960eb7ee806275",
-      "sha256": "0c535nxpakg86yhf91ysppnnmjfcwrhf88jgqzn0g7nyz3fwvmv7"
-    },
-    "jar": {
-      "sha1": "6a0b2c43c7a757f23b0c670b2a3995bdc3e5b713",
-      "sha256": "0jm4jk6gb5j6b94ilkla5jpamjwxjv7pljnka337yh0b0hbq34ba"
+    "path": "com/facebook/fresco/nativeimagefilters/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "nativeimagefilters-2.2.0.pom": {
+        "sha1": "79bb9b688df382eeb4f76b878f960eb7ee806275",
+        "sha256": "0c535nxpakg86yhf91ysppnnmjfcwrhf88jgqzn0g7nyz3fwvmv7"
+      },
+      "nativeimagefilters-2.2.0.aar": {
+        "sha1": "6a0b2c43c7a757f23b0c670b2a3995bdc3e5b713",
+        "sha256": "0jm4jk6gb5j6b94ilkla5jpamjwxjv7pljnka337yh0b0hbq34ba"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/stetho/2.2.0/stetho-2.2.0",
-    "host": "https://plugins.gradle.org/m2",
-    "type": "aar",
-    "pom": {
-      "sha1": "c98731a6a9b6d7ae4f4516c3515c817931f95c46",
-      "sha256": "1jm22xa58vgrgl4pzy4bcbz9bm1nkhg7xf6x0dz915asqfcpgzsg"
-    },
-    "jar": {
-      "sha1": "4c4ee688f80216c4dca4c67afa130b283a8bf5a5",
-      "sha256": "06k888gr75z9lbx4dwjfr8fpbjwcjh9ikff9nv3yar8r24f8fszb"
+    "path": "com/facebook/fresco/stetho/2.2.0",
+    "repo": "https://plugins.gradle.org/m2",
+    "files": {
+      "stetho-2.2.0.pom": {
+        "sha1": "c98731a6a9b6d7ae4f4516c3515c817931f95c46",
+        "sha256": "1jm22xa58vgrgl4pzy4bcbz9bm1nkhg7xf6x0dz915asqfcpgzsg"
+      },
+      "stetho-2.2.0.aar": {
+        "sha1": "4c4ee688f80216c4dca4c67afa130b283a8bf5a5",
+        "sha256": "06k888gr75z9lbx4dwjfr8fpbjwcjh9ikff9nv3yar8r24f8fszb"
+      }
     }
   },
 
   {
-    "path": "antlr/antlr/2.7.1/antlr-2.7.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "22aff158409d056a24ee49717ecb32fc9142edbe",
-      "sha256": "1hd7j5ajgmx3f282fi4b621bm4jpd3sv4rv5blhanni2qgcqxjq9"
-    },
-    "jar": {
-      "sha1": "9f391a14266a640b029a990aa5da4a26830cae98",
-      "sha256": "1mh1jwk133k512kh74b0gdswm9vij2y0cijysk0yqqc68qpadci6"
+    "path": "antlr/antlr/2.7.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-2.7.1.pom": {
+        "sha1": "22aff158409d056a24ee49717ecb32fc9142edbe",
+        "sha256": "1hd7j5ajgmx3f282fi4b621bm4jpd3sv4rv5blhanni2qgcqxjq9"
+      },
+      "antlr-2.7.1.jar": {
+        "sha1": "9f391a14266a640b029a990aa5da4a26830cae98",
+        "sha256": "1mh1jwk133k512kh74b0gdswm9vij2y0cijysk0yqqc68qpadci6"
+      }
     }
   },
 
   {
-    "path": "antlr/antlr/2.7.7/antlr-2.7.7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "52f15b99911ab8b8bc8744675f5cf1994a626fb8",
-      "sha256": "1dyf3yxs01zagx905z2cz7h58vpkxdqn3d7d0i14x2vzl8xpj3qh"
-    },
-    "jar": {
-      "sha1": "83cd2cd674a217ade95a4bb83a8a14f351f48bd0",
-      "sha256": "0k6wav7w33z1sgfwyvkpa7xsqjwmrj0fa4lfdvsvk5i5j55xmyw8"
+    "path": "antlr/antlr/2.7.7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-2.7.7.pom": {
+        "sha1": "52f15b99911ab8b8bc8744675f5cf1994a626fb8",
+        "sha256": "1dyf3yxs01zagx905z2cz7h58vpkxdqn3d7d0i14x2vzl8xpj3qh"
+      },
+      "antlr-2.7.7.jar": {
+        "sha1": "83cd2cd674a217ade95a4bb83a8a14f351f48bd0",
+        "sha256": "0k6wav7w33z1sgfwyvkpa7xsqjwmrj0fa4lfdvsvk5i5j55xmyw8"
+      }
     }
   },
 
   {
-    "path": "commons-cli/commons-cli/1.2/commons-cli-1.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e1b71e4b511c3c63f8b19d0302fe1d1c6e79035a",
-      "sha256": "0qa51rbqvrnpy91yn4k9bylalswziq4jaw1i93g2z370fqhfkwqq"
-    },
-    "jar": {
-      "sha1": "2bf96b7aa8b611c177d329452af1dc933e14501c",
-      "sha256": "1nar28vxmzsjiw12phv77q8qr6jjnbsx9kvwidb9nd3djm8qkkg7"
+    "path": "commons-cli/commons-cli/1.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-cli-1.2.pom": {
+        "sha1": "e1b71e4b511c3c63f8b19d0302fe1d1c6e79035a",
+        "sha256": "0qa51rbqvrnpy91yn4k9bylalswziq4jaw1i93g2z370fqhfkwqq"
+      },
+      "commons-cli-1.2.jar": {
+        "sha1": "2bf96b7aa8b611c177d329452af1dc933e14501c",
+        "sha256": "1nar28vxmzsjiw12phv77q8qr6jjnbsx9kvwidb9nd3djm8qkkg7"
+      }
     }
   },
 
   {
-    "path": "commons-codec/commons-codec/1.4/commons-codec-1.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "393db4ae967c6e831025d432632d1f72f7108b01",
-      "sha256": "13s0k9nv1zbmppf5b5fwc4j0506cgm061rzcdgki780v89lh1wzm"
-    },
-    "jar": {
-      "sha1": "4216af16d38465bbab0f3dff8efa14204f7a399a",
-      "sha256": "06v3ccc5srj9w2v459i5f5rc7j37b1a24n52a5bh78gkfi62793a"
+    "path": "commons-codec/commons-codec/1.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-codec-1.4.pom": {
+        "sha1": "393db4ae967c6e831025d432632d1f72f7108b01",
+        "sha256": "13s0k9nv1zbmppf5b5fwc4j0506cgm061rzcdgki780v89lh1wzm"
+      },
+      "commons-codec-1.4.jar": {
+        "sha1": "4216af16d38465bbab0f3dff8efa14204f7a399a",
+        "sha256": "06v3ccc5srj9w2v459i5f5rc7j37b1a24n52a5bh78gkfi62793a"
+      }
     }
   },
 
   {
-    "path": "commons-codec/commons-codec/1.6/commons-codec-1.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9499f0c87ab43a74c456b9847acbcb5e67fe9f32",
-      "sha256": "1298qykf61rrg2p3jnschq659ycqwkryp528v49vi9pkzz9kavm0"
-    },
-    "jar": {
-      "sha1": "b7f0fc8f61ecadeb3695f0b9464755eee44374d4",
-      "sha256": "11ix43vckkj5mbv9ccnv4vf745s8sgpkdms07syi854f3fa4xcsl"
+    "path": "commons-codec/commons-codec/1.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-codec-1.6.pom": {
+        "sha1": "9499f0c87ab43a74c456b9847acbcb5e67fe9f32",
+        "sha256": "1298qykf61rrg2p3jnschq659ycqwkryp528v49vi9pkzz9kavm0"
+      },
+      "commons-codec-1.6.jar": {
+        "sha1": "b7f0fc8f61ecadeb3695f0b9464755eee44374d4",
+        "sha256": "11ix43vckkj5mbv9ccnv4vf745s8sgpkdms07syi854f3fa4xcsl"
+      }
     }
   },
 
   {
-    "path": "commons-codec/commons-codec/1.9/commons-codec-1.9",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f5357ff0f308600af3660bf00a8be3415a335723",
-      "sha256": "143rq2sy3lp7qmzjn9a01qgz1mjg2jdlgi8x4266h2frkh1wzvz5"
-    },
-    "jar": {
-      "sha1": "9ce04e34240f674bc72680f8b843b1457383161a",
-      "sha256": "1ki3lyadsy1v0685nfay63iw3a16w89l2fjwdfa0pgrs3ihd46dd"
+    "path": "commons-codec/commons-codec/1.9",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-codec-1.9.pom": {
+        "sha1": "f5357ff0f308600af3660bf00a8be3415a335723",
+        "sha256": "143rq2sy3lp7qmzjn9a01qgz1mjg2jdlgi8x4266h2frkh1wzvz5"
+      },
+      "commons-codec-1.9.jar": {
+        "sha1": "9ce04e34240f674bc72680f8b843b1457383161a",
+        "sha256": "1ki3lyadsy1v0685nfay63iw3a16w89l2fjwdfa0pgrs3ihd46dd"
+      }
     }
   },
 
   {
-    "path": "commons-codec/commons-codec/1.10/commons-codec-1.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "44b9477418d2942d45550f7e7c66c16262062d0e",
-      "sha256": "1yscxabk7i59vgfjg7c1y3prj39h1d8prnwgxbisc4ni29qdpf5x"
-    },
-    "jar": {
-      "sha1": "4b95f4897fa13f2cd904aee711aeafc0c5295cd8",
-      "sha256": "0scm6321zz76dc3bs8sy2qyami755lz4lq5455gl67bi9slxyha2"
+    "path": "commons-codec/commons-codec/1.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-codec-1.10.pom": {
+        "sha1": "44b9477418d2942d45550f7e7c66c16262062d0e",
+        "sha256": "1yscxabk7i59vgfjg7c1y3prj39h1d8prnwgxbisc4ni29qdpf5x"
+      },
+      "commons-codec-1.10.jar": {
+        "sha1": "4b95f4897fa13f2cd904aee711aeafc0c5295cd8",
+        "sha256": "0scm6321zz76dc3bs8sy2qyami755lz4lq5455gl67bi9slxyha2"
+      }
     }
   },
 
   {
-    "path": "commons-codec/commons-codec/1.15/commons-codec-1.15",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c08f2dcdbba1a9466f3f9fa05e669fd61c3a47b7",
-      "sha256": "0n5b40x4wsmygna7fivix3cy9rs2yv5ikx30g141adsslfcf2vn8"
-    },
-    "jar": {
-      "sha1": "49d94806b6e3dc933dacbd8acb0fdbab8ebd1e5d",
-      "sha256": "0qzd8v96j4x7jjcfpvvdh9ar1xhwxpxi2rh51nzhj0br7bbgdsdk"
+    "path": "commons-codec/commons-codec/1.15",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-codec-1.15.pom": {
+        "sha1": "c08f2dcdbba1a9466f3f9fa05e669fd61c3a47b7",
+        "sha256": "0n5b40x4wsmygna7fivix3cy9rs2yv5ikx30g141adsslfcf2vn8"
+      },
+      "commons-codec-1.15.jar": {
+        "sha1": "49d94806b6e3dc933dacbd8acb0fdbab8ebd1e5d",
+        "sha256": "0qzd8v96j4x7jjcfpvvdh9ar1xhwxpxi2rh51nzhj0br7bbgdsdk"
+      }
     }
   },
 
   {
-    "path": "commons-io/commons-io/2.4/commons-io-2.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9ece23effe8bce3904f3797a76b1ba6ab681e1b9",
-      "sha256": "1wiikf78kr9k4pk68hb9jb9whrv19w8ir2kgxckad3wrrx3dvddj"
-    },
-    "jar": {
-      "sha1": "b1b6ea3b7e4aa4f492509a4952029cd8e48019ad",
-      "sha256": "108mw2v8ncig29kjvzh8wi76plr01f4x5l3b1929xk5a7vf42snc"
+    "path": "commons-io/commons-io/2.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-io-2.4.pom": {
+        "sha1": "9ece23effe8bce3904f3797a76b1ba6ab681e1b9",
+        "sha256": "1wiikf78kr9k4pk68hb9jb9whrv19w8ir2kgxckad3wrrx3dvddj"
+      },
+      "commons-io-2.4.jar": {
+        "sha1": "b1b6ea3b7e4aa4f492509a4952029cd8e48019ad",
+        "sha256": "108mw2v8ncig29kjvzh8wi76plr01f4x5l3b1929xk5a7vf42snc"
+      }
     }
   },
 
   {
-    "path": "commons-logging/commons-logging/1.1.1/commons-logging-1.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "76672afb562b9e903674ad3a544cdf2092f1faa3",
-      "sha256": "1s2yqfrwxa3xg0l2mkczh29gcii3xcjnb8lwvmxbk2sf0mny3wnh"
-    },
-    "jar": {
-      "sha1": "5043bfebc3db072ed80fbd362e7caf00e885d8ae",
-      "sha256": "0brngjgq24kk2c5qxzp3k6dcrzy7bdfdd1h1symb638zmly92vyf"
+    "path": "commons-logging/commons-logging/1.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-logging-1.1.1.pom": {
+        "sha1": "76672afb562b9e903674ad3a544cdf2092f1faa3",
+        "sha256": "1s2yqfrwxa3xg0l2mkczh29gcii3xcjnb8lwvmxbk2sf0mny3wnh"
+      },
+      "commons-logging-1.1.1.jar": {
+        "sha1": "5043bfebc3db072ed80fbd362e7caf00e885d8ae",
+        "sha256": "0brngjgq24kk2c5qxzp3k6dcrzy7bdfdd1h1symb638zmly92vyf"
+      }
     }
   },
 
   {
-    "path": "commons-logging/commons-logging/1.2/commons-logging-1.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "075c03ba4b01932842a996ef8d3fc1ab61ddeac2",
-      "sha256": "085vkxrh0hg2kwbyjblp0820hl1cpk38w5fc0zyzd1hdaymba6n9"
-    },
-    "jar": {
-      "sha1": "4bfc12adfe4842bf07b657f0369c4cb522955686",
-      "sha256": "0dm61zgmgjkg67kf9dyrzgpayd18r656n05kiabmc3xyl0gfmpfs"
+    "path": "commons-logging/commons-logging/1.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-logging-1.2.pom": {
+        "sha1": "075c03ba4b01932842a996ef8d3fc1ab61ddeac2",
+        "sha256": "085vkxrh0hg2kwbyjblp0820hl1cpk38w5fc0zyzd1hdaymba6n9"
+      },
+      "commons-logging-1.2.jar": {
+        "sha1": "4bfc12adfe4842bf07b657f0369c4cb522955686",
+        "sha256": "0dm61zgmgjkg67kf9dyrzgpayd18r656n05kiabmc3xyl0gfmpfs"
+      }
     }
   },
 
   {
-    "path": "com/adobe/xmp/xmpcore/5.1.2/xmpcore-5.1.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5f77687c678a0a6d8bfa82bb6f2ef708f084ba00",
-      "sha256": "1a2wfrwqchrks835jd8fnq4nypb9vi550lyrmarl55xyy0g2xsfc"
-    },
-    "jar": {
-      "sha1": "55615fa2582424e38705487d1d3969af8554f637",
-      "sha256": "143h5138azr3h5lb7aaiqxlj22l95p6arxiqp63hmzxa0cqddp0a"
+    "path": "com/adobe/xmp/xmpcore/5.1.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "xmpcore-5.1.2.pom": {
+        "sha1": "5f77687c678a0a6d8bfa82bb6f2ef708f084ba00",
+        "sha256": "1a2wfrwqchrks835jd8fnq4nypb9vi550lyrmarl55xyy0g2xsfc"
+      },
+      "xmpcore-5.1.2.jar": {
+        "sha1": "55615fa2582424e38705487d1d3969af8554f637",
+        "sha256": "143h5138azr3h5lb7aaiqxlj22l95p6arxiqp63hmzxa0cqddp0a"
+      }
     }
   },
 
   {
-    "path": "com/afollestad/material-dialogs/commons/0.9.6.0/commons-0.9.6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "aa1ed023a8ac8b5df9b17e41c2406010bd38bda1",
-      "sha256": "1ccchmljmb43jjba1qccnsbscara2bpj9lsjvsafib90f97l38i0"
-    },
-    "jar": {
-      "sha1": "21f4607036dc455fbe6c67ecbe5234c8257c33dc",
-      "sha256": "0zy97zx0pywq9622mzwhp7naj9x0nw1191h7ly70dlpp1bc87kym"
+    "path": "com/afollestad/material-dialogs/commons/0.9.6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-0.9.6.0.pom": {
+        "sha1": "aa1ed023a8ac8b5df9b17e41c2406010bd38bda1",
+        "sha256": "1ccchmljmb43jjba1qccnsbscara2bpj9lsjvsafib90f97l38i0"
+      },
+      "commons-0.9.6.0.aar": {
+        "sha1": "21f4607036dc455fbe6c67ecbe5234c8257c33dc",
+        "sha256": "0zy97zx0pywq9622mzwhp7naj9x0nw1191h7ly70dlpp1bc87kym"
+      }
     }
   },
 
   {
-    "path": "com/afollestad/material-dialogs/core/0.9.6.0/core-0.9.6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "d2640552c87f4803f40a8f526b1cf84c29608727",
-      "sha256": "17g2cd7ndx0vwag8y5gj6rg0in0mwm1p0clxmghxkrva8hfji3sv"
-    },
-    "jar": {
-      "sha1": "8f7a3101248ff835d06374a890d6037ee12c8c52",
-      "sha256": "1124xndki0ww0qpsa9xxpr3nd149m27d4w3i4aalxg40jfzaa6ib"
+    "path": "com/afollestad/material-dialogs/core/0.9.6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "core-0.9.6.0.pom": {
+        "sha1": "d2640552c87f4803f40a8f526b1cf84c29608727",
+        "sha256": "17g2cd7ndx0vwag8y5gj6rg0in0mwm1p0clxmghxkrva8hfji3sv"
+      },
+      "core-0.9.6.0.aar": {
+        "sha1": "8f7a3101248ff835d06374a890d6037ee12c8c52",
+        "sha256": "1124xndki0ww0qpsa9xxpr3nd149m27d4w3i4aalxg40jfzaa6ib"
+      }
     }
   },
 
   {
-    "path": "com/airbnb/android/lottie/3.4.4/lottie-3.4.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "cc31f1b29d1432093566c8ab31d830c20339aaa0",
-      "sha256": "1w3vnlg8r7f1asn7f5ajws8l2kmr9kv0aad0xwci4k2gfqhqdprv"
-    },
-    "jar": {
-      "sha1": "213d6753c5580a5ef8c935da845779e1cd350e60",
-      "sha256": "0lz8g59fi47a86lr7n642y9nh3zidpxgh1c40nqvgjzsjbz3ili3"
+    "path": "com/airbnb/android/lottie/3.4.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lottie-3.4.4.pom": {
+        "sha1": "cc31f1b29d1432093566c8ab31d830c20339aaa0",
+        "sha256": "1w3vnlg8r7f1asn7f5ajws8l2kmr9kv0aad0xwci4k2gfqhqdprv"
+      },
+      "lottie-3.4.4.aar": {
+        "sha1": "213d6753c5580a5ef8c935da845779e1cd350e60",
+        "sha256": "0lz8g59fi47a86lr7n642y9nh3zidpxgh1c40nqvgjzsjbz3ili3"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/1.0-rc5/baseLibrary-1.0-rc5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e956f9975bff435c6fc95aab976ff3b1032f3794",
-      "sha256": "0w80l57rlyjbdadwav8vwacanymvhimxzwirmgpbhyd1073s0hha"
-    },
-    "jar": {
-      "sha1": "4d15bfec5956b906a26527dbde26a4fc84326611",
-      "sha256": "18fkkkdy3qp7ixa10az5jmqf4x9vk2gqg6r6xqp8lid2c07w6hzc"
+    "path": "com/android/databinding/baseLibrary/1.0-rc5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "baseLibrary-1.0-rc5.pom": {
+        "sha1": "e956f9975bff435c6fc95aab976ff3b1032f3794",
+        "sha256": "0w80l57rlyjbdadwav8vwacanymvhimxzwirmgpbhyd1073s0hha"
+      },
+      "baseLibrary-1.0-rc5.jar": {
+        "sha1": "4d15bfec5956b906a26527dbde26a4fc84326611",
+        "sha256": "18fkkkdy3qp7ixa10az5jmqf4x9vk2gqg6r6xqp8lid2c07w6hzc"
+      }
     }
   },
 
   {
-    "path": "com/android/databinding/compilerCommon/1.0-rc5/compilerCommon-1.0-rc5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "167cd6131d81c21ed0582c157339425d33b6afbd",
-      "sha256": "1bxfnqb8pvc9hlk7mxnqy8am6lin9wxqn86irz1k47fc9j3gjjpp"
-    },
-    "jar": {
-      "sha1": "3152caf6b493a20e5b0d63bb36f5322dbce6d10f",
-      "sha256": "0ks2a7dff0wfihmcvircr9lkfc7j7g5cgprp021hqgk2hgij5iic"
+    "path": "com/android/databinding/compilerCommon/1.0-rc5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "compilerCommon-1.0-rc5.pom": {
+        "sha1": "167cd6131d81c21ed0582c157339425d33b6afbd",
+        "sha256": "1bxfnqb8pvc9hlk7mxnqy8am6lin9wxqn86irz1k47fc9j3gjjpp"
+      },
+      "compilerCommon-1.0-rc5.jar": {
+        "sha1": "3152caf6b493a20e5b0d63bb36f5322dbce6d10f",
+        "sha256": "0ks2a7dff0wfihmcvircr9lkfc7j7g5cgprp021hqgk2hgij5iic"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/24.1.3/annotations-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "96be923aa65cf1398c081aef3283f6316b7e7872",
-      "sha256": "1dsivp9xz98lw6pfn7rgak7sbx39x12fsgs49yplfv2vcmbnr0ks"
-    },
-    "jar": {
-      "sha1": "50057fe6aa0834b11e35f9723414c793022b30e4",
-      "sha256": "1a1plgmrrxykyb3b91ccqz9wkg3k01fs3rkwvsbdg8iaw90xsdy3"
+    "path": "com/android/tools/annotations/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotations-24.1.3.pom": {
+        "sha1": "96be923aa65cf1398c081aef3283f6316b7e7872",
+        "sha256": "1dsivp9xz98lw6pfn7rgak7sbx39x12fsgs49yplfv2vcmbnr0ks"
+      },
+      "annotations-24.1.3.jar": {
+        "sha1": "50057fe6aa0834b11e35f9723414c793022b30e4",
+        "sha256": "1a1plgmrrxykyb3b91ccqz9wkg3k01fs3rkwvsbdg8iaw90xsdy3"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/24.3.1/annotations-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ad6e2d7013950d4b3d6290420fc145c5107821be",
-      "sha256": "063k7zqjs4zsjra611gck9l6j1xb6vz3mw4xdz2j3mdlwycwn23y"
-    },
-    "jar": {
-      "sha1": "3c0f015e74a277e90ca34229458dd767aa39bb30",
-      "sha256": "123qw6v6w8cmznyf8lbfkn56209wzd7p24ddgs64wsp4dw47q16a"
+    "path": "com/android/tools/annotations/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotations-24.3.1.pom": {
+        "sha1": "ad6e2d7013950d4b3d6290420fc145c5107821be",
+        "sha256": "063k7zqjs4zsjra611gck9l6j1xb6vz3mw4xdz2j3mdlwycwn23y"
+      },
+      "annotations-24.3.1.jar": {
+        "sha1": "3c0f015e74a277e90ca34229458dd767aa39bb30",
+        "sha256": "123qw6v6w8cmznyf8lbfkn56209wzd7p24ddgs64wsp4dw47q16a"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/annotations/24.5.0/annotations-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "16ae9945d5f0ed5fb1aff1d9aaa627b82096b56e",
-      "sha256": "0m2wj96mar7cij4yzvcx1da9ab7ffcaa1s8mcgl9z242h7srpjf3"
-    },
-    "jar": {
-      "sha1": "7f2bcdf40b008f15481324327b7f9e377b0b1697",
-      "sha256": "08nrgm8j7q49ds9r0k1cbn1jsxdv0if9bhi37szxpjz7ks7azyr9"
+    "path": "com/android/tools/annotations/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotations-24.5.0.pom": {
+        "sha1": "16ae9945d5f0ed5fb1aff1d9aaa627b82096b56e",
+        "sha256": "0m2wj96mar7cij4yzvcx1da9ab7ffcaa1s8mcgl9z242h7srpjf3"
+      },
+      "annotations-24.5.0.jar": {
+        "sha1": "7f2bcdf40b008f15481324327b7f9e377b0b1697",
+        "sha256": "08nrgm8j7q49ds9r0k1cbn1jsxdv0if9bhi37szxpjz7ks7azyr9"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/1.1.3/builder-model-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "77113aabbd852756ee84d5e4b84bdd828b150366",
-      "sha256": "0c5vd5ca3v7d7rsbzijv5rh7ibv8sryfh8pdl46hzkr7r7321jsr"
-    },
-    "jar": {
-      "sha1": "1bff7ac9edd904720fde8a0a0978818e39a04e73",
-      "sha256": "1pww8x60m0r8safpr6ncf4h0zyzx26dflxyx7h6zs5ahvls7vqwi"
+    "path": "com/android/tools/build/builder-model/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-model-1.1.3.pom": {
+        "sha1": "77113aabbd852756ee84d5e4b84bdd828b150366",
+        "sha256": "0c5vd5ca3v7d7rsbzijv5rh7ibv8sryfh8pdl46hzkr7r7321jsr"
+      },
+      "builder-model-1.1.3.jar": {
+        "sha1": "1bff7ac9edd904720fde8a0a0978818e39a04e73",
+        "sha256": "1pww8x60m0r8safpr6ncf4h0zyzx26dflxyx7h6zs5ahvls7vqwi"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/1.3.1/builder-model-1.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ac4b0c04b2ad8d2549370600443b0790c9633f7b",
-      "sha256": "1ag6ngamvvz8z32796l3j2kaqcnx2lyap0339fzl540063iy3vvb"
-    },
-    "jar": {
-      "sha1": "16c0a3e34af44f31f757144d7c1bf045777dff88",
-      "sha256": "0v29x4pvgyksqg6fsaxdz46846snm1va73cd2d85pjll4vncjrh1"
+    "path": "com/android/tools/build/builder-model/1.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-model-1.3.1.pom": {
+        "sha1": "ac4b0c04b2ad8d2549370600443b0790c9633f7b",
+        "sha256": "1ag6ngamvvz8z32796l3j2kaqcnx2lyap0339fzl540063iy3vvb"
+      },
+      "builder-model-1.3.1.jar": {
+        "sha1": "16c0a3e34af44f31f757144d7c1bf045777dff88",
+        "sha256": "0v29x4pvgyksqg6fsaxdz46846snm1va73cd2d85pjll4vncjrh1"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-model/1.5.0/builder-model-1.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "669b49337dfbcc7cbfc0c12d3bff4e179bf160ad",
-      "sha256": "0mz3dq6in417r7rlads3pzkk0427yz9fpvw3j2l1vcgsm0mgy1yg"
-    },
-    "jar": {
-      "sha1": "51a48a2f4c1da923b0b8bb174e57bc68ee040889",
-      "sha256": "0mnl8znv1m6mfp67mlyjypvnsad2zpn18rj1wkccd9964kgk6jj0"
+    "path": "com/android/tools/build/builder-model/1.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-model-1.5.0.pom": {
+        "sha1": "669b49337dfbcc7cbfc0c12d3bff4e179bf160ad",
+        "sha256": "0mz3dq6in417r7rlads3pzkk0427yz9fpvw3j2l1vcgsm0mgy1yg"
+      },
+      "builder-model-1.5.0.jar": {
+        "sha1": "51a48a2f4c1da923b0b8bb174e57bc68ee040889",
+        "sha256": "0mnl8znv1m6mfp67mlyjypvnsad2zpn18rj1wkccd9964kgk6jj0"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/1.1.3/builder-test-api-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c5ac16a8a61af39c3f849314536187144e09c63d",
-      "sha256": "1scfz6dw29imr2689f8bki3xa3q89q34npl2q1cakrgdkjx9vm64"
-    },
-    "jar": {
-      "sha1": "cd1aebe463d911774829a144a48c5b88f13513e0",
-      "sha256": "1vi1sigcwkcx6hmi2ylprbj72fn6yh6jihwm4ks1c0chwpiwmyzc"
+    "path": "com/android/tools/build/builder-test-api/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-test-api-1.1.3.pom": {
+        "sha1": "c5ac16a8a61af39c3f849314536187144e09c63d",
+        "sha256": "1scfz6dw29imr2689f8bki3xa3q89q34npl2q1cakrgdkjx9vm64"
+      },
+      "builder-test-api-1.1.3.jar": {
+        "sha1": "cd1aebe463d911774829a144a48c5b88f13513e0",
+        "sha256": "1vi1sigcwkcx6hmi2ylprbj72fn6yh6jihwm4ks1c0chwpiwmyzc"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/1.3.1/builder-test-api-1.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0a5740c225133609a72df078483677bbd52ab5d5",
-      "sha256": "005wia2cqs9p1bya48pyvlhag6sfmh19amdlld3bs02z64rf1z49"
-    },
-    "jar": {
-      "sha1": "1954d436ec3eeea11070e91e6c808232837728b8",
-      "sha256": "065z0hh2cy2n0m25gx6hd7hvkf1c02kf3zin4mvk1idigl6c80xc"
+    "path": "com/android/tools/build/builder-test-api/1.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-test-api-1.3.1.pom": {
+        "sha1": "0a5740c225133609a72df078483677bbd52ab5d5",
+        "sha256": "005wia2cqs9p1bya48pyvlhag6sfmh19amdlld3bs02z64rf1z49"
+      },
+      "builder-test-api-1.3.1.jar": {
+        "sha1": "1954d436ec3eeea11070e91e6c808232837728b8",
+        "sha256": "065z0hh2cy2n0m25gx6hd7hvkf1c02kf3zin4mvk1idigl6c80xc"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/1.5.0/builder-test-api-1.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c72342d5d41bc45f97e42f74f887a2c88e3c69c5",
-      "sha256": "0a40zglgq1pddacrch3w2sqmdrm3ykq32n3ifk17nr1z7xph9ycd"
-    },
-    "jar": {
-      "sha1": "0d9240c30b1bb243b4f57c48f734df2635fbd07e",
-      "sha256": "0zvlzsdkj6h897124mv7x8ckf9wh51gfkl2y3i33r4pa6yjahxlh"
+    "path": "com/android/tools/build/builder-test-api/1.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-test-api-1.5.0.pom": {
+        "sha1": "c72342d5d41bc45f97e42f74f887a2c88e3c69c5",
+        "sha256": "0a40zglgq1pddacrch3w2sqmdrm3ykq32n3ifk17nr1z7xph9ycd"
+      },
+      "builder-test-api-1.5.0.jar": {
+        "sha1": "0d9240c30b1bb243b4f57c48f734df2635fbd07e",
+        "sha256": "0zvlzsdkj6h897124mv7x8ckf9wh51gfkl2y3i33r4pa6yjahxlh"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/1.1.3/builder-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5106e4e65ebd5ffeadf245c4c41da76938cd24bf",
-      "sha256": "1zk2hh69xsk9gx01lcbpvza0if83wx8y626g5xlwqp6fwzmisv56"
-    },
-    "jar": {
-      "sha1": "44e9cc678b260278b39349f7f13c305d68d17c8c",
-      "sha256": "0kxdvscdyail6ykcp07hnd2sw5kikz4cq83vdafqqmycbh4wfkhl"
+    "path": "com/android/tools/build/builder/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-1.1.3.pom": {
+        "sha1": "5106e4e65ebd5ffeadf245c4c41da76938cd24bf",
+        "sha256": "1zk2hh69xsk9gx01lcbpvza0if83wx8y626g5xlwqp6fwzmisv56"
+      },
+      "builder-1.1.3.jar": {
+        "sha1": "44e9cc678b260278b39349f7f13c305d68d17c8c",
+        "sha256": "0kxdvscdyail6ykcp07hnd2sw5kikz4cq83vdafqqmycbh4wfkhl"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/1.3.1/builder-1.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "dae3278eebf0589048e229b0142fcca0799bc170",
-      "sha256": "0d3h8z83a8pr8kcj0r4ar0w49s1gyg8s6k1k6j5sfghza4s7amkp"
-    },
-    "jar": {
-      "sha1": "83e6307a43477f2a5ff0b5b654b131425c3dcbc5",
-      "sha256": "1h1dc7nx2hfz6rw0si0k3hfjcwf26j7016d6vfxdrabavn27hwx7"
+    "path": "com/android/tools/build/builder/1.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-1.3.1.pom": {
+        "sha1": "dae3278eebf0589048e229b0142fcca0799bc170",
+        "sha256": "0d3h8z83a8pr8kcj0r4ar0w49s1gyg8s6k1k6j5sfghza4s7amkp"
+      },
+      "builder-1.3.1.jar": {
+        "sha1": "83e6307a43477f2a5ff0b5b654b131425c3dcbc5",
+        "sha256": "1h1dc7nx2hfz6rw0si0k3hfjcwf26j7016d6vfxdrabavn27hwx7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/builder/1.5.0/builder-1.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9ebf618447bc810b57feb2fd4635b556826696cb",
-      "sha256": "1q7ad0rraq0k3n3n1ac037qbwl6i62x51zvr2jhp369h9wh8br5j"
-    },
-    "jar": {
-      "sha1": "1dcd59f6f3c90b2a8bc7156d091ad1b87a41beed",
-      "sha256": "03kcavz74wk8wvk2g4a4l42sj7nifg17nsacsrkgpnr82fz573dp"
+    "path": "com/android/tools/build/builder/1.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "builder-1.5.0.pom": {
+        "sha1": "9ebf618447bc810b57feb2fd4635b556826696cb",
+        "sha256": "1q7ad0rraq0k3n3n1ac037qbwl6i62x51zvr2jhp369h9wh8br5j"
+      },
+      "builder-1.5.0.jar": {
+        "sha1": "1dcd59f6f3c90b2a8bc7156d091ad1b87a41beed",
+        "sha256": "03kcavz74wk8wvk2g4a4l42sj7nifg17nsacsrkgpnr82fz573dp"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-core/1.1.3/gradle-core-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "83d5be34609ab59c923f5b9fb70e52c1242335ad",
-      "sha256": "1w14j2y6dvm8ak2rhz6lp9wnqbi14q095k9m39rw69gnp9p6nazz"
-    },
-    "jar": {
-      "sha1": "94d5817bc8d445c5b2cfd44e8035afb6879c1bae",
-      "sha256": "0yd0bmpg5qx1zpmlcfna0fk52fmsrllrfm17ll06176qsbnl5dxj"
+    "path": "com/android/tools/build/gradle-core/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-core-1.1.3.pom": {
+        "sha1": "83d5be34609ab59c923f5b9fb70e52c1242335ad",
+        "sha256": "1w14j2y6dvm8ak2rhz6lp9wnqbi14q095k9m39rw69gnp9p6nazz"
+      },
+      "gradle-core-1.1.3.jar": {
+        "sha1": "94d5817bc8d445c5b2cfd44e8035afb6879c1bae",
+        "sha256": "0yd0bmpg5qx1zpmlcfna0fk52fmsrllrfm17ll06176qsbnl5dxj"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-core/1.3.1/gradle-core-1.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d25a6df467931a378d376e430604076753bbb1f3",
-      "sha256": "03bmm01wyh05zpxanam9f9fnvkwj8q7jr2idz1vj62fazwv9n7da"
-    },
-    "jar": {
-      "sha1": "70731f5b83a22faa2f25d6281f6812977f64f520",
-      "sha256": "1jnqk68w67pypljqfda1b3l1nwdk6kf85vc71svkc0c81qmscq69"
+    "path": "com/android/tools/build/gradle-core/1.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-core-1.3.1.pom": {
+        "sha1": "d25a6df467931a378d376e430604076753bbb1f3",
+        "sha256": "03bmm01wyh05zpxanam9f9fnvkwj8q7jr2idz1vj62fazwv9n7da"
+      },
+      "gradle-core-1.3.1.jar": {
+        "sha1": "70731f5b83a22faa2f25d6281f6812977f64f520",
+        "sha256": "1jnqk68w67pypljqfda1b3l1nwdk6kf85vc71svkc0c81qmscq69"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle-core/1.5.0/gradle-core-1.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "38fc0646f9f74f90543167609f80583c69d03393",
-      "sha256": "0dbfh9zk4si34i7s9zjz1dd0q8fqvaj335kbh27s17wj7mi6h87l"
-    },
-    "jar": {
-      "sha1": "70915a3f0ef4243d4630ea23219f5445fac82700",
-      "sha256": "0x4n6kpswqdaf4dw0w3iv1ahg6dmydvmnb07rl1gax4a8lpx1v68"
+    "path": "com/android/tools/build/gradle-core/1.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-core-1.5.0.pom": {
+        "sha1": "38fc0646f9f74f90543167609f80583c69d03393",
+        "sha256": "0dbfh9zk4si34i7s9zjz1dd0q8fqvaj335kbh27s17wj7mi6h87l"
+      },
+      "gradle-core-1.5.0.jar": {
+        "sha1": "70915a3f0ef4243d4630ea23219f5445fac82700",
+        "sha256": "0x4n6kpswqdaf4dw0w3iv1ahg6dmydvmnb07rl1gax4a8lpx1v68"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/1.1.3/gradle-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4af09990348139fa57d4a3e92a2285544b0d4b7b",
-      "sha256": "1yhrjnnm6mpqi76fknbc6f68n14ls8sc6gchnmx3hhacnhl29swm"
-    },
-    "jar": {
-      "sha1": "c6f66d30006cebbaf8c1c7f8675e955223bf64e6",
-      "sha256": "1rpa2plnz2znkszgg77fsm7zmcjiv77kh95r1s8x9nynf5ys0am6"
+    "path": "com/android/tools/build/gradle/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-1.1.3.pom": {
+        "sha1": "4af09990348139fa57d4a3e92a2285544b0d4b7b",
+        "sha256": "1yhrjnnm6mpqi76fknbc6f68n14ls8sc6gchnmx3hhacnhl29swm"
+      },
+      "gradle-1.1.3.jar": {
+        "sha1": "c6f66d30006cebbaf8c1c7f8675e955223bf64e6",
+        "sha256": "1rpa2plnz2znkszgg77fsm7zmcjiv77kh95r1s8x9nynf5ys0am6"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/1.3.1/gradle-1.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3c8a4b12eeed68097bc8470fb80504e1243a483c",
-      "sha256": "0s3kgm6q0n67n9ji3gxjr91vd1ssjj70vq03sjf0pb3vpwialamn"
-    },
-    "jar": {
-      "sha1": "f9f3d53c24efd3b9176ec36aeed9c518954c2fd9",
-      "sha256": "0p3z1yl397hm9va0i049k09cvkpkp1hwqngpicwdm3j3a6cfbbbm"
+    "path": "com/android/tools/build/gradle/1.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-1.3.1.pom": {
+        "sha1": "3c8a4b12eeed68097bc8470fb80504e1243a483c",
+        "sha256": "0s3kgm6q0n67n9ji3gxjr91vd1ssjj70vq03sjf0pb3vpwialamn"
+      },
+      "gradle-1.3.1.jar": {
+        "sha1": "f9f3d53c24efd3b9176ec36aeed9c518954c2fd9",
+        "sha256": "0p3z1yl397hm9va0i049k09cvkpkp1hwqngpicwdm3j3a6cfbbbm"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/gradle/1.5.0/gradle-1.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1c3d2b23212349ffbe6479fcb04732c5cddaf98b",
-      "sha256": "1lfyn5mpv1iyfb0kff869hp2dvpf45y28v1lylva6im1nk9wja1s"
-    },
-    "jar": {
-      "sha1": "ca6476d93e374e70d0b7ca45ddc86151da840aa6",
-      "sha256": "0yq6kw511hrcdr0383ar0lxjr0r247m10j1902qs3y5k15kmp8fd"
+    "path": "com/android/tools/build/gradle/1.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-1.5.0.pom": {
+        "sha1": "1c3d2b23212349ffbe6479fcb04732c5cddaf98b",
+        "sha256": "1lfyn5mpv1iyfb0kff869hp2dvpf45y28v1lylva6im1nk9wja1s"
+      },
+      "gradle-1.5.0.jar": {
+        "sha1": "ca6476d93e374e70d0b7ca45ddc86151da840aa6",
+        "sha256": "0yq6kw511hrcdr0383ar0lxjr0r247m10j1902qs3y5k15kmp8fd"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/24.1.3/manifest-merger-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d8c0c2eca527da981410a446c21a965c0e6ccb73",
-      "sha256": "114rz6xnnb9h9zywabqs0pl57w968x9h6cxw84nyf1255mvay2af"
-    },
-    "jar": {
-      "sha1": "bceca436ab72301a3add739dbffb747ebb19ddc8",
-      "sha256": "0by5zjrkaapg5cyzq8vv66pzfxnan524nh11l49vi4xakkajkh2l"
+    "path": "com/android/tools/build/manifest-merger/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "manifest-merger-24.1.3.pom": {
+        "sha1": "d8c0c2eca527da981410a446c21a965c0e6ccb73",
+        "sha256": "114rz6xnnb9h9zywabqs0pl57w968x9h6cxw84nyf1255mvay2af"
+      },
+      "manifest-merger-24.1.3.jar": {
+        "sha1": "bceca436ab72301a3add739dbffb747ebb19ddc8",
+        "sha256": "0by5zjrkaapg5cyzq8vv66pzfxnan524nh11l49vi4xakkajkh2l"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/24.3.1/manifest-merger-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d92b94e91d3a7e12d513c8aff3099b61d1fd274e",
-      "sha256": "0rsi5yg6zkmkag9gzk4ygk1qlbs1fma9qqwy1x5ryjqnrhjlgk05"
-    },
-    "jar": {
-      "sha1": "b9b0fc1064f963774beb573469ac371bf0c2c461",
-      "sha256": "1qy78vvpdz13ayrfv594gi276m48s14rj5rq42lpyfzjd9n81yl7"
+    "path": "com/android/tools/build/manifest-merger/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "manifest-merger-24.3.1.pom": {
+        "sha1": "d92b94e91d3a7e12d513c8aff3099b61d1fd274e",
+        "sha256": "0rsi5yg6zkmkag9gzk4ygk1qlbs1fma9qqwy1x5ryjqnrhjlgk05"
+      },
+      "manifest-merger-24.3.1.jar": {
+        "sha1": "b9b0fc1064f963774beb573469ac371bf0c2c461",
+        "sha256": "1qy78vvpdz13ayrfv594gi276m48s14rj5rq42lpyfzjd9n81yl7"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/24.5.0/manifest-merger-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4ed7f2f4e41e4dae51810f14d34c09e64ffae831",
-      "sha256": "0xmzf5s7y22h8qbdk9jfr41yyf166v50d60dmcj2ns2xkz485lnk"
-    },
-    "jar": {
-      "sha1": "dc521cf0bc3565f990d4da7fac4aabc73b6d62cf",
-      "sha256": "0smk0lrn6cl4rknhhbv8vj67rlqwrvbn5c07prgdnlbxv9r4qkwr"
+    "path": "com/android/tools/build/manifest-merger/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "manifest-merger-24.5.0.pom": {
+        "sha1": "4ed7f2f4e41e4dae51810f14d34c09e64ffae831",
+        "sha256": "0xmzf5s7y22h8qbdk9jfr41yyf166v50d60dmcj2ns2xkz485lnk"
+      },
+      "manifest-merger-24.5.0.jar": {
+        "sha1": "dc521cf0bc3565f990d4da7fac4aabc73b6d62cf",
+        "sha256": "0smk0lrn6cl4rknhhbv8vj67rlqwrvbn5c07prgdnlbxv9r4qkwr"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/transform-api/1.5.0/transform-api-1.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "48a97797e6ee321d516e5ef4844449660f09adb2",
-      "sha256": "1mclffhshq5llxv7d9ri4667rm6xsgc7qb6js4w8zfvydraisy31"
-    },
-    "jar": {
-      "sha1": "090f914a7972579a4cc726c9e0022878f6c675e2",
-      "sha256": "09knq0fpnal7a98x2bmv4ip5r486vnbi4npxy38p582rqa3dgd5f"
+    "path": "com/android/tools/build/transform-api/1.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "transform-api-1.5.0.pom": {
+        "sha1": "48a97797e6ee321d516e5ef4844449660f09adb2",
+        "sha256": "1mclffhshq5llxv7d9ri4667rm6xsgc7qb6js4w8zfvydraisy31"
+      },
+      "transform-api-1.5.0.jar": {
+        "sha1": "090f914a7972579a4cc726c9e0022878f6c675e2",
+        "sha256": "09knq0fpnal7a98x2bmv4ip5r486vnbi4npxy38p582rqa3dgd5f"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/build/transform-api/2.0.0-deprecated-use-gradle-api/transform-api-2.0.0-deprecated-use-gradle-api",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d2a89c5569f53a8c8adfe599ede88cb6f38a8a6e",
-      "sha256": "1sr2ksrjzr9gv0y70w17l97x9a2anlv63lx7n803lgvxf2gig7fl"
-    },
-    "jar": {
-      "sha1": "085bee1acea9e27152b920746c68133b30b11431",
-      "sha256": "16nfz9w0zpbbb0ghsab3gfp53imkr4d3gvhlgaz1m7v7w4d1bd78"
+    "path": "com/android/tools/build/transform-api/2.0.0-deprecated-use-gradle-api",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "transform-api-2.0.0-deprecated-use-gradle-api.pom": {
+        "sha1": "d2a89c5569f53a8c8adfe599ede88cb6f38a8a6e",
+        "sha256": "1sr2ksrjzr9gv0y70w17l97x9a2anlv63lx7n803lgvxf2gig7fl"
+      },
+      "transform-api-2.0.0-deprecated-use-gradle-api.jar": {
+        "sha1": "085bee1acea9e27152b920746c68133b30b11431",
+        "sha256": "16nfz9w0zpbbb0ghsab3gfp53imkr4d3gvhlgaz1m7v7w4d1bd78"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/24.1.3/common-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c457b4538f57ec5de8303c1bc571086588263be8",
-      "sha256": "1bxd8nnjzhkb8zakfil2sf8jmi8xshhhwyvyjbf814rw20223xdf"
-    },
-    "jar": {
-      "sha1": "84b5eaf800d08899fa7d3f7daf971a0d02ea80f0",
-      "sha256": "0cdhgvmlwbrc233l4c9pzif3i8qhqgyhikm1zf055jiawrmb9nch"
+    "path": "com/android/tools/common/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "common-24.1.3.pom": {
+        "sha1": "c457b4538f57ec5de8303c1bc571086588263be8",
+        "sha256": "1bxd8nnjzhkb8zakfil2sf8jmi8xshhhwyvyjbf814rw20223xdf"
+      },
+      "common-24.1.3.jar": {
+        "sha1": "84b5eaf800d08899fa7d3f7daf971a0d02ea80f0",
+        "sha256": "0cdhgvmlwbrc233l4c9pzif3i8qhqgyhikm1zf055jiawrmb9nch"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/24.3.1/common-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "23de0b66e531bd1e140b1121ff66edff6e17a5aa",
-      "sha256": "03gp1i0awzy0s327qkycma9v231id4fyz28izzjwsyyfbdxvwfka"
-    },
-    "jar": {
-      "sha1": "92f1a60ebb004e2969661315de200232f90e0a80",
-      "sha256": "0yh7c9jpy8ry54s02xwy23dscfqcca17gj7vdzj9iyd5ixkzk7pl"
+    "path": "com/android/tools/common/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "common-24.3.1.pom": {
+        "sha1": "23de0b66e531bd1e140b1121ff66edff6e17a5aa",
+        "sha256": "03gp1i0awzy0s327qkycma9v231id4fyz28izzjwsyyfbdxvwfka"
+      },
+      "common-24.3.1.jar": {
+        "sha1": "92f1a60ebb004e2969661315de200232f90e0a80",
+        "sha256": "0yh7c9jpy8ry54s02xwy23dscfqcca17gj7vdzj9iyd5ixkzk7pl"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/common/24.5.0/common-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "db31e9ab2e791b2eb4a90319b101aff1c333f75c",
-      "sha256": "1g3dw2vv5jpsw6hzdczq777hxcf93svqhg3h1dk203v9fsq0jld4"
-    },
-    "jar": {
-      "sha1": "55436737b893bac95c978b184dd35c76002d2eef",
-      "sha256": "1csmfwm5f02bdx9nmcr5pngf7si22608bymsm10raham3gdw540a"
+    "path": "com/android/tools/common/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "common-24.5.0.pom": {
+        "sha1": "db31e9ab2e791b2eb4a90319b101aff1c333f75c",
+        "sha256": "1g3dw2vv5jpsw6hzdczq777hxcf93svqhg3h1dk203v9fsq0jld4"
+      },
+      "common-24.5.0.jar": {
+        "sha1": "55436737b893bac95c978b184dd35c76002d2eef",
+        "sha256": "1csmfwm5f02bdx9nmcr5pngf7si22608bymsm10raham3gdw540a"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/24.1.3/ddmlib-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "73deb8a552731dd29742446b61e6b9e1726e2f88",
-      "sha256": "0c50xbjl0ygipmy2jpxla95ihr6kr4hq9f4dn62bb9s7wp2jn0la"
-    },
-    "jar": {
-      "sha1": "666d2e62661eccf89033ea1433e3a8f3622b5078",
-      "sha256": "0vxq71zz8v32sgr3qpa2rg04ibg55wdbkhsib3q0ljbgnmiw4xlp"
+    "path": "com/android/tools/ddms/ddmlib/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ddmlib-24.1.3.pom": {
+        "sha1": "73deb8a552731dd29742446b61e6b9e1726e2f88",
+        "sha256": "0c50xbjl0ygipmy2jpxla95ihr6kr4hq9f4dn62bb9s7wp2jn0la"
+      },
+      "ddmlib-24.1.3.jar": {
+        "sha1": "666d2e62661eccf89033ea1433e3a8f3622b5078",
+        "sha256": "0vxq71zz8v32sgr3qpa2rg04ibg55wdbkhsib3q0ljbgnmiw4xlp"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/24.3.1/ddmlib-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "82d64d7df960709b51584d4c2cb8c011a384bd7d",
-      "sha256": "0ghs0942dgyprfzmyx7h24c2sgrsrjhqjkjiyfxad6v1mnsclqy8"
-    },
-    "jar": {
-      "sha1": "2018ea863b14fe3aeaf2b49316ee98567e1d9c11",
-      "sha256": "0lmay6v7svqn2l97iwqhcc3sgs87pnhwc2p7293ykbr7gba9m5gz"
+    "path": "com/android/tools/ddms/ddmlib/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ddmlib-24.3.1.pom": {
+        "sha1": "82d64d7df960709b51584d4c2cb8c011a384bd7d",
+        "sha256": "0ghs0942dgyprfzmyx7h24c2sgrsrjhqjkjiyfxad6v1mnsclqy8"
+      },
+      "ddmlib-24.3.1.jar": {
+        "sha1": "2018ea863b14fe3aeaf2b49316ee98567e1d9c11",
+        "sha256": "0lmay6v7svqn2l97iwqhcc3sgs87pnhwc2p7293ykbr7gba9m5gz"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/24.5.0/ddmlib-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cd0a918c94d6f5745a8f8a3be1cf4e5da24228a9",
-      "sha256": "1qap223ph5mpndck080q2kp7r74w78pal9hsmka6al8yx2c4pys9"
-    },
-    "jar": {
-      "sha1": "d45670b5511da60d2939a1eece4c7c4407fee95b",
-      "sha256": "05r4fsjafhsqln5lblgzya9s6a5a9h28lb24w2ajs9ikr4qa73gm"
+    "path": "com/android/tools/ddms/ddmlib/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ddmlib-24.5.0.pom": {
+        "sha1": "cd0a918c94d6f5745a8f8a3be1cf4e5da24228a9",
+        "sha256": "1qap223ph5mpndck080q2kp7r74w78pal9hsmka6al8yx2c4pys9"
+      },
+      "ddmlib-24.5.0.jar": {
+        "sha1": "d45670b5511da60d2939a1eece4c7c4407fee95b",
+        "sha256": "05r4fsjafhsqln5lblgzya9s6a5a9h28lb24w2ajs9ikr4qa73gm"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/24.1.3/dvlib-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "922082f0d944cd196d68003500a398d2446a563b",
-      "sha256": "175lyn7gl84y47ix9igxi7llaywv60hqjji95k5w7v0snh6cqfsb"
-    },
-    "jar": {
-      "sha1": "637a1a657b190ee8abbbf2298f09ed6e90c3b8ef",
-      "sha256": "1a8jib0h7l83vw2cd3akp4h4rnns3j0rw920x9sfd0r1zb1ya345"
+    "path": "com/android/tools/dvlib/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "dvlib-24.1.3.pom": {
+        "sha1": "922082f0d944cd196d68003500a398d2446a563b",
+        "sha256": "175lyn7gl84y47ix9igxi7llaywv60hqjji95k5w7v0snh6cqfsb"
+      },
+      "dvlib-24.1.3.jar": {
+        "sha1": "637a1a657b190ee8abbbf2298f09ed6e90c3b8ef",
+        "sha256": "1a8jib0h7l83vw2cd3akp4h4rnns3j0rw920x9sfd0r1zb1ya345"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/24.3.1/dvlib-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f6b49646e055630844bd5e1a93affd62887ce613",
-      "sha256": "1v97xla81338arh6nrc9bmbv8n35dcqkkfyqnb5yi09dqg9k16wr"
-    },
-    "jar": {
-      "sha1": "1d78ec584fb99277e54e849b8ab57b860d590c17",
-      "sha256": "15r51gii0hx1fif8v3nwffh6fdjrc7vzzl8kp32mh3k2fjl8san4"
+    "path": "com/android/tools/dvlib/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "dvlib-24.3.1.pom": {
+        "sha1": "f6b49646e055630844bd5e1a93affd62887ce613",
+        "sha256": "1v97xla81338arh6nrc9bmbv8n35dcqkkfyqnb5yi09dqg9k16wr"
+      },
+      "dvlib-24.3.1.jar": {
+        "sha1": "1d78ec584fb99277e54e849b8ab57b860d590c17",
+        "sha256": "15r51gii0hx1fif8v3nwffh6fdjrc7vzzl8kp32mh3k2fjl8san4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/dvlib/24.5.0/dvlib-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ce0a9bdd22c7f8ddd0072526f4d0e3c5e565b107",
-      "sha256": "05ljif0lfvviz7c36m9xw2v5h16ylc7hz0v0wi8h01rxh5ajlz36"
-    },
-    "jar": {
-      "sha1": "0bb3cda7db1fa6c9543e887a8c451d0449e76fa4",
-      "sha256": "1zdnbx8mwxxh9g5894ly1sz4wfdnl63bppx0f4naq0ip7ahgcwvi"
+    "path": "com/android/tools/dvlib/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "dvlib-24.5.0.pom": {
+        "sha1": "ce0a9bdd22c7f8ddd0072526f4d0e3c5e565b107",
+        "sha256": "05ljif0lfvviz7c36m9xw2v5h16ylc7hz0v0wi8h01rxh5ajlz36"
+      },
+      "dvlib-24.5.0.jar": {
+        "sha1": "0bb3cda7db1fa6c9543e887a8c451d0449e76fa4",
+        "sha256": "1zdnbx8mwxxh9g5894ly1sz4wfdnl63bppx0f4naq0ip7ahgcwvi"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/external/lombok/lombok-ast/0.2.3/lombok-ast-0.2.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ac2e013f1621e1456de3ac77aeae0437237c736c",
-      "sha256": "1gbljyqw5r2vc31dl1flclsvdias3049pdrc6dicizcbvph92qcc"
-    },
-    "jar": {
-      "sha1": "0528b6f8bde3157f17530aa366631f2aad2a6cf9",
-      "sha256": "0vg8w757n8a8v6lafrg4xb9nl7dqw3x56p1qzfsp20j395p0vss5"
+    "path": "com/android/tools/external/lombok/lombok-ast/0.2.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lombok-ast-0.2.3.pom": {
+        "sha1": "ac2e013f1621e1456de3ac77aeae0437237c736c",
+        "sha256": "1gbljyqw5r2vc31dl1flclsvdias3049pdrc6dicizcbvph92qcc"
+      },
+      "lombok-ast-0.2.3.jar": {
+        "sha1": "0528b6f8bde3157f17530aa366631f2aad2a6cf9",
+        "sha256": "0vg8w757n8a8v6lafrg4xb9nl7dqw3x56p1qzfsp20j395p0vss5"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/jack/jack-api/0.9.0/jack-api-0.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2abc263cbda683515f7a62a4e78cbb418ce1d336",
-      "sha256": "11cx90mikr26cvylgz0d1sdvcmc5dpp5g6alm8agv022wx7jf34j"
-    },
-    "jar": {
-      "sha1": "6b474acfffc1e9d9e03df4ab3579b5fef852ed23",
-      "sha256": "0ahl804jlvxr2h4ls6mbq3ym4k6mr5kx62hdigsfil7iglmj80mq"
+    "path": "com/android/tools/jack/jack-api/0.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jack-api-0.9.0.pom": {
+        "sha1": "2abc263cbda683515f7a62a4e78cbb418ce1d336",
+        "sha256": "11cx90mikr26cvylgz0d1sdvcmc5dpp5g6alm8agv022wx7jf34j"
+      },
+      "jack-api-0.9.0.jar": {
+        "sha1": "6b474acfffc1e9d9e03df4ab3579b5fef852ed23",
+        "sha256": "0ahl804jlvxr2h4ls6mbq3ym4k6mr5kx62hdigsfil7iglmj80mq"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/jill/jill-api/0.9.0/jill-api-0.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f2b3545b3b7149a5e27c95a815ee6d7781ecd485",
-      "sha256": "0ffa7a7dhm2dqckk3w0vllknsq5i2q6qng7srlisdl8g7na5svx3"
-    },
-    "jar": {
-      "sha1": "09a83e898b15c853f6c92c74791064ca400cd3f3",
-      "sha256": "072gj0rkzxa77jhjs1bkzdfsmxpv57h5809yznrvqsav82nyy75q"
+    "path": "com/android/tools/jill/jill-api/0.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jill-api-0.9.0.pom": {
+        "sha1": "f2b3545b3b7149a5e27c95a815ee6d7781ecd485",
+        "sha256": "0ffa7a7dhm2dqckk3w0vllknsq5i2q6qng7srlisdl8g7na5svx3"
+      },
+      "jill-api-0.9.0.jar": {
+        "sha1": "09a83e898b15c853f6c92c74791064ca400cd3f3",
+        "sha256": "072gj0rkzxa77jhjs1bkzdfsmxpv57h5809yznrvqsav82nyy75q"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/24.1.3/layoutlib-api-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "349988c1cd90e600314c3187b0e3a908bcb91391",
-      "sha256": "11pxp107dam6xcbam2garn2adb51lcr1yjvx8a79mlhy1mg44gbz"
-    },
-    "jar": {
-      "sha1": "2160ac4c4d9795cf8a8130149a2ea0557ba02283",
-      "sha256": "1swfzjpbnrf0wqiakjpgym06ndjyig8wkv93crllfiiw21klxppg"
+    "path": "com/android/tools/layoutlib/layoutlib-api/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "layoutlib-api-24.1.3.pom": {
+        "sha1": "349988c1cd90e600314c3187b0e3a908bcb91391",
+        "sha256": "11pxp107dam6xcbam2garn2adb51lcr1yjvx8a79mlhy1mg44gbz"
+      },
+      "layoutlib-api-24.1.3.jar": {
+        "sha1": "2160ac4c4d9795cf8a8130149a2ea0557ba02283",
+        "sha256": "1swfzjpbnrf0wqiakjpgym06ndjyig8wkv93crllfiiw21klxppg"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/24.3.1/layoutlib-api-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f34f004d8e5c2a38fabe6323815f94ace633853a",
-      "sha256": "1klb099wp98j55k0fwkncnlqr7fp7sy8jl0ibhxp2dsh9p0gp45b"
-    },
-    "jar": {
-      "sha1": "982783a222369254fce34336cc48155bbd87e3fd",
-      "sha256": "16aw3kkkhmn055dxnmhfvf31fi1x1zh3ksj3kb990rcjb23yc6vr"
+    "path": "com/android/tools/layoutlib/layoutlib-api/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "layoutlib-api-24.3.1.pom": {
+        "sha1": "f34f004d8e5c2a38fabe6323815f94ace633853a",
+        "sha256": "1klb099wp98j55k0fwkncnlqr7fp7sy8jl0ibhxp2dsh9p0gp45b"
+      },
+      "layoutlib-api-24.3.1.jar": {
+        "sha1": "982783a222369254fce34336cc48155bbd87e3fd",
+        "sha256": "16aw3kkkhmn055dxnmhfvf31fi1x1zh3ksj3kb990rcjb23yc6vr"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/24.5.0/layoutlib-api-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fa97b9a79f6122105ba672a6fa02d1a1577dcdf5",
-      "sha256": "1hagbs722dgnwagxgwazggzp5y8wzgiz89qgw14yd3b1zsvwzv7c"
-    },
-    "jar": {
-      "sha1": "387949832720a36855711d2033cd4122e945f36e",
-      "sha256": "03dmpkz64xb2fmca8gw67vbvlpjvdbv0rs5hsymk90rj2cqz66mv"
+    "path": "com/android/tools/layoutlib/layoutlib-api/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "layoutlib-api-24.5.0.pom": {
+        "sha1": "fa97b9a79f6122105ba672a6fa02d1a1577dcdf5",
+        "sha256": "1hagbs722dgnwagxgwazggzp5y8wzgiz89qgw14yd3b1zsvwzv7c"
+      },
+      "layoutlib-api-24.5.0.jar": {
+        "sha1": "387949832720a36855711d2033cd4122e945f36e",
+        "sha256": "03dmpkz64xb2fmca8gw67vbvlpjvdbv0rs5hsymk90rj2cqz66mv"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-api/24.1.3/lint-api-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c741c76fb890f09637e77eec63bf550c6a9bcb00",
-      "sha256": "1286shvlk9nd7wp9zbcxayaggd76x42r8lqjbbisnqbqa5q7l4gf"
-    },
-    "jar": {
-      "sha1": "0a75b3dfb9104e09fef100fce9feb18b7fe30c2e",
-      "sha256": "18g2dq6q8dfzkcbxwkhjzzwgqx83ymdqvpw6rw34h85sq2q3yzwj"
+    "path": "com/android/tools/lint/lint-api/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-api-24.1.3.pom": {
+        "sha1": "c741c76fb890f09637e77eec63bf550c6a9bcb00",
+        "sha256": "1286shvlk9nd7wp9zbcxayaggd76x42r8lqjbbisnqbqa5q7l4gf"
+      },
+      "lint-api-24.1.3.jar": {
+        "sha1": "0a75b3dfb9104e09fef100fce9feb18b7fe30c2e",
+        "sha256": "18g2dq6q8dfzkcbxwkhjzzwgqx83ymdqvpw6rw34h85sq2q3yzwj"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-api/24.3.1/lint-api-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "47bb5e97941016323d8191f45651371ca6ed3dcf",
-      "sha256": "09czl4whxcdrgyk0k6q43j9lwzvrqbsxr6j46293hdglyayyypcw"
-    },
-    "jar": {
-      "sha1": "f5666b0d8408e79273a17cbe89c673c98f37b9fa",
-      "sha256": "1j6x1ccnb53ihv0n1xn20ba5plnsywqwrvi17cj3aznmz97gzhf4"
+    "path": "com/android/tools/lint/lint-api/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-api-24.3.1.pom": {
+        "sha1": "47bb5e97941016323d8191f45651371ca6ed3dcf",
+        "sha256": "09czl4whxcdrgyk0k6q43j9lwzvrqbsxr6j46293hdglyayyypcw"
+      },
+      "lint-api-24.3.1.jar": {
+        "sha1": "f5666b0d8408e79273a17cbe89c673c98f37b9fa",
+        "sha256": "1j6x1ccnb53ihv0n1xn20ba5plnsywqwrvi17cj3aznmz97gzhf4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-api/24.5.0/lint-api-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a9683a32abea8a508c6ed7c3c1b5eb3dc0b75557",
-      "sha256": "0yqmk5n9mljw2781r9mihfnm3322wfn22hyhc8pvik25qlyhy9kj"
-    },
-    "jar": {
-      "sha1": "7d93eb96a2f07860ab8d9ae761ebe5c416777fcf",
-      "sha256": "150h0x0yrf4gw325qlml4nalxm85ci2cr3gjini8sjljdhiaffp6"
+    "path": "com/android/tools/lint/lint-api/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-api-24.5.0.pom": {
+        "sha1": "a9683a32abea8a508c6ed7c3c1b5eb3dc0b75557",
+        "sha256": "0yqmk5n9mljw2781r9mihfnm3322wfn22hyhc8pvik25qlyhy9kj"
+      },
+      "lint-api-24.5.0.jar": {
+        "sha1": "7d93eb96a2f07860ab8d9ae761ebe5c416777fcf",
+        "sha256": "150h0x0yrf4gw325qlml4nalxm85ci2cr3gjini8sjljdhiaffp6"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-checks/24.1.3/lint-checks-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "70d5799c43e94c5414434b36792f578f60013c73",
-      "sha256": "0r10k23vsrscnmvc4w9rr3kcp3x0vsi5q7dvip2450jnbrwcyf0d"
-    },
-    "jar": {
-      "sha1": "077820b72a4390e2d640932106588de4dfa5ed67",
-      "sha256": "0gaf3hm0bhjnbzqyy0i69l17a0d14qkgm2wy7j1qnwsffli6vk1a"
+    "path": "com/android/tools/lint/lint-checks/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-checks-24.1.3.pom": {
+        "sha1": "70d5799c43e94c5414434b36792f578f60013c73",
+        "sha256": "0r10k23vsrscnmvc4w9rr3kcp3x0vsi5q7dvip2450jnbrwcyf0d"
+      },
+      "lint-checks-24.1.3.jar": {
+        "sha1": "077820b72a4390e2d640932106588de4dfa5ed67",
+        "sha256": "0gaf3hm0bhjnbzqyy0i69l17a0d14qkgm2wy7j1qnwsffli6vk1a"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-checks/24.3.1/lint-checks-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c5fa1b16386424e0a2fee9830554cf1214d9ac8f",
-      "sha256": "0r10z3ya4rc0c25prplxgmvpk0fpv5kfv09ajng9sdd61w8rkns6"
-    },
-    "jar": {
-      "sha1": "ee1edb630d923511bb46bef4da148dcb0a74a029",
-      "sha256": "0w92dm31sxr3findkp58ar774vjrfn64j1bdg54f0j1j7acrxsz4"
+    "path": "com/android/tools/lint/lint-checks/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-checks-24.3.1.pom": {
+        "sha1": "c5fa1b16386424e0a2fee9830554cf1214d9ac8f",
+        "sha256": "0r10z3ya4rc0c25prplxgmvpk0fpv5kfv09ajng9sdd61w8rkns6"
+      },
+      "lint-checks-24.3.1.jar": {
+        "sha1": "ee1edb630d923511bb46bef4da148dcb0a74a029",
+        "sha256": "0w92dm31sxr3findkp58ar774vjrfn64j1bdg54f0j1j7acrxsz4"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint-checks/24.5.0/lint-checks-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "489b0c0e5c956150a7cf29cd2749d6e505db3917",
-      "sha256": "02kfbr9hh29gx4brc7zlcv2x6pvbh5di5dfm4ir3dn4bi328h7dg"
-    },
-    "jar": {
-      "sha1": "dbdca0447c2333481823e088a356393e653276b4",
-      "sha256": "0iny9gdiw3l8x909g670ph4hl30crl1mmrqbsiacm7qb861v5msr"
+    "path": "com/android/tools/lint/lint-checks/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-checks-24.5.0.pom": {
+        "sha1": "489b0c0e5c956150a7cf29cd2749d6e505db3917",
+        "sha256": "02kfbr9hh29gx4brc7zlcv2x6pvbh5di5dfm4ir3dn4bi328h7dg"
+      },
+      "lint-checks-24.5.0.jar": {
+        "sha1": "dbdca0447c2333481823e088a356393e653276b4",
+        "sha256": "0iny9gdiw3l8x909g670ph4hl30crl1mmrqbsiacm7qb861v5msr"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint/24.1.3/lint-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2ce3cc74bd843616dda1d84a5bc7bfdc8fbae54f",
-      "sha256": "1qbdmj9lq3pg93cwfg3fi6fbsrqvwirg7zvv4hdk5zfx755fqwas"
-    },
-    "jar": {
-      "sha1": "7f120107f7cce494650581e345070818713eb433",
-      "sha256": "1rknkfg0vbl6wxdfkqhrqs42xhhwrkwsb5i9ng429l3bizkafv08"
+    "path": "com/android/tools/lint/lint/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-24.1.3.pom": {
+        "sha1": "2ce3cc74bd843616dda1d84a5bc7bfdc8fbae54f",
+        "sha256": "1qbdmj9lq3pg93cwfg3fi6fbsrqvwirg7zvv4hdk5zfx755fqwas"
+      },
+      "lint-24.1.3.jar": {
+        "sha1": "7f120107f7cce494650581e345070818713eb433",
+        "sha256": "1rknkfg0vbl6wxdfkqhrqs42xhhwrkwsb5i9ng429l3bizkafv08"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint/24.3.1/lint-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0ee9c4bf792910e6dff319f2602f1b0ca99940d6",
-      "sha256": "114mjyx7kabw4xnhn4gfps8gxiyk7nmhigdnfg3kl03lbg8qf9nj"
-    },
-    "jar": {
-      "sha1": "57cb2a6361f32753bee3670f072f097840219e34",
-      "sha256": "1pd71803sj1zi9nji2n1s9vhx6fkwbiqp3h5wr4g0kg80fw2ifvd"
+    "path": "com/android/tools/lint/lint/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-24.3.1.pom": {
+        "sha1": "0ee9c4bf792910e6dff319f2602f1b0ca99940d6",
+        "sha256": "114mjyx7kabw4xnhn4gfps8gxiyk7nmhigdnfg3kl03lbg8qf9nj"
+      },
+      "lint-24.3.1.jar": {
+        "sha1": "57cb2a6361f32753bee3670f072f097840219e34",
+        "sha256": "1pd71803sj1zi9nji2n1s9vhx6fkwbiqp3h5wr4g0kg80fw2ifvd"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/lint/lint/24.5.0/lint-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3759044c677888f526044f3ee25d77de19dfb4f8",
-      "sha256": "0qgbh875q595zc72ka74p3dmbkrgcgcn8yc63qmvqxb4p9y7j9yb"
-    },
-    "jar": {
-      "sha1": "461d7d801b822cbeb7daf001924fe1c616ce9535",
-      "sha256": "09ql9nn4l4v7rvl7qdww9klwaml2dazfixisf31lvs58vmd3yw1p"
+    "path": "com/android/tools/lint/lint/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "lint-24.5.0.pom": {
+        "sha1": "3759044c677888f526044f3ee25d77de19dfb4f8",
+        "sha256": "0qgbh875q595zc72ka74p3dmbkrgcgcn8yc63qmvqxb4p9y7j9yb"
+      },
+      "lint-24.5.0.jar": {
+        "sha1": "461d7d801b822cbeb7daf001924fe1c616ce9535",
+        "sha256": "09ql9nn4l4v7rvl7qdww9klwaml2dazfixisf31lvs58vmd3yw1p"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/24.1.3/sdklib-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "69fbae0fdd5a847d8eeee0e2bcf0970dbc06438d",
-      "sha256": "1zs3mfspi3lwvddpy43dx0nksml5sv5hrng68ha1b7wyc1kiffmb"
-    },
-    "jar": {
-      "sha1": "7b2e09d45db370f3219c3da2d2e82493bdb9069f",
-      "sha256": "16dkz0ql5zfxhfhvcir8jyqhagsab4ivwcgdmllbr89h4m0h60wa"
+    "path": "com/android/tools/sdklib/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "sdklib-24.1.3.pom": {
+        "sha1": "69fbae0fdd5a847d8eeee0e2bcf0970dbc06438d",
+        "sha256": "1zs3mfspi3lwvddpy43dx0nksml5sv5hrng68ha1b7wyc1kiffmb"
+      },
+      "sdklib-24.1.3.jar": {
+        "sha1": "7b2e09d45db370f3219c3da2d2e82493bdb9069f",
+        "sha256": "16dkz0ql5zfxhfhvcir8jyqhagsab4ivwcgdmllbr89h4m0h60wa"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/24.3.1/sdklib-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "045ca04b7749735b99d854d3abddf56cb49b3f10",
-      "sha256": "0lcsi0hqc697rmby7416v4glcq6b5biqrcran697ijdn71zqng2z"
-    },
-    "jar": {
-      "sha1": "1a4226d7db1381552b94fee30453a08fbfd678a5",
-      "sha256": "0piy4k3ybxswl8y2d0mi4x8w6f2624mbn9nzd06vcj88vb8hmjsa"
+    "path": "com/android/tools/sdklib/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "sdklib-24.3.1.pom": {
+        "sha1": "045ca04b7749735b99d854d3abddf56cb49b3f10",
+        "sha256": "0lcsi0hqc697rmby7416v4glcq6b5biqrcran697ijdn71zqng2z"
+      },
+      "sdklib-24.3.1.jar": {
+        "sha1": "1a4226d7db1381552b94fee30453a08fbfd678a5",
+        "sha256": "0piy4k3ybxswl8y2d0mi4x8w6f2624mbn9nzd06vcj88vb8hmjsa"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdklib/24.5.0/sdklib-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bff3e933089e1c17d494ea2ade8b9690803b26f3",
-      "sha256": "1sgcrp7ahzz9rn5f64zbjf75jfwajranzjinnq9qjch5ibpdap1g"
-    },
-    "jar": {
-      "sha1": "473c60ca5786363b6b3ea944446cf41676207ca7",
-      "sha256": "1w95kzmspw692crs1w8pc4bpn35jpmjdwkbbvw772kjs3k6simhn"
+    "path": "com/android/tools/sdklib/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "sdklib-24.5.0.pom": {
+        "sha1": "bff3e933089e1c17d494ea2ade8b9690803b26f3",
+        "sha256": "1sgcrp7ahzz9rn5f64zbjf75jfwajranzjinnq9qjch5ibpdap1g"
+      },
+      "sdklib-24.5.0.jar": {
+        "sha1": "473c60ca5786363b6b3ea944446cf41676207ca7",
+        "sha256": "1w95kzmspw692crs1w8pc4bpn35jpmjdwkbbvw772kjs3k6simhn"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/24.1.3/sdk-common-24.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4743b690b9c5358f254277bae367faed8be54221",
-      "sha256": "0b3kcjwri58p9nibrmpahhg1l5wnc0b0zgmalfmn34cfszzhqq89"
-    },
-    "jar": {
-      "sha1": "318e9d8ea2bbf481096e409c366795a6302498e5",
-      "sha256": "1m32bl87w7f34f8clfpzpv4q3d68km2bbv3fx0s26h2xkipl0610"
+    "path": "com/android/tools/sdk-common/24.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "sdk-common-24.1.3.pom": {
+        "sha1": "4743b690b9c5358f254277bae367faed8be54221",
+        "sha256": "0b3kcjwri58p9nibrmpahhg1l5wnc0b0zgmalfmn34cfszzhqq89"
+      },
+      "sdk-common-24.1.3.jar": {
+        "sha1": "318e9d8ea2bbf481096e409c366795a6302498e5",
+        "sha256": "1m32bl87w7f34f8clfpzpv4q3d68km2bbv3fx0s26h2xkipl0610"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/24.3.1/sdk-common-24.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b1614d578635b1badd25f11b64d658b5fe1b1b26",
-      "sha256": "0w77vwybipx1g2q4xdbh3f3vn5kk0y1r4zmr9ywyzda62xhanfsw"
-    },
-    "jar": {
-      "sha1": "5c28ab2dda1600eddaa978e095f0d8c044cac33b",
-      "sha256": "1lzykp6lqknxmlgxj4zq83dgj4m1x0cnsq0jw7mklwhmbghcc0n8"
+    "path": "com/android/tools/sdk-common/24.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "sdk-common-24.3.1.pom": {
+        "sha1": "b1614d578635b1badd25f11b64d658b5fe1b1b26",
+        "sha256": "0w77vwybipx1g2q4xdbh3f3vn5kk0y1r4zmr9ywyzda62xhanfsw"
+      },
+      "sdk-common-24.3.1.jar": {
+        "sha1": "5c28ab2dda1600eddaa978e095f0d8c044cac33b",
+        "sha256": "1lzykp6lqknxmlgxj4zq83dgj4m1x0cnsq0jw7mklwhmbghcc0n8"
+      }
     }
   },
 
   {
-    "path": "com/android/tools/sdk-common/24.5.0/sdk-common-24.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7c9c1a690245a44d024cc8700211c39c1ec900ef",
-      "sha256": "0qm1q8yfs2m5iply1wkamszgqap989m9hsq10x1rz1xav7wf5iq9"
-    },
-    "jar": {
-      "sha1": "e9b9c057d8df82ee7bc682558fe21b2110b3e40a",
-      "sha256": "09p26l9i7qmzhvk6jy2lk7z0v08p9ak1n2bc0902jbns3av2c9n7"
+    "path": "com/android/tools/sdk-common/24.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "sdk-common-24.5.0.pom": {
+        "sha1": "7c9c1a690245a44d024cc8700211c39c1ec900ef",
+        "sha256": "0qm1q8yfs2m5iply1wkamszgqap989m9hsq10x1rz1xav7wf5iq9"
+      },
+      "sdk-common-24.5.0.jar": {
+        "sha1": "e9b9c057d8df82ee7bc682558fe21b2110b3e40a",
+        "sha256": "09p26l9i7qmzhvk6jy2lk7z0v08p9ak1n2bc0902jbns3av2c9n7"
+      }
     }
   },
 
   {
-    "path": "com/drewnoakes/metadata-extractor/2.9.1/metadata-extractor-2.9.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d2c2b713b72d2382621c74c16464018c334df65c",
-      "sha256": "00bab2fd9pzih049k13lgb3s6c6w0y8963p8n6fgn8gndgbzqdlr"
-    },
-    "jar": {
-      "sha1": "53fdf22be10c9d426ec63431c7342895bc642261",
-      "sha256": "095hy0qphcjgxpl67ifa5sc3799hn1kzvn31qabaqnjyi9b84wsd"
+    "path": "com/drewnoakes/metadata-extractor/2.9.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "metadata-extractor-2.9.1.pom": {
+        "sha1": "d2c2b713b72d2382621c74c16464018c334df65c",
+        "sha256": "00bab2fd9pzih049k13lgb3s6c6w0y8963p8n6fgn8gndgbzqdlr"
+      },
+      "metadata-extractor-2.9.1.jar": {
+        "sha1": "53fdf22be10c9d426ec63431c7342895bc642261",
+        "sha256": "095hy0qphcjgxpl67ifa5sc3799hn1kzvn31qabaqnjyi9b84wsd"
+      }
     }
   },
 
   {
-    "path": "com/facebook/conceal/conceal/1.1.3/conceal-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "7a127807f09f8dfd511c539d42608f585ebd64fa",
-      "sha256": "0wmfmb1vk4d8shvd1jrs3y49mkmfaqikpcmx22cgqcmp0ca4l13p"
-    },
-    "jar": {
-      "sha1": "5d117a4a5dc63f52575fe16cca1b1605cbd8f86d",
-      "sha256": "1k9nziqybmylf5jkg4wpzlms0h5vi7rdkmg50qhp5ima1y54pxl1"
+    "path": "com/facebook/conceal/conceal/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "conceal-1.1.3.pom": {
+        "sha1": "7a127807f09f8dfd511c539d42608f585ebd64fa",
+        "sha256": "0wmfmb1vk4d8shvd1jrs3y49mkmfaqikpcmx22cgqcmp0ca4l13p"
+      },
+      "conceal-1.1.3.aar": {
+        "sha1": "5d117a4a5dc63f52575fe16cca1b1605cbd8f86d",
+        "sha256": "1k9nziqybmylf5jkg4wpzlms0h5vi7rdkmg50qhp5ima1y54pxl1"
+      },
+      "conceal-1.1.3.aar.asc": {
+        "sha1": "f88925f7e40e0c99b86cbd0ee060fd3393f0a875",
+        "sha256": "0ab24mb7ffy976p9f9qsrbh4szf0qn2r80sacmqn1dvjy9c1xp6z"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fbjni/fbjni-java-only/0.0.3/fbjni-java-only-0.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "de3576b735ff4fb2c9b60701b7c346c905c48433",
-      "sha256": "1pra3yy7pig69a9dz508wxarl1g4m7rdhvyga22lh16szpvc5rsk"
-    },
-    "jar": {
-      "sha1": "c4540aecb99b9ec380acef6c10bb6f700de8ac2c",
-      "sha256": "1h0whgk0bj7zid7kdy4hwz5n3jxcz8wi5mycqwjsqsndvlyk3ip2"
+    "path": "com/facebook/fbjni/fbjni-java-only/0.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fbjni-java-only-0.0.3.pom": {
+        "sha1": "de3576b735ff4fb2c9b60701b7c346c905c48433",
+        "sha256": "1pra3yy7pig69a9dz508wxarl1g4m7rdhvyga22lh16szpvc5rsk"
+      },
+      "fbjni-java-only-0.0.3.jar": {
+        "sha1": "c4540aecb99b9ec380acef6c10bb6f700de8ac2c",
+        "sha256": "1h0whgk0bj7zid7kdy4hwz5n3jxcz8wi5mycqwjsqsndvlyk3ip2"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fbjni/fbjni/0.0.2/fbjni-0.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "eb474889a1c485e1902b10ef0383fac4d74a7130",
-      "sha256": "0xl0i6jp308s1n0jpj6rg7k8v0a1acvjvk556gxg7bfh5knzngii"
-    },
-    "jar": {
-      "sha1": "d9e1b6ebbe55fe25f6ee6257ef64588e0f8a8db0",
-      "sha256": "0pjfj4p14wq8ya40awnlm389ynavbnx9l890vj0i917fzbc8i7h3"
+    "path": "com/facebook/fbjni/fbjni/0.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fbjni-0.0.2.pom": {
+        "sha1": "eb474889a1c485e1902b10ef0383fac4d74a7130",
+        "sha256": "0xl0i6jp308s1n0jpj6rg7k8v0a1acvjvk556gxg7bfh5knzngii"
+      },
+      "fbjni-0.0.2.aar": {
+        "sha1": "d9e1b6ebbe55fe25f6ee6257ef64588e0f8a8db0",
+        "sha256": "0pjfj4p14wq8ya40awnlm389ynavbnx9l890vj0i917fzbc8i7h3"
+      }
     }
   },
 
   {
-    "path": "com/facebook/flipper/flipper-fresco-plugin/0.54.0/flipper-fresco-plugin-0.54.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "78b6dd76ca355a13262d1b6fe97ea225d5b8c445",
-      "sha256": "0p5j7nix6q86xa3fiq0i2bnnb6qaszdl2yyq0w5c8yva86drvfrw"
-    },
-    "jar": {
-      "sha1": "36a4f4a3f4173cd4bdfe9a7f078e56fc93b63e64",
-      "sha256": "0kbv37kcj3lr3bikjfyfk48a0cq06n8jadbcyl7i6w7pr9lh7hlc"
+    "path": "com/facebook/flipper/flipper-fresco-plugin/0.54.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "flipper-fresco-plugin-0.54.0.pom": {
+        "sha1": "78b6dd76ca355a13262d1b6fe97ea225d5b8c445",
+        "sha256": "0p5j7nix6q86xa3fiq0i2bnnb6qaszdl2yyq0w5c8yva86drvfrw"
+      },
+      "flipper-fresco-plugin-0.54.0.aar": {
+        "sha1": "36a4f4a3f4173cd4bdfe9a7f078e56fc93b63e64",
+        "sha256": "0kbv37kcj3lr3bikjfyfk48a0cq06n8jadbcyl7i6w7pr9lh7hlc"
+      }
     }
   },
 
   {
-    "path": "com/facebook/flipper/flipper/0.54.0/flipper-0.54.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f1e963be185c5c5d5a8416faf16af29fddeaf1ab",
-      "sha256": "023hmlkczyswy2bdl559rasw7w3fi8210qkspl2wdh70axq8qvjq"
-    },
-    "jar": {
-      "sha1": "55d7417b5db25a08ac19048a6d03a44770ef1f68",
-      "sha256": "0aifn1d43f9b2xvww0r3xn59hv4np3s84m737xd2rkhvl38hcr5p"
+    "path": "com/facebook/flipper/flipper/0.54.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "flipper-0.54.0.pom": {
+        "sha1": "f1e963be185c5c5d5a8416faf16af29fddeaf1ab",
+        "sha256": "023hmlkczyswy2bdl559rasw7w3fi8210qkspl2wdh70axq8qvjq"
+      },
+      "flipper-0.54.0.aar": {
+        "sha1": "55d7417b5db25a08ac19048a6d03a44770ef1f68",
+        "sha256": "0aifn1d43f9b2xvww0r3xn59hv4np3s84m737xd2rkhvl38hcr5p"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/animated-base/2.2.0/animated-base-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "3c9efabd53423f457b58dcb07c7dc4baf7437fd6",
-      "sha256": "00am7zv5sa9wl6fyvbq2qh82f5575bi3zv9jvhisy139fbrgqsp2"
-    },
-    "jar": {
-      "sha1": "f20b31b8209c8a1739b2359da8b5f7eab1d96816",
-      "sha256": "04h9pfzkbk40jfhnj5bs6771l8ixhw1xhq83fxg0vcad60zyzvjd"
+    "path": "com/facebook/fresco/animated-base/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animated-base-2.2.0.pom": {
+        "sha1": "3c9efabd53423f457b58dcb07c7dc4baf7437fd6",
+        "sha256": "00am7zv5sa9wl6fyvbq2qh82f5575bi3zv9jvhisy139fbrgqsp2"
+      },
+      "animated-base-2.2.0.aar": {
+        "sha1": "f20b31b8209c8a1739b2359da8b5f7eab1d96816",
+        "sha256": "04h9pfzkbk40jfhnj5bs6771l8ixhw1xhq83fxg0vcad60zyzvjd"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/animated-drawable/2.2.0/animated-drawable-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "37d0119be3f63d25b518d5d960f84b67b4ffc945",
-      "sha256": "05mlhh321m2a42a9j0lrhi2i4v5z3j2wy01xjqjw772akc9mpvmn"
-    },
-    "jar": {
-      "sha1": "1190da6ea5f992a2fece1868d3a094bea171165e",
-      "sha256": "1m28dhwnyrjhdhm2383jx166x89y6c50p8rhrdplrhr0ajycd68d"
+    "path": "com/facebook/fresco/animated-drawable/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animated-drawable-2.2.0.pom": {
+        "sha1": "37d0119be3f63d25b518d5d960f84b67b4ffc945",
+        "sha256": "05mlhh321m2a42a9j0lrhi2i4v5z3j2wy01xjqjw772akc9mpvmn"
+      },
+      "animated-drawable-2.2.0.aar": {
+        "sha1": "1190da6ea5f992a2fece1868d3a094bea171165e",
+        "sha256": "1m28dhwnyrjhdhm2383jx166x89y6c50p8rhrdplrhr0ajycd68d"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/animated-gif/2.2.0/animated-gif-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "d90a3a13962a01927c72e9cc70dbd5a663673047",
-      "sha256": "10h3r457jmw94wy6rwy01r7g8djhcnqc719ngl5y4mj014n2pns6"
-    },
-    "jar": {
-      "sha1": "9015b920983f40af3de068f49baf1b8a24f8e073",
-      "sha256": "1am1wgarlk1qa0dwlmrb40vbd9jpl6cga39ahibrcn8w0l5yjzbp"
+    "path": "com/facebook/fresco/animated-gif/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animated-gif-2.2.0.pom": {
+        "sha1": "d90a3a13962a01927c72e9cc70dbd5a663673047",
+        "sha256": "10h3r457jmw94wy6rwy01r7g8djhcnqc719ngl5y4mj014n2pns6"
+      },
+      "animated-gif-2.2.0.aar": {
+        "sha1": "9015b920983f40af3de068f49baf1b8a24f8e073",
+        "sha256": "1am1wgarlk1qa0dwlmrb40vbd9jpl6cga39ahibrcn8w0l5yjzbp"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/drawee/2.0.0/drawee-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "da515406e37a176631d4eca1fb476ff4679526af",
-      "sha256": "1l5r22i6wjf2wxqzmwqn7543c7fhr8xmxv974rm4jqbzvmfdmcrc"
-    },
-    "jar": {
-      "sha1": "a85bfaeb87a9c8d1521c70edf6ded91ff9999475",
-      "sha256": "0j79cc0hr6fysqzbz5nqvj5s2dq12ivcvk61rrfdim2xg3r75xmk"
+    "path": "com/facebook/fresco/drawee/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "drawee-2.0.0.pom": {
+        "sha1": "da515406e37a176631d4eca1fb476ff4679526af",
+        "sha256": "1l5r22i6wjf2wxqzmwqn7543c7fhr8xmxv974rm4jqbzvmfdmcrc"
+      },
+      "drawee-2.0.0.aar": {
+        "sha1": "a85bfaeb87a9c8d1521c70edf6ded91ff9999475",
+        "sha256": "0j79cc0hr6fysqzbz5nqvj5s2dq12ivcvk61rrfdim2xg3r75xmk"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/fbcore/2.0.0/fbcore-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "d89be940a2441c81107d8170b8845243692e0d87",
-      "sha256": "0i8jwswahx4cvjlvrd4qq7lxjacnhwmbl81liiqnpm3001mq81r2"
-    },
-    "jar": {
-      "sha1": "8de91f71e8aa84a4d9be4dd88d1a0ac51600ad60",
-      "sha256": "1535zqgjyfrks3a04g4057yw1v348c0f669g6bxy59mlvsfkd6b2"
+    "path": "com/facebook/fresco/fbcore/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fbcore-2.0.0.pom": {
+        "sha1": "d89be940a2441c81107d8170b8845243692e0d87",
+        "sha256": "0i8jwswahx4cvjlvrd4qq7lxjacnhwmbl81liiqnpm3001mq81r2"
+      },
+      "fbcore-2.0.0.aar": {
+        "sha1": "8de91f71e8aa84a4d9be4dd88d1a0ac51600ad60",
+        "sha256": "1535zqgjyfrks3a04g4057yw1v348c0f669g6bxy59mlvsfkd6b2"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/flipper/2.2.0/flipper-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "ab86f244b9a4aa60328cc079e0450f7194020b78",
-      "sha256": "0iy8b0p4q30l1b0bnfpxmaqdhp8zfqxgbij2chnbyzralyxfa453"
-    },
-    "jar": {
-      "sha1": "f231a02b695bae83f7a985d3b16a160245e40e62",
-      "sha256": "1crvr3nmrn3xz7qb4srp88plzixcv050542qlihkbzp5w13my51p"
+    "path": "com/facebook/fresco/flipper/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "flipper-2.2.0.pom": {
+        "sha1": "ab86f244b9a4aa60328cc079e0450f7194020b78",
+        "sha256": "0iy8b0p4q30l1b0bnfpxmaqdhp8zfqxgbij2chnbyzralyxfa453"
+      },
+      "flipper-2.2.0.aar": {
+        "sha1": "f231a02b695bae83f7a985d3b16a160245e40e62",
+        "sha256": "1crvr3nmrn3xz7qb4srp88plzixcv050542qlihkbzp5w13my51p"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/fresco/2.0.0/fresco-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "44dc5a1512ee7539a2cbaa92cc4e0cb753ba5f6e",
-      "sha256": "05vy24y4dirlvcl314i5ph9bf1d9rfskbvwfxp3adrckq9pslj6q"
-    },
-    "jar": {
-      "sha1": "d473020b37b7cdd3171154942b55021a55a9d990",
-      "sha256": "0d32n8cjr3pczvd7z51j9jgdkgrnnna47l8dhf3av4mdgasps8vp"
+    "path": "com/facebook/fresco/fresco/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fresco-2.0.0.pom": {
+        "sha1": "44dc5a1512ee7539a2cbaa92cc4e0cb753ba5f6e",
+        "sha256": "05vy24y4dirlvcl314i5ph9bf1d9rfskbvwfxp3adrckq9pslj6q"
+      },
+      "fresco-2.0.0.aar": {
+        "sha1": "d473020b37b7cdd3171154942b55021a55a9d990",
+        "sha256": "0d32n8cjr3pczvd7z51j9jgdkgrnnna47l8dhf3av4mdgasps8vp"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/imagepipeline-base/2.0.0/imagepipeline-base-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "03370726ed9b383c8fe18f46da0bb99e7065360e",
-      "sha256": "0rwg88kwz18997gins4s0qqg5849y6bzdw7xhc57hacazlnqhyw3"
-    },
-    "jar": {
-      "sha1": "d27635390665d433f987177c548d25d0473eadbe",
-      "sha256": "1ii88f9xv919xz84c5ikcz5ilhw1gnpmdi11f87hd9pb24b61vls"
+    "path": "com/facebook/fresco/imagepipeline-base/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "imagepipeline-base-2.0.0.pom": {
+        "sha1": "03370726ed9b383c8fe18f46da0bb99e7065360e",
+        "sha256": "0rwg88kwz18997gins4s0qqg5849y6bzdw7xhc57hacazlnqhyw3"
+      },
+      "imagepipeline-base-2.0.0.aar": {
+        "sha1": "d27635390665d433f987177c548d25d0473eadbe",
+        "sha256": "1ii88f9xv919xz84c5ikcz5ilhw1gnpmdi11f87hd9pb24b61vls"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/imagepipeline-base/2.2.0/imagepipeline-base-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "e37d0acfeea73cbac29477c79b24d667e260eb18",
-      "sha256": "0z8nsdi191cc96xh5khspdqfr9rmpf2bd5hdylq1winndkmjqqx6"
-    },
-    "jar": {
-      "sha1": "9f9be2d9ccf4d96fb341f0fedcb47b9c800653a6",
-      "sha256": "13xmlnblbrax12q18l4dvhsal3rmfj7sigmkgk6ixry5k6xisr9g"
+    "path": "com/facebook/fresco/imagepipeline-base/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "imagepipeline-base-2.2.0.pom": {
+        "sha1": "e37d0acfeea73cbac29477c79b24d667e260eb18",
+        "sha256": "0z8nsdi191cc96xh5khspdqfr9rmpf2bd5hdylq1winndkmjqqx6"
+      },
+      "imagepipeline-base-2.2.0.aar": {
+        "sha1": "9f9be2d9ccf4d96fb341f0fedcb47b9c800653a6",
+        "sha256": "13xmlnblbrax12q18l4dvhsal3rmfj7sigmkgk6ixry5k6xisr9g"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/imagepipeline-okhttp3/2.0.0/imagepipeline-okhttp3-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "45180768c13c487c28b16994e3606d99d3e43b91",
-      "sha256": "0h2pbflga7hb12fzmrw0nxqvlxli6wdzs6yv1swkgasb0xxdl2xd"
-    },
-    "jar": {
-      "sha1": "bc1212ca66cd09678b416894ea8bd04102d26c5f",
-      "sha256": "0i70dcc7vl30fzzs7jcr2zdib0d0ykyw017nbwiv8myj52qn3x0g"
+    "path": "com/facebook/fresco/imagepipeline-okhttp3/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "imagepipeline-okhttp3-2.0.0.pom": {
+        "sha1": "45180768c13c487c28b16994e3606d99d3e43b91",
+        "sha256": "0h2pbflga7hb12fzmrw0nxqvlxli6wdzs6yv1swkgasb0xxdl2xd"
+      },
+      "imagepipeline-okhttp3-2.0.0.aar": {
+        "sha1": "bc1212ca66cd09678b416894ea8bd04102d26c5f",
+        "sha256": "0i70dcc7vl30fzzs7jcr2zdib0d0ykyw017nbwiv8myj52qn3x0g"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/imagepipeline/2.0.0/imagepipeline-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "24169782ac4accd2943d78545fefc8f4d802036f",
-      "sha256": "0v0wd314xb139vczm9bxhwc4p3r6zhy31k0rzcwn9vzna725xn0p"
-    },
-    "jar": {
-      "sha1": "7bc59327fb4895c465cbfeede700daf349ea56da",
-      "sha256": "1njlsbngxjvyy315ks1a4i1m0zn2x2jczmqyqrsn2qpiwq2swh5y"
+    "path": "com/facebook/fresco/imagepipeline/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "imagepipeline-2.0.0.pom": {
+        "sha1": "24169782ac4accd2943d78545fefc8f4d802036f",
+        "sha256": "0v0wd314xb139vczm9bxhwc4p3r6zhy31k0rzcwn9vzna725xn0p"
+      },
+      "imagepipeline-2.0.0.aar": {
+        "sha1": "7bc59327fb4895c465cbfeede700daf349ea56da",
+        "sha256": "1njlsbngxjvyy315ks1a4i1m0zn2x2jczmqyqrsn2qpiwq2swh5y"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/memory-type-ashmem/2.2.0/memory-type-ashmem-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "5e1b2193074370248aeb1bdff1b5cc80072d5fa9",
-      "sha256": "0lh5hnbp9irq277drmzv06cb74fbaqf47zlap5nybqcmygdm58dp"
-    },
-    "jar": {
-      "sha1": "7ae95af772c88b0e112fc7dc3b80b26fa42ed3c2",
-      "sha256": "0lahv1sr176hpfiq3ilyg5nhmr8myjkbwi01x3715b2zd111xplv"
+    "path": "com/facebook/fresco/memory-type-ashmem/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "memory-type-ashmem-2.2.0.pom": {
+        "sha1": "5e1b2193074370248aeb1bdff1b5cc80072d5fa9",
+        "sha256": "0lh5hnbp9irq277drmzv06cb74fbaqf47zlap5nybqcmygdm58dp"
+      },
+      "memory-type-ashmem-2.2.0.aar": {
+        "sha1": "7ae95af772c88b0e112fc7dc3b80b26fa42ed3c2",
+        "sha256": "0lahv1sr176hpfiq3ilyg5nhmr8myjkbwi01x3715b2zd111xplv"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/nativeimagefilters/2.0.0/nativeimagefilters-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "1f0bbe309c203355c6020aa084d7403389a82270",
-      "sha256": "1ccmdafcaa9zl2fbx60k1j01c1r29zjilgx4zjrjwlw1dy822wjj"
-    },
-    "jar": {
-      "sha1": "f49525db580abc4d2fb0a74fac771fc6c69f2adb",
-      "sha256": "06dp54s8ssrvy3nmdgfn5ffisi4c5qjqgdhbi22npk6l7w6fwpi4"
+    "path": "com/facebook/fresco/nativeimagefilters/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "nativeimagefilters-2.0.0.pom": {
+        "sha1": "1f0bbe309c203355c6020aa084d7403389a82270",
+        "sha256": "1ccmdafcaa9zl2fbx60k1j01c1r29zjilgx4zjrjwlw1dy822wjj"
+      },
+      "nativeimagefilters-2.0.0.aar": {
+        "sha1": "f49525db580abc4d2fb0a74fac771fc6c69f2adb",
+        "sha256": "06dp54s8ssrvy3nmdgfn5ffisi4c5qjqgdhbi22npk6l7w6fwpi4"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/nativeimagetranscoder/2.0.0/nativeimagetranscoder-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "0b0377ce474f9682274e0ad5174e1c8a61276d5a",
-      "sha256": "0m0r1v46iz8yhld0diiv0ryi77gnblvhxk8y4cjjbpi954fj78f2"
-    },
-    "jar": {
-      "sha1": "50fcabd33cbf73759206847bf3ed2dac7a0a588a",
-      "sha256": "1p29c8q3s8lalviasm95x77r7j1wdgfpsgjadnxmi3shzq1nrjg7"
+    "path": "com/facebook/fresco/nativeimagetranscoder/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "nativeimagetranscoder-2.0.0.pom": {
+        "sha1": "0b0377ce474f9682274e0ad5174e1c8a61276d5a",
+        "sha256": "0m0r1v46iz8yhld0diiv0ryi77gnblvhxk8y4cjjbpi954fj78f2"
+      },
+      "nativeimagetranscoder-2.0.0.aar": {
+        "sha1": "50fcabd33cbf73759206847bf3ed2dac7a0a588a",
+        "sha256": "1p29c8q3s8lalviasm95x77r7j1wdgfpsgjadnxmi3shzq1nrjg7"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/nativeimagetranscoder/2.2.0/nativeimagetranscoder-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "58f11fa92efadc1c59bbdc8cf9e9234f8f8a3ac1",
-      "sha256": "0ppwqs3ii232zfj5iisg1pkzr7qdz41xf75xjqrp6hxcbmnld3zm"
-    },
-    "jar": {
-      "sha1": "47f9472de0b3eda631d95cd927ff4bd0dd98816b",
-      "sha256": "0p7awfkagb15iqv37g5fdhjhnn22dqahqhav0ypcvwikvn30fs26"
+    "path": "com/facebook/fresco/nativeimagetranscoder/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "nativeimagetranscoder-2.2.0.pom": {
+        "sha1": "58f11fa92efadc1c59bbdc8cf9e9234f8f8a3ac1",
+        "sha256": "0ppwqs3ii232zfj5iisg1pkzr7qdz41xf75xjqrp6hxcbmnld3zm"
+      },
+      "nativeimagetranscoder-2.2.0.aar": {
+        "sha1": "47f9472de0b3eda631d95cd927ff4bd0dd98816b",
+        "sha256": "0p7awfkagb15iqv37g5fdhjhnn22dqahqhav0ypcvwikvn30fs26"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/soloader/2.2.0/soloader-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "300e6a8991ac9f84c5195faf80f61ce8ef63e27f",
-      "sha256": "0qcs2k95k19w4drff5cw109s3bz8mwghv4ydbp1r99d0gv5dsn0w"
-    },
-    "jar": {
-      "sha1": "b67d3ff3c1da2858a075286c6c458c36ccf295b7",
-      "sha256": "00dv4dm037xlirrq6rqfvplgbn467mkwpsgwia38yngj31jvjp9p"
+    "path": "com/facebook/fresco/soloader/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "soloader-2.2.0.pom": {
+        "sha1": "300e6a8991ac9f84c5195faf80f61ce8ef63e27f",
+        "sha256": "0qcs2k95k19w4drff5cw109s3bz8mwghv4ydbp1r99d0gv5dsn0w"
+      },
+      "soloader-2.2.0.aar": {
+        "sha1": "b67d3ff3c1da2858a075286c6c458c36ccf295b7",
+        "sha256": "00dv4dm037xlirrq6rqfvplgbn467mkwpsgwia38yngj31jvjp9p"
+      }
     }
   },
 
   {
-    "path": "com/facebook/fresco/ui-common/2.2.0/ui-common-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "1f5e47e876212694aebcc24e1389ddce54258381",
-      "sha256": "1iqfzl9l2wkbhyh8km9yzldny6j52y059v6vyxywjpp5gk1gigzs"
-    },
-    "jar": {
-      "sha1": "d053182f7cdce15a81861d665abca337708bc660",
-      "sha256": "0zdi3wnj142bidhnz5yl1rm6zprd4x1hz0514yq54q2yyb22mwfy"
+    "path": "com/facebook/fresco/ui-common/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ui-common-2.2.0.pom": {
+        "sha1": "1f5e47e876212694aebcc24e1389ddce54258381",
+        "sha256": "1iqfzl9l2wkbhyh8km9yzldny6j52y059v6vyxywjpp5gk1gigzs"
+      },
+      "ui-common-2.2.0.aar": {
+        "sha1": "d053182f7cdce15a81861d665abca337708bc660",
+        "sha256": "0zdi3wnj142bidhnz5yl1rm6zprd4x1hz0514yq54q2yyb22mwfy"
+      }
     }
   },
 
   {
-    "path": "com/facebook/infer/annotation/infer-annotation/0.11.2/infer-annotation-0.11.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7438ce677964a0745b4bf71a1ee1b3c9dc9a5f78",
-      "sha256": "0760d2q476scm3fg63s0pam1l6hllfcadqsz0cpcy94kzcqb99vr"
-    },
-    "jar": {
-      "sha1": "f514ff4ca022a579d9cf7524846988b646ae4491",
-      "sha256": "02fm111rcqqcp7avlvcv53n438g0nb5paxk75c15g90k1bx34y79"
+    "path": "com/facebook/infer/annotation/infer-annotation/0.11.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "infer-annotation-0.11.2.pom": {
+        "sha1": "7438ce677964a0745b4bf71a1ee1b3c9dc9a5f78",
+        "sha256": "0760d2q476scm3fg63s0pam1l6hllfcadqsz0cpcy94kzcqb99vr"
+      },
+      "infer-annotation-0.11.2.jar": {
+        "sha1": "f514ff4ca022a579d9cf7524846988b646ae4491",
+        "sha256": "02fm111rcqqcp7avlvcv53n438g0nb5paxk75c15g90k1bx34y79"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/annotation/0.8.2/annotation-0.8.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "f6ca5f3e78b1e68d3c8a2f5c8df24c01385ee4bb",
-      "sha256": "06x2bf6yfgi21m127wvk48sm1pjips3jw8c5gpjssswlsq3ql8qd"
-    },
-    "jar": {
-      "sha1": "ae6d46195467467fae746c6225f79ac41e7039e8",
-      "sha256": "0sbzgvkmx351gavaxw4ij27cghhvhhdjxpcsqlbmca2q8qcwwa3s"
+    "path": "com/facebook/soloader/annotation/0.8.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotation-0.8.2.pom": {
+        "sha1": "f6ca5f3e78b1e68d3c8a2f5c8df24c01385ee4bb",
+        "sha256": "06x2bf6yfgi21m127wvk48sm1pjips3jw8c5gpjssswlsq3ql8qd"
+      },
+      "annotation-0.8.2.aar": {
+        "sha1": "ae6d46195467467fae746c6225f79ac41e7039e8",
+        "sha256": "0sbzgvkmx351gavaxw4ij27cghhvhhdjxpcsqlbmca2q8qcwwa3s"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/annotation/0.9.0/annotation-0.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f108cf734bd827489b73a8c271aba1a7fdb0ba8b",
-      "sha256": "0a03digp52kh7rqjh6rchk0skbma1n39b9rv5h7xmxzs3wqpawa7"
-    },
-    "jar": {
-      "sha1": "dc58463712cb3e5f03d8ee5ac9743b9ced9afa77",
-      "sha256": "1syln51ijdd207wb4lwlyh2msb9v2i5r1l3zyk4n96q2yyp8f35d"
+    "path": "com/facebook/soloader/annotation/0.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotation-0.9.0.pom": {
+        "sha1": "f108cf734bd827489b73a8c271aba1a7fdb0ba8b",
+        "sha256": "0a03digp52kh7rqjh6rchk0skbma1n39b9rv5h7xmxzs3wqpawa7"
+      },
+      "annotation-0.9.0.jar": {
+        "sha1": "dc58463712cb3e5f03d8ee5ac9743b9ced9afa77",
+        "sha256": "1syln51ijdd207wb4lwlyh2msb9v2i5r1l3zyk4n96q2yyp8f35d"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/nativeloader/0.8.0/nativeloader-0.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d4a89469dc5d7e0d67e1f4af6e953b29be0d712e",
-      "sha256": "1s3l0f4lcl10r2mzxiqc6laqxjjwzk7kzcq4867jgciw2dnnpq3v"
-    },
-    "jar": {
-      "sha1": "50524ca901bccb0540204b8166abb23557809050",
-      "sha256": "1zx8535ym084hiba4bx3yk6d4vbalyry14zwlfkxjr37s09pp1pj"
+    "path": "com/facebook/soloader/nativeloader/0.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "nativeloader-0.8.0.pom": {
+        "sha1": "d4a89469dc5d7e0d67e1f4af6e953b29be0d712e",
+        "sha256": "1s3l0f4lcl10r2mzxiqc6laqxjjwzk7kzcq4867jgciw2dnnpq3v"
+      },
+      "nativeloader-0.8.0.jar": {
+        "sha1": "50524ca901bccb0540204b8166abb23557809050",
+        "sha256": "1zx8535ym084hiba4bx3yk6d4vbalyry14zwlfkxjr37s09pp1pj"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/nativeloader/0.8.2/nativeloader-0.8.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7209961d42aa840eb60b5c00ca623553b267b5ba",
-      "sha256": "01mkkys2xcmglksl0cb5vf87rx8bkiywi01amm38rd15dl6pgx5g"
-    },
-    "jar": {
-      "sha1": "86cb3da9384707034355ac1e84e9a8cf6de80f7c",
-      "sha256": "1kd6ipfaph30qn54mbkmjcaqicnp6r2ixpyncqy8p6yqvy6qyzr8"
+    "path": "com/facebook/soloader/nativeloader/0.8.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "nativeloader-0.8.2.pom": {
+        "sha1": "7209961d42aa840eb60b5c00ca623553b267b5ba",
+        "sha256": "01mkkys2xcmglksl0cb5vf87rx8bkiywi01amm38rd15dl6pgx5g"
+      },
+      "nativeloader-0.8.2.jar": {
+        "sha1": "86cb3da9384707034355ac1e84e9a8cf6de80f7c",
+        "sha256": "1kd6ipfaph30qn54mbkmjcaqicnp6r2ixpyncqy8p6yqvy6qyzr8"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/nativeloader/0.9.0/nativeloader-0.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "47c3f55508d9611da3cc1a5e21950851f88e5fcc",
-      "sha256": "0can8r0sa8f868fsx85h9a9khyfgx7bnb8hinm76ix1fsl74lq0p"
-    },
-    "jar": {
-      "sha1": "677c7fbfcc847d7eb6082048d07b10afd4cff898",
-      "sha256": "1a0vc40xvw08phmnhbb517frfqnn9i42ncbjsrbrp6v40a4c5gqq"
+    "path": "com/facebook/soloader/nativeloader/0.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "nativeloader-0.9.0.pom": {
+        "sha1": "47c3f55508d9611da3cc1a5e21950851f88e5fcc",
+        "sha256": "0can8r0sa8f868fsx85h9a9khyfgx7bnb8hinm76ix1fsl74lq0p"
+      },
+      "nativeloader-0.9.0.jar": {
+        "sha1": "677c7fbfcc847d7eb6082048d07b10afd4cff898",
+        "sha256": "1a0vc40xvw08phmnhbb517frfqnn9i42ncbjsrbrp6v40a4c5gqq"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/soloader/0.6.0/soloader-0.6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "53cb6e74ea402df0db7b87d27b6d977e3b20d18e",
-      "sha256": "17mb6v4vbb9mvs6zmwjacn244px7w4q5pnrmmymq9s3bcsivs6da"
-    },
-    "jar": {
-      "sha1": "4de8f64830aff60beb52fb27dffb2fcbe54c39df",
-      "sha256": "0bnrcda0pfivhzd2x514p7qfdpkz65fwgz0jgskrkjh45175rqnc"
+    "path": "com/facebook/soloader/soloader/0.6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "soloader-0.6.0.pom": {
+        "sha1": "53cb6e74ea402df0db7b87d27b6d977e3b20d18e",
+        "sha256": "17mb6v4vbb9mvs6zmwjacn244px7w4q5pnrmmymq9s3bcsivs6da"
+      },
+      "soloader-0.6.0.aar": {
+        "sha1": "4de8f64830aff60beb52fb27dffb2fcbe54c39df",
+        "sha256": "0bnrcda0pfivhzd2x514p7qfdpkz65fwgz0jgskrkjh45175rqnc"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/soloader/0.8.2/soloader-0.8.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "ed92ecd4b7f4ba68e2042694d2e1c44eb71b8cf2",
-      "sha256": "03mlzkiy7dm0f50dpvm1sz7px7iivjkbm74r56mks34hhy3m5wh1"
-    },
-    "jar": {
-      "sha1": "8575dbdec464207a19273bd3c09d758a08fa655c",
-      "sha256": "05vv6fqngfgq2sppn86csyfrx93igjf444n0nbhx2lkhcvxpv4wn"
+    "path": "com/facebook/soloader/soloader/0.8.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "soloader-0.8.2.pom": {
+        "sha1": "ed92ecd4b7f4ba68e2042694d2e1c44eb71b8cf2",
+        "sha256": "03mlzkiy7dm0f50dpvm1sz7px7iivjkbm74r56mks34hhy3m5wh1"
+      },
+      "soloader-0.8.2.aar": {
+        "sha1": "8575dbdec464207a19273bd3c09d758a08fa655c",
+        "sha256": "05vv6fqngfgq2sppn86csyfrx93igjf444n0nbhx2lkhcvxpv4wn"
+      }
     }
   },
 
   {
-    "path": "com/facebook/soloader/soloader/0.9.0/soloader-0.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "322607b4987e70c7fe76e12af15765f469369d65",
-      "sha256": "0xrdp6axm9lxc6nskgcmclf1c0ylfngd0l3bp0ngn8a7qwqakamq"
-    },
-    "jar": {
-      "sha1": "6e138af1dd29ceabf5bace2d24dc4333f304d104",
-      "sha256": "0sdpgjfnfa5gxbbx4ak8rml0f5d623gx8jknzkkj03iaj0c7b9ig"
+    "path": "com/facebook/soloader/soloader/0.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "soloader-0.9.0.pom": {
+        "sha1": "322607b4987e70c7fe76e12af15765f469369d65",
+        "sha256": "0xrdp6axm9lxc6nskgcmclf1c0ylfngd0l3bp0ngn8a7qwqakamq"
+      },
+      "soloader-0.9.0.aar": {
+        "sha1": "6e138af1dd29ceabf5bace2d24dc4333f304d104",
+        "sha256": "0sdpgjfnfa5gxbbx4ak8rml0f5d623gx8jknzkkj03iaj0c7b9ig"
+      }
     }
   },
 
   {
-    "path": "com/facebook/stetho/stetho/1.3.1/stetho-1.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e16906589a3ad314809946a37d838dbe53b7d936",
-      "sha256": "0djvpxdsn36dmzqpgibl567ghxvd2kp2m5k10rx5ci5c7nbpiwj4"
-    },
-    "jar": {
-      "sha1": "2c4076b466a0eb4d6ddf5721edd35cd1adc1f317",
-      "sha256": "003s99d4a1xk7i9nqy717yici09q533pwyw59ss3p2407s4j53ml"
+    "path": "com/facebook/stetho/stetho/1.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "stetho-1.3.1.pom": {
+        "sha1": "e16906589a3ad314809946a37d838dbe53b7d936",
+        "sha256": "0djvpxdsn36dmzqpgibl567ghxvd2kp2m5k10rx5ci5c7nbpiwj4"
+      },
+      "stetho-1.3.1.jar": {
+        "sha1": "2c4076b466a0eb4d6ddf5721edd35cd1adc1f317",
+        "sha256": "003s99d4a1xk7i9nqy717yici09q533pwyw59ss3p2407s4j53ml"
+      }
     }
   },
 
   {
-    "path": "com/facebook/yoga/proguard-annotations/1.14.1/proguard-annotations-1.14.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "59f786ef9485f034cfed3f0c9cd7bdee8155314b",
-      "sha256": "1c11zbpsmfyaklgjc5r401li1155jb89f9mx53hb84zp4zd28nqk"
-    },
-    "jar": {
-      "sha1": "3d015bb821875657ac8e4b808a223aae339defb2",
-      "sha256": "02czcs5blwl6l60ka82h5k355ib4szfrawg7s8dnba0jrdm8gs4z"
+    "path": "com/facebook/yoga/proguard-annotations/1.14.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-annotations-1.14.1.pom": {
+        "sha1": "59f786ef9485f034cfed3f0c9cd7bdee8155314b",
+        "sha256": "1c11zbpsmfyaklgjc5r401li1155jb89f9mx53hb84zp4zd28nqk"
+      },
+      "proguard-annotations-1.14.1.jar": {
+        "sha1": "3d015bb821875657ac8e4b808a223aae339defb2",
+        "sha256": "02czcs5blwl6l60ka82h5k355ib4szfrawg7s8dnba0jrdm8gs4z"
+      }
     }
   },
 
   {
-    "path": "com/github/bumptech/glide/annotations/4.12.0/annotations-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "94d5a495b107bd421804a296c9073439402c0996",
-      "sha256": "0r1f6n03hrh7m0br3wzx81bz8addxk2pgc0cnfw2bx1n46d469z4"
-    },
-    "jar": {
-      "sha1": "298d793db124809d74ad9a90de5eddc408898c84",
-      "sha256": "13nyz9h7ibplz14nybkcmk464kgg8iasp5c1qf4ws7wkiyzhqhzs"
+    "path": "com/github/bumptech/glide/annotations/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotations-4.12.0.pom": {
+        "sha1": "94d5a495b107bd421804a296c9073439402c0996",
+        "sha256": "0r1f6n03hrh7m0br3wzx81bz8addxk2pgc0cnfw2bx1n46d469z4"
+      },
+      "annotations-4.12.0.jar": {
+        "sha1": "298d793db124809d74ad9a90de5eddc408898c84",
+        "sha256": "13nyz9h7ibplz14nybkcmk464kgg8iasp5c1qf4ws7wkiyzhqhzs"
+      }
     }
   },
 
   {
-    "path": "com/github/bumptech/glide/compiler/4.12.0/compiler-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4a090fcf1fe6ec3782581efc517a8f621e85a804",
-      "sha256": "121xrlvir16f38k7qif0c311l2ccivxaqsq6sr4csdd1jgs25agc"
-    },
-    "jar": {
-      "sha1": "75cf5e43fd6e6c6e769e060014feb985284cfae7",
-      "sha256": "16n94cf2d7sba5r6kzh8sqvvaikl5ph9an6lz4pdabd579rrf0h3"
+    "path": "com/github/bumptech/glide/compiler/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "compiler-4.12.0.pom": {
+        "sha1": "4a090fcf1fe6ec3782581efc517a8f621e85a804",
+        "sha256": "121xrlvir16f38k7qif0c311l2ccivxaqsq6sr4csdd1jgs25agc"
+      },
+      "compiler-4.12.0.jar": {
+        "sha1": "75cf5e43fd6e6c6e769e060014feb985284cfae7",
+        "sha256": "16n94cf2d7sba5r6kzh8sqvvaikl5ph9an6lz4pdabd579rrf0h3"
+      }
     }
   },
 
   {
-    "path": "com/github/bumptech/glide/disklrucache/4.12.0/disklrucache-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0c90a83f7490992222d8bf7227b35e6bc0e4f552",
-      "sha256": "1m0a7yiafry9g84vgqmaznxqhs0sg008vya13i2ckhbcky2nblk4"
-    },
-    "jar": {
-      "sha1": "6d44c9103551e3ff51f00ac26077c143a8fb74f9",
-      "sha256": "0yb38pnjbsb8qc5c4hffp40a4gihj0g65gwdwwp5ib26jq3cj33g"
+    "path": "com/github/bumptech/glide/disklrucache/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "disklrucache-4.12.0.pom": {
+        "sha1": "0c90a83f7490992222d8bf7227b35e6bc0e4f552",
+        "sha256": "1m0a7yiafry9g84vgqmaznxqhs0sg008vya13i2ckhbcky2nblk4"
+      },
+      "disklrucache-4.12.0.jar": {
+        "sha1": "6d44c9103551e3ff51f00ac26077c143a8fb74f9",
+        "sha256": "0yb38pnjbsb8qc5c4hffp40a4gihj0g65gwdwwp5ib26jq3cj33g"
+      }
     }
   },
 
   {
-    "path": "com/github/bumptech/glide/gifdecoder/4.12.0/gifdecoder-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "9105e854c39f7d5dbcfd04f644a243f31e48033d",
-      "sha256": "1s9qsf8awvnrr3a5ia7ppcj2vx51pnqwd8mvdmqjdl5y0w3vv4w1"
-    },
-    "jar": {
-      "sha1": "a00cc6741d9f7cf025dd93293c724a688c47631e",
-      "sha256": "0158p9w1w80m8fmnzff23n89n8lkw9s3kh9hn81almb8nzaiqyhr"
+    "path": "com/github/bumptech/glide/gifdecoder/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gifdecoder-4.12.0.pom": {
+        "sha1": "9105e854c39f7d5dbcfd04f644a243f31e48033d",
+        "sha256": "1s9qsf8awvnrr3a5ia7ppcj2vx51pnqwd8mvdmqjdl5y0w3vv4w1"
+      },
+      "gifdecoder-4.12.0.aar": {
+        "sha1": "a00cc6741d9f7cf025dd93293c724a688c47631e",
+        "sha256": "0158p9w1w80m8fmnzff23n89n8lkw9s3kh9hn81almb8nzaiqyhr"
+      }
     }
   },
 
   {
-    "path": "com/github/bumptech/glide/glide/4.12.0/glide-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "74ef469a4966c69ec7346df8b3895ac11474f8be",
-      "sha256": "1h5qbi06valf58madv01zlapny64368r17x21lck54wy2dr4hvgx"
-    },
-    "jar": {
-      "sha1": "3f57db6cc954212739bb0d693ec48ecbc8ab73c4",
-      "sha256": "11432hpyjc74rhf494xn50c6qcmx49mgii227zjpz5v2vd599qka"
+    "path": "com/github/bumptech/glide/glide/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "glide-4.12.0.pom": {
+        "sha1": "74ef469a4966c69ec7346df8b3895ac11474f8be",
+        "sha256": "1h5qbi06valf58madv01zlapny64368r17x21lck54wy2dr4hvgx"
+      },
+      "glide-4.12.0.aar": {
+        "sha1": "3f57db6cc954212739bb0d693ec48ecbc8ab73c4",
+        "sha256": "11432hpyjc74rhf494xn50c6qcmx49mgii227zjpz5v2vd599qka"
+      }
     }
   },
 
   {
-    "path": "com/github/bumptech/glide/okhttp3-integration/4.12.0/okhttp3-integration-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "86bab5a64ff1b3492ca0a416b59de2ed89d46608",
-      "sha256": "0x30kznlw383w6yvz7vynk7mwbhscx4j1lyjl9aa0419byiyw7ng"
-    },
-    "jar": {
-      "sha1": "8235c8ea4484c142ac058b736e807f9c56346e59",
-      "sha256": "086nrnk2i6jgfi6iv2s3gfqhywzzm79isd87x84ks7wpvbs2wwhd"
+    "path": "com/github/bumptech/glide/okhttp3-integration/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp3-integration-4.12.0.pom": {
+        "sha1": "86bab5a64ff1b3492ca0a416b59de2ed89d46608",
+        "sha256": "0x30kznlw383w6yvz7vynk7mwbhscx4j1lyjl9aa0419byiyw7ng"
+      },
+      "okhttp3-integration-4.12.0.aar": {
+        "sha1": "8235c8ea4484c142ac058b736e807f9c56346e59",
+        "sha256": "086nrnk2i6jgfi6iv2s3gfqhywzzm79isd87x84ks7wpvbs2wwhd"
+      }
     }
   },
 
   {
-    "path": "com/github/clans/fab/1.6.4/fab-1.6.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "1211e25e0611566427a6fc5fdcee00a1ddda3dd2",
-      "sha256": "1kdb3j0h2drrh8bfp68am145lk322x4w9ggrdg7dkzr3yn13n8y6"
-    },
-    "jar": {
-      "sha1": "8e468a9d9ba05bdb2612eb22d5cd5add9a238c8c",
-      "sha256": "0j6l599pvmxy4bv4a3dafn85niqi4p302l3q0p8yrczyz0ar64jk"
+    "path": "com/github/clans/fab/1.6.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fab-1.6.4.pom": {
+        "sha1": "1211e25e0611566427a6fc5fdcee00a1ddda3dd2",
+        "sha256": "1kdb3j0h2drrh8bfp68am145lk322x4w9ggrdg7dkzr3yn13n8y6"
+      },
+      "fab-1.6.4.aar": {
+        "sha1": "8e468a9d9ba05bdb2612eb22d5cd5add9a238c8c",
+        "sha256": "0j6l599pvmxy4bv4a3dafn85niqi4p302l3q0p8yrczyz0ar64jk"
+      }
     }
   },
 
   {
-    "path": "com/github/gundy/semver4j/0.16.4/semver4j-0.16.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ca8df209029884f283afdcd7b104fb88576a18b1",
-      "sha256": "0kb0s5r0z7w1vr5j2308pb8j5rxds4lzyyav3z99scrv8jr1s01j"
-    },
-    "jar": {
-      "sha1": "de8c77583e97bbbd3cdbe5f406b583e9b081ff56",
-      "sha256": "0435ff3qzmcxprsm93x3aw9clgfpa871zl41izhijwm3bwib9yfy"
-    },
-    "nodeps": {
-      "sha1": "273cc1869ddf7ebbac8176402e29f41b1c83d7df",
-      "sha256": "1w4a2ak60r46wiy8yl00yy8v397qa2zja5jmsd7wsk1p2sjyqn9z"
+    "path": "com/github/gundy/semver4j/0.16.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "semver4j-0.16.4.pom": {
+        "sha1": "ca8df209029884f283afdcd7b104fb88576a18b1",
+        "sha256": "0kb0s5r0z7w1vr5j2308pb8j5rxds4lzyyav3z99scrv8jr1s01j"
+      },
+      "semver4j-0.16.4.jar": {
+        "sha1": "de8c77583e97bbbd3cdbe5f406b583e9b081ff56",
+        "sha256": "0435ff3qzmcxprsm93x3aw9clgfpa871zl41izhijwm3bwib9yfy"
+      },
+      "semver4j-0.16.4-nodeps.jar": {
+        "sha1": "273cc1869ddf7ebbac8176402e29f41b1c83d7df",
+        "sha256": "1w4a2ak60r46wiy8yl00yy8v397qa2zja5jmsd7wsk1p2sjyqn9z"
+      }
     }
   },
 
   {
-    "path": "com/googlecode/json-simple/json-simple/1.1/json-simple-1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a2c3a73d894b86ac979b88be6537b284eb4bf916",
-      "sha256": "1avxrxknd1xy8ahq67rrkh8jlkb5hwsciljzvdvd9v8gzbh9pa27"
-    },
-    "jar": {
-      "sha1": "5e303a03d04e6788dddfa3655272580ae0fc13bb",
-      "sha256": "0fb49wk04rl324qclzb1cpp715vjzijr8iwsgzs0ixs9qvs8951d"
+    "path": "com/googlecode/json-simple/json-simple/1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "json-simple-1.1.pom": {
+        "sha1": "a2c3a73d894b86ac979b88be6537b284eb4bf916",
+        "sha256": "1avxrxknd1xy8ahq67rrkh8jlkb5hwsciljzvdvd9v8gzbh9pa27"
+      },
+      "json-simple-1.1.jar": {
+        "sha1": "5e303a03d04e6788dddfa3655272580ae0fc13bb",
+        "sha256": "0fb49wk04rl324qclzb1cpp715vjzijr8iwsgzs0ixs9qvs8951d"
+      }
     }
   },
 
   {
-    "path": "com/googlecode/juniversalchardet/juniversalchardet/1.0.3/juniversalchardet-1.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "be6da8320adedafc712d645ddaaad00357b55408",
-      "sha256": "0sq85z68pcf87j9vcis5garlxl325lz0q01skcm69kf76ndkjikq"
-    },
-    "jar": {
-      "sha1": "cd49678784c46aa8789c060538e0154013bb421b",
-      "sha256": "0xjakmvlyl4i2lwb1prc19vx0mbbgpb6rhlxwx8vdf4kc68gwyvm"
+    "path": "com/googlecode/juniversalchardet/juniversalchardet/1.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "juniversalchardet-1.0.3.pom": {
+        "sha1": "be6da8320adedafc712d645ddaaad00357b55408",
+        "sha256": "0sq85z68pcf87j9vcis5garlxl325lz0q01skcm69kf76ndkjikq"
+      },
+      "juniversalchardet-1.0.3.jar": {
+        "sha1": "cd49678784c46aa8789c060538e0154013bb421b",
+        "sha256": "0xjakmvlyl4i2lwb1prc19vx0mbbgpb6rhlxwx8vdf4kc68gwyvm"
+      }
     }
   },
 
   {
-    "path": "com/google/auto/auto-parent/3/auto-parent-3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "8e22bd67b5aeb5f03fd50efd5910ba6dfb7f4c86",
-      "sha256": "1a78xc2zm7ixc1499amka8i6kq0cqm0f123kq894glngg04ip3y9"
+    "path": "com/google/auto/auto-parent/3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "auto-parent-3.pom": {
+        "sha1": "8e22bd67b5aeb5f03fd50efd5910ba6dfb7f4c86",
+        "sha256": "1a78xc2zm7ixc1499amka8i6kq0cqm0f123kq894glngg04ip3y9"
+      }
     }
   },
 
   {
-    "path": "com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "72aa2e866fd52dc58222aacc490b6f469ff8a50f",
-      "sha256": "0ixh52nx4b2l2hc9s16hm4f4rmhg8sjy9was9pxlv46ijj3crflz"
-    },
-    "jar": {
-      "sha1": "9e5162c15f6033c524134cba05a5e93dc1d37c4b",
-      "sha256": "1qiblzy89vnlyhg8kx9iz4ds2w8ixriifx0da6l3is9534hhmzm4"
+    "path": "com/google/auto/value/auto-value-annotations/1.10.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "auto-value-annotations-1.10.1.pom": {
+        "sha1": "72aa2e866fd52dc58222aacc490b6f469ff8a50f",
+        "sha256": "0ixh52nx4b2l2hc9s16hm4f4rmhg8sjy9was9pxlv46ijj3crflz"
+      },
+      "auto-value-annotations-1.10.1.jar": {
+        "sha1": "9e5162c15f6033c524134cba05a5e93dc1d37c4b",
+        "sha256": "1qiblzy89vnlyhg8kx9iz4ds2w8ixriifx0da6l3is9534hhmzm4"
+      }
     }
   },
 
   {
-    "path": "com/google/auto/value/auto-value-parent/1.10.1/auto-value-parent-1.10.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "cfd31b18489357b9f2b0acee57d6674394575c37",
-      "sha256": "1sfgfdwkz8yvyqakni8b3syx6cjahfm36wnd8j3qpqdw32pa6bgp"
+    "path": "com/google/auto/value/auto-value-parent/1.10.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "auto-value-parent-1.10.1.pom": {
+        "sha1": "cfd31b18489357b9f2b0acee57d6674394575c37",
+        "sha256": "1sfgfdwkz8yvyqakni8b3syx6cjahfm36wnd8j3qpqdw32pa6bgp"
+      }
     }
   },
 
   {
-    "path": "com/google/auto/value/auto-value/1.5.2/auto-value-1.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e9ba039f98da8c1ea01ad9715befc4a6cf4fdc7c",
-      "sha256": "13b8ghy1fmqbx8p688l87kspnr491d6b8yrsap0f1y0f192b27wh"
-    },
-    "jar": {
-      "sha1": "1b94ab7ec707e2220a0d1a7517488d1843236345",
-      "sha256": "1kzlnzsb15n1fb1z446426cscqll0gnqqwvnmbsbjfcv8chr9b3c"
+    "path": "com/google/auto/value/auto-value/1.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "auto-value-1.5.2.pom": {
+        "sha1": "e9ba039f98da8c1ea01ad9715befc4a6cf4fdc7c",
+        "sha256": "13b8ghy1fmqbx8p688l87kspnr491d6b8yrsap0f1y0f192b27wh"
+      },
+      "auto-value-1.5.2.jar": {
+        "sha1": "1b94ab7ec707e2220a0d1a7517488d1843236345",
+        "sha256": "1kzlnzsb15n1fb1z446426cscqll0gnqqwvnmbsbjfcv8chr9b3c"
+      }
     }
   },
 
   {
-    "path": "com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "67ea333a3244bc20a17d6f0c29498071dfa409fc",
-      "sha256": "0fm9gfc8ris3mq3zp06ra8fks3f8mxj60vdnybp7lg8w668r3azy"
-    },
-    "jar": {
-      "sha1": "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf",
-      "sha256": "1vf98qdxy0l4v1f0mvqxz92ydrd29vpyczmv999q22m9xsh22mwh"
+    "path": "com/google/code/findbugs/jsr305/1.3.9",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jsr305-1.3.9.pom": {
+        "sha1": "67ea333a3244bc20a17d6f0c29498071dfa409fc",
+        "sha256": "0fm9gfc8ris3mq3zp06ra8fks3f8mxj60vdnybp7lg8w668r3azy"
+      },
+      "jsr305-1.3.9.jar": {
+        "sha1": "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf",
+        "sha256": "1vf98qdxy0l4v1f0mvqxz92ydrd29vpyczmv999q22m9xsh22mwh"
+      }
     }
   },
 
   {
-    "path": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "95efa8cea662452bb74b34abe09a93ff47625c8f",
-      "sha256": "1c7vvi1nvgwm28c4lndw8hgs57jd5b493xlz45sx8bg158y2rh82"
-    },
-    "jar": {
-      "sha1": "516c03b21d50a644d538de0f0369c620989cd8f0",
-      "sha256": "0s74pv8qjc42c7q8nbc0c3b1hgx0bmk3b8vbk1z80p4bbgx56zqy"
+    "path": "com/google/code/findbugs/jsr305/2.0.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jsr305-2.0.1.pom": {
+        "sha1": "95efa8cea662452bb74b34abe09a93ff47625c8f",
+        "sha256": "1c7vvi1nvgwm28c4lndw8hgs57jd5b493xlz45sx8bg158y2rh82"
+      },
+      "jsr305-2.0.1.jar": {
+        "sha1": "516c03b21d50a644d538de0f0369c620989cd8f0",
+        "sha256": "0s74pv8qjc42c7q8nbc0c3b1hgx0bmk3b8vbk1z80p4bbgx56zqy"
+      }
     }
   },
 
   {
-    "path": "com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d04690f71f3393e23f30998d9534365274fa5f9f",
-      "sha256": "1khlag991h7326xsjnpx6hnyip5cwawsmxz6m20kkzavvihsfw21"
-    },
-    "jar": {
-      "sha1": "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
-      "sha256": "1k9zl76xi2nykixaynss2gk4h861zipdb9xl6q1br0ln4hscx1f8"
+    "path": "com/google/code/findbugs/jsr305/3.0.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jsr305-3.0.1.pom": {
+        "sha1": "d04690f71f3393e23f30998d9534365274fa5f9f",
+        "sha256": "1khlag991h7326xsjnpx6hnyip5cwawsmxz6m20kkzavvihsfw21"
+      },
+      "jsr305-3.0.1.jar": {
+        "sha1": "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
+        "sha256": "1k9zl76xi2nykixaynss2gk4h861zipdb9xl6q1br0ln4hscx1f8"
+      }
     }
   },
 
   {
-    "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8d93cdf4d84d7e1de736df607945c6df0730a10f",
-      "sha256": "1zldsximvzlag566i5r2i124d5vs2jw4brjy39hb4m5jy6yrv20r"
-    },
-    "jar": {
-      "sha1": "25ea2e8b0c338a877313bd4672d3fe056ea78f0d",
-      "sha256": "1iyh53li6y4b8gp8bl52fagqp8iqrkp4rmwa5jb8f9izg2hd4skn"
+    "path": "com/google/code/findbugs/jsr305/3.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jsr305-3.0.2.pom": {
+        "sha1": "8d93cdf4d84d7e1de736df607945c6df0730a10f",
+        "sha256": "1zldsximvzlag566i5r2i124d5vs2jw4brjy39hb4m5jy6yrv20r"
+      },
+      "jsr305-3.0.2.jar": {
+        "sha1": "25ea2e8b0c338a877313bd4672d3fe056ea78f0d",
+        "sha256": "1iyh53li6y4b8gp8bl52fagqp8iqrkp4rmwa5jb8f9izg2hd4skn"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson-parent/2.7/gson-parent-2.7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "3e147803ee87007ec82a1f625a0034be35c9b8a8",
-      "sha256": "0ar7wk4zrdlb56jywsk6v3cpji8cjsi3kzmcr061yc12fdrqq7l7"
+    "path": "com/google/code/gson/gson-parent/2.7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-parent-2.7.pom": {
+        "sha1": "3e147803ee87007ec82a1f625a0034be35c9b8a8",
+        "sha256": "0ar7wk4zrdlb56jywsk6v3cpji8cjsi3kzmcr061yc12fdrqq7l7"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson-parent/2.8.0/gson-parent-2.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "df4e302623519c6b801aee5281bada262b9ed876",
-      "sha256": "1ljcy2x9lbwvlp1ik12wbfnklwsrigfwz3bw8r5vrwg9n5lq678g"
+    "path": "com/google/code/gson/gson-parent/2.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-parent-2.8.0.pom": {
+        "sha1": "df4e302623519c6b801aee5281bada262b9ed876",
+        "sha256": "1ljcy2x9lbwvlp1ik12wbfnklwsrigfwz3bw8r5vrwg9n5lq678g"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson-parent/2.8.5/gson-parent-2.8.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "40f295fd74fbe91f1589481c967b14f176d6e549",
-      "sha256": "09vv4d94lm8blnrmavbw15mln4niqiwggx9rxhwylw8sp5rfq7wg"
+    "path": "com/google/code/gson/gson-parent/2.8.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-parent-2.8.5.pom": {
+        "sha1": "40f295fd74fbe91f1589481c967b14f176d6e549",
+        "sha256": "09vv4d94lm8blnrmavbw15mln4niqiwggx9rxhwylw8sp5rfq7wg"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson-parent/2.8.6/gson-parent-2.8.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "88d12a7aeaeaa9bbc773bc5f32690edf4d3ff9e6",
-      "sha256": "0x5761zgyz6f6pz244832d26i3rax0599578jmr2c6gcb4w4cdip"
+    "path": "com/google/code/gson/gson-parent/2.8.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-parent-2.8.6.pom": {
+        "sha1": "88d12a7aeaeaa9bbc773bc5f32690edf4d3ff9e6",
+        "sha256": "0x5761zgyz6f6pz244832d26i3rax0599578jmr2c6gcb4w4cdip"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson/2.2.4/gson-2.2.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "06252c690921ee1dc719594a5d4da1829194f8b3",
-      "sha256": "106k9ynbhls8nkihxrhkj5033z7q2am6x1l98vffck4935flv65f"
-    },
-    "jar": {
-      "sha1": "a60a5e993c98c864010053cb901b7eab25306568",
-      "sha256": "1yw7qszcw1dsh54q6wyksr5mbkz8mzs1q36hmjjn7qx9gk88qcn0"
+    "path": "com/google/code/gson/gson/2.2.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-2.2.4.pom": {
+        "sha1": "06252c690921ee1dc719594a5d4da1829194f8b3",
+        "sha256": "106k9ynbhls8nkihxrhkj5033z7q2am6x1l98vffck4935flv65f"
+      },
+      "gson-2.2.4.jar": {
+        "sha1": "a60a5e993c98c864010053cb901b7eab25306568",
+        "sha256": "1yw7qszcw1dsh54q6wyksr5mbkz8mzs1q36hmjjn7qx9gk88qcn0"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson/2.3/gson-2.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9bdcf3053cba435cadc5fa575cc835429a0fb0c2",
-      "sha256": "1qj9kd2yn4h2h0nasxpys85v0r6s60dp1fdnj788z0qgqlprjmhs"
-    },
-    "jar": {
-      "sha1": "5fc52c41ef0239d1093a1eb7c3697036183677ce",
-      "sha256": "0k3s5k4gavwj8kh9c46ivspxxczpfd9nhq9ni9mdc2ygv0n52rll"
+    "path": "com/google/code/gson/gson/2.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-2.3.pom": {
+        "sha1": "9bdcf3053cba435cadc5fa575cc835429a0fb0c2",
+        "sha256": "1qj9kd2yn4h2h0nasxpys85v0r6s60dp1fdnj788z0qgqlprjmhs"
+      },
+      "gson-2.3.jar": {
+        "sha1": "5fc52c41ef0239d1093a1eb7c3697036183677ce",
+        "sha256": "0k3s5k4gavwj8kh9c46ivspxxczpfd9nhq9ni9mdc2ygv0n52rll"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson/2.7/gson-2.7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "09f9e39f9b791aeb73ba428ad30872f1a703edb3",
-      "sha256": "1phf2qksjf75ykwgp39189jdbqsn5zrmi07g8h522yxq0zn3cfbj"
-    },
-    "jar": {
-      "sha1": "751f548c85fa49f330cecbb1875893f971b33c4e",
-      "sha256": "0clda1xrjfja969xsbrhc61ip588xvsi9k054kpd4cz1m5gfnhrd"
+    "path": "com/google/code/gson/gson/2.7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-2.7.pom": {
+        "sha1": "09f9e39f9b791aeb73ba428ad30872f1a703edb3",
+        "sha256": "1phf2qksjf75ykwgp39189jdbqsn5zrmi07g8h522yxq0zn3cfbj"
+      },
+      "gson-2.7.jar": {
+        "sha1": "751f548c85fa49f330cecbb1875893f971b33c4e",
+        "sha256": "0clda1xrjfja969xsbrhc61ip588xvsi9k054kpd4cz1m5gfnhrd"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson/2.8.0/gson-2.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "36e74e4b4e2a699b4dc43e722cd0ad436f6b21fd",
-      "sha256": "0vya2vs781xzrldxwgbnjzl232n38fncg4svmd19k3slrc71lcx5"
-    },
-    "jar": {
-      "sha1": "c4ba5371a29ac9b2ad6129b1d39ea38750043eff",
-      "sha256": "0988qi0f75hqyz2184xqcyrkifx055ghnxbzvk1z3i3rpmiif8n6"
+    "path": "com/google/code/gson/gson/2.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-2.8.0.pom": {
+        "sha1": "36e74e4b4e2a699b4dc43e722cd0ad436f6b21fd",
+        "sha256": "0vya2vs781xzrldxwgbnjzl232n38fncg4svmd19k3slrc71lcx5"
+      },
+      "gson-2.8.0.jar": {
+        "sha1": "c4ba5371a29ac9b2ad6129b1d39ea38750043eff",
+        "sha256": "0988qi0f75hqyz2184xqcyrkifx055ghnxbzvk1z3i3rpmiif8n6"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson/2.8.5/gson-2.8.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2c18fa1082aa1c422aece88244c084be50c76500",
-      "sha256": "14m0alr8966skrlfgk9fbll63csqj9cx133wzvcr5k7wlxbqac5q"
-    },
-    "jar": {
-      "sha1": "f645ed69d595b24d4cf8b3fbb64cc505bede8829",
-      "sha256": "10bxiss29jdkyvdap3p97dvxr6xicvicz0ynvdp9yp1nzi4h2fi3"
+    "path": "com/google/code/gson/gson/2.8.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-2.8.5.pom": {
+        "sha1": "2c18fa1082aa1c422aece88244c084be50c76500",
+        "sha256": "14m0alr8966skrlfgk9fbll63csqj9cx133wzvcr5k7wlxbqac5q"
+      },
+      "gson-2.8.5.jar": {
+        "sha1": "f645ed69d595b24d4cf8b3fbb64cc505bede8829",
+        "sha256": "10bxiss29jdkyvdap3p97dvxr6xicvicz0ynvdp9yp1nzi4h2fi3"
+      }
     }
   },
 
   {
-    "path": "com/google/code/gson/gson/2.8.6/gson-2.8.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b9d7e274612598f1e8835d8bbe30baa5b970ca32",
-      "sha256": "049r21729n48c5cpylgpxa2cqglaf3y1rg84v87x6ckkcid42x11"
-    },
-    "jar": {
-      "sha1": "9180733b7df8542621dc12e21e87557e8c99b8cb",
-      "sha256": "0pzjycvfb1yji92yp8lbxclg1qkxm7sx207q6cq0na2d0lwliyy8"
+    "path": "com/google/code/gson/gson/2.8.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gson-2.8.6.pom": {
+        "sha1": "b9d7e274612598f1e8835d8bbe30baa5b970ca32",
+        "sha256": "049r21729n48c5cpylgpxa2cqglaf3y1rg84v87x6ckkcid42x11"
+      },
+      "gson-2.8.6.jar": {
+        "sha1": "9180733b7df8542621dc12e21e87557e8c99b8cb",
+        "sha256": "0pzjycvfb1yji92yp8lbxclg1qkxm7sx207q6cq0na2d0lwliyy8"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.0.18/error_prone_annotations-2.0.18",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8e0351439081cc11563b09019302926addadaa25",
-      "sha256": "11w4193x21z1zzqhngmq60qxbc13xgmdq9b86v115xnnj9qi4i4i"
-    },
-    "jar": {
-      "sha1": "5f65affce1684999e2f4024983835efc3504012e",
-      "sha256": "0sv5i2kyl7qbchcb786d1x2fq39zfsjvwglz343klmmzf3cglk6b"
+    "path": "com/google/errorprone/error_prone_annotations/2.0.18",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_annotations-2.0.18.pom": {
+        "sha1": "8e0351439081cc11563b09019302926addadaa25",
+        "sha256": "11w4193x21z1zzqhngmq60qxbc13xgmdq9b86v115xnnj9qi4i4i"
+      },
+      "error_prone_annotations-2.0.18.jar": {
+        "sha1": "5f65affce1684999e2f4024983835efc3504012e",
+        "sha256": "0sv5i2kyl7qbchcb786d1x2fq39zfsjvwglz343klmmzf3cglk6b"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.1.2/error_prone_annotations-2.1.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "44f5d3b9781c31822991ff9f948d6cbfb8cdf055",
-      "sha256": "04894gp1inj1cpgp68cjh0rzpv0svfzhv2spak2prvdlp25mh2hq"
-    },
-    "jar": {
-      "sha1": "6dcc08f90f678ac33e5ef78c3c752b6f59e63e0c",
-      "sha256": "0akq6zj7fd6i0abyz5c0q5aikp7lldrbind4lbvn0q60blxqfg6y"
+    "path": "com/google/errorprone/error_prone_annotations/2.1.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_annotations-2.1.2.pom": {
+        "sha1": "44f5d3b9781c31822991ff9f948d6cbfb8cdf055",
+        "sha256": "04894gp1inj1cpgp68cjh0rzpv0svfzhv2spak2prvdlp25mh2hq"
+      },
+      "error_prone_annotations-2.1.2.jar": {
+        "sha1": "6dcc08f90f678ac33e5ef78c3c752b6f59e63e0c",
+        "sha256": "0akq6zj7fd6i0abyz5c0q5aikp7lldrbind4lbvn0q60blxqfg6y"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e28b5b546020f18ea29e2b4756023f53ee91492b",
-      "sha256": "1m9dwhdyyign3633w1z49chspxs84k10ns226w9imrd43gm5h0jy"
-    },
-    "jar": {
-      "sha1": "88e3c593e9b3586e1c6177f89267da6fc6986f0c",
-      "sha256": "06j838kxxyblsfg5y0s2gdhdk0b9b7h693fy85nw13lx3g525gbf"
+    "path": "com/google/errorprone/error_prone_annotations/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_annotations-2.2.0.pom": {
+        "sha1": "e28b5b546020f18ea29e2b4756023f53ee91492b",
+        "sha256": "1m9dwhdyyign3633w1z49chspxs84k10ns226w9imrd43gm5h0jy"
+      },
+      "error_prone_annotations-2.2.0.jar": {
+        "sha1": "88e3c593e9b3586e1c6177f89267da6fc6986f0c",
+        "sha256": "06j838kxxyblsfg5y0s2gdhdk0b9b7h693fy85nw13lx3g525gbf"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.3.1/error_prone_annotations-2.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "19c878e6870c8382864dcc459de1c6bfe7f36e54",
-      "sha256": "16l1kbc7wbisjmjvkfac854ddyql0b5smdxr2vz8wdms26vydp1y"
-    },
-    "jar": {
-      "sha1": "a6a2b2df72fd13ec466216049b303f206bd66c5d",
-      "sha256": "0831h49f21znl7z8lkr2ikywwajdachgxva7zpj8sp7rl2d9998h"
+    "path": "com/google/errorprone/error_prone_annotations/2.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_annotations-2.3.1.pom": {
+        "sha1": "19c878e6870c8382864dcc459de1c6bfe7f36e54",
+        "sha256": "16l1kbc7wbisjmjvkfac854ddyql0b5smdxr2vz8wdms26vydp1y"
+      },
+      "error_prone_annotations-2.3.1.jar": {
+        "sha1": "a6a2b2df72fd13ec466216049b303f206bd66c5d",
+        "sha256": "0831h49f21znl7z8lkr2ikywwajdachgxva7zpj8sp7rl2d9998h"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6d7bbfd3d7567e4c18e981a675ecda707e8a2db1",
-      "sha256": "1p5xswxnd9cjz1b2zldws560ld4dlm17c0awb9xr39fcgmwka0cj"
-    },
-    "jar": {
-      "sha1": "89b684257096f548fa39a7df9fdaa409d4d4df91",
-      "sha256": "1bjlxady2jg83lmicb2jil2vf6zjm29sj1qvznj8hsc1f75i8s4y"
+    "path": "com/google/errorprone/error_prone_annotations/2.18.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_annotations-2.18.0.pom": {
+        "sha1": "6d7bbfd3d7567e4c18e981a675ecda707e8a2db1",
+        "sha256": "1p5xswxnd9cjz1b2zldws560ld4dlm17c0awb9xr39fcgmwka0cj"
+      },
+      "error_prone_annotations-2.18.0.jar": {
+        "sha1": "89b684257096f548fa39a7df9fdaa409d4d4df91",
+        "sha256": "1bjlxady2jg83lmicb2jil2vf6zjm29sj1qvznj8hsc1f75i8s4y"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "16ffdb67ed91d9d87a943a3127da3900d83cc81d",
-      "sha256": "1i46saxm7vx68cdl9drxswqfjsaa2v0qayc13vqx81wv4xarj56g"
+    "path": "com/google/errorprone/error_prone_parent/2.0.18",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_parent-2.0.18.pom": {
+        "sha1": "16ffdb67ed91d9d87a943a3127da3900d83cc81d",
+        "sha256": "1i46saxm7vx68cdl9drxswqfjsaa2v0qayc13vqx81wv4xarj56g"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.1.2/error_prone_parent-2.1.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "ae2dd256d508d2ffc9d77fbec0414ee695973a8a",
-      "sha256": "0hx1cf07n7kwcl2pwiab628fm8fmymgy7bwdkvr3nswgvcfxddn6"
+    "path": "com/google/errorprone/error_prone_parent/2.1.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_parent-2.1.2.pom": {
+        "sha1": "ae2dd256d508d2ffc9d77fbec0414ee695973a8a",
+        "sha256": "0hx1cf07n7kwcl2pwiab628fm8fmymgy7bwdkvr3nswgvcfxddn6"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "72e2f31cb1952eada003d2ba7e82874cfe4b738c",
-      "sha256": "0f0iajykris8ynl83b56ydfb0a095bjiq9vb5j1nikjyvwnr0q64"
+    "path": "com/google/errorprone/error_prone_parent/2.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_parent-2.2.0.pom": {
+        "sha1": "72e2f31cb1952eada003d2ba7e82874cfe4b738c",
+        "sha256": "0f0iajykris8ynl83b56ydfb0a095bjiq9vb5j1nikjyvwnr0q64"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.3.1/error_prone_parent-2.3.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a32c199defa0dcf9c42a32c26fec4d1fbb408e58",
-      "sha256": "08y16fkxl49930d2bqmic90vw9v36f02jf38344csa8im3cjaxbn"
+    "path": "com/google/errorprone/error_prone_parent/2.3.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_parent-2.3.1.pom": {
+        "sha1": "a32c199defa0dcf9c42a32c26fec4d1fbb408e58",
+        "sha256": "08y16fkxl49930d2bqmic90vw9v36f02jf38344csa8im3cjaxbn"
+      }
     }
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.18.0/error_prone_parent-2.18.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "b1779a677965027cd2a3de91e61a80102086bb30",
-      "sha256": "1bazw49mb0246s2nbkxvynk3npayk1vq6vzivs8n6imzqycjxwj7"
+    "path": "com/google/errorprone/error_prone_parent/2.18.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_parent-2.18.0.pom": {
+        "sha1": "b1779a677965027cd2a3de91e61a80102086bb30",
+        "sha256": "1bazw49mb0246s2nbkxvynk3npayk1vq6vzivs8n6imzqycjxwj7"
+      }
     }
   },
 
   {
-    "path": "com/google/google/1/google-1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c35a5268151b7a1bbb77f7ee94a950f00e32db61",
-      "sha256": "10by4ybrjnl8zwfg4ca74d0gcl4p9l7dzlfb9iwxw7m325xb2vfd"
+    "path": "com/google/google/1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "google-1.pom": {
+        "sha1": "c35a5268151b7a1bbb77f7ee94a950f00e32db61",
+        "sha256": "10by4ybrjnl8zwfg4ca74d0gcl4p9l7dzlfb9iwxw7m325xb2vfd"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e8160e78fdaaf7088621dc1649d9dd2dfcf8d0e8",
-      "sha256": "1ff40d0r4d54fbb3rzdmj6i40yy88wlm4r795gda1jzyg3744q79"
-    },
-    "jar": {
-      "sha1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
-      "sha256": "09na6vwxmpw4xcqszba15avzl6k6yjfvw5jbgs1xmljdfd6fwwd1"
+    "path": "com/google/guava/failureaccess/1.0.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "failureaccess-1.0.1.pom": {
+        "sha1": "e8160e78fdaaf7088621dc1649d9dd2dfcf8d0e8",
+        "sha256": "1ff40d0r4d54fbb3rzdmj6i40yy88wlm4r795gda1jzyg3744q79"
+      },
+      "failureaccess-1.0.1.jar": {
+        "sha1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
+        "sha256": "09na6vwxmpw4xcqszba15avzl6k6yjfvw5jbgs1xmljdfd6fwwd1"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/17.0/guava-parent-17.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "f8ba48b925d1c925d0fc0379ffa14a06e44eb464",
-      "sha256": "0ajka1xsh28sammy3zbx82mvxi3k19v5ks4x2xswglsiamc57flz"
+    "path": "com/google/guava/guava-parent/17.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-17.0.pom": {
+        "sha1": "f8ba48b925d1c925d0fc0379ffa14a06e44eb464",
+        "sha256": "0ajka1xsh28sammy3zbx82mvxi3k19v5ks4x2xswglsiamc57flz"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/22.0/guava-parent-22.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "52822d0abaa6bc42a26ea0d26a83abad05d938a8",
-      "sha256": "0f8m410r12g9y34szyhbk5l8qf9n0pvzpnqflx81qz4pw6193bqy"
+    "path": "com/google/guava/guava-parent/22.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-22.0.pom": {
+        "sha1": "52822d0abaa6bc42a26ea0d26a83abad05d938a8",
+        "sha256": "0f8m410r12g9y34szyhbk5l8qf9n0pvzpnqflx81qz4pw6193bqy"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/23.0/guava-parent-23.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "79d7a4be1ccf3691ee279c5ee165385b7132f71c",
-      "sha256": "0karnf4ycikvfmv3mwh25xhv56ss3s82rnszc0qf37wz686kmk36"
+    "path": "com/google/guava/guava-parent/23.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-23.0.pom": {
+        "sha1": "79d7a4be1ccf3691ee279c5ee165385b7132f71c",
+        "sha256": "0karnf4ycikvfmv3mwh25xhv56ss3s82rnszc0qf37wz686kmk36"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a2c0df489614352b7e8e503e274bd1dee5c42a64",
-      "sha256": "016c2q03chipb3a9ij2d0dmsrf2yyaj8rz0skj4cx5m9djs8lsgq"
+    "path": "com/google/guava/guava-parent/26.0-android",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-26.0-android.pom": {
+        "sha1": "a2c0df489614352b7e8e503e274bd1dee5c42a64",
+        "sha256": "016c2q03chipb3a9ij2d0dmsrf2yyaj8rz0skj4cx5m9djs8lsgq"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/26.0-jre/guava-parent-26.0-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "3a638a46e3277ff6a3d43d2a50bcccfac2966815",
-      "sha256": "18za79by0g61arws1n0s4pyd68imsbyr4w72wgsxxmy02za5qzdv"
+    "path": "com/google/guava/guava-parent/26.0-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-26.0-jre.pom": {
+        "sha1": "3a638a46e3277ff6a3d43d2a50bcccfac2966815",
+        "sha256": "18za79by0g61arws1n0s4pyd68imsbyr4w72wgsxxmy02za5qzdv"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/27.0.1-jre/guava-parent-27.0.1-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "8f7a96c144da567471d3d763a240c25ba374ebb1",
-      "sha256": "15p668bsn24xblpi3qf2hmf5dm7ia24c2mp90llczq3228lqhzii"
+    "path": "com/google/guava/guava-parent/27.0.1-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-27.0.1-jre.pom": {
+        "sha1": "8f7a96c144da567471d3d763a240c25ba374ebb1",
+        "sha256": "15p668bsn24xblpi3qf2hmf5dm7ia24c2mp90llczq3228lqhzii"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-parent/31.1-jre/guava-parent-31.1-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "99dae234b84eeaafa621086b6fff3530fb7e45d3",
-      "sha256": "1z70610yl7s699m9dwml9v69ddsbvlhpdw2zy1gd4jmlhdkn4fa4"
+    "path": "com/google/guava/guava-parent/31.1-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-parent-31.1-jre.pom": {
+        "sha1": "99dae234b84eeaafa621086b6fff3530fb7e45d3",
+        "sha256": "1z70610yl7s699m9dwml9v69ddsbvlhpdw2zy1gd4jmlhdkn4fa4"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava-testlib/31.1-jre/guava-testlib-31.1-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5e4e72ce96bbb4564930f70906636bb7c3167628",
-      "sha256": "1c9d20i0yp1fmlnfwdr7zn4vy13ja3ch4w2c1z9jcbqm9gmja4x5"
-    },
-    "jar": {
-      "sha1": "64d8b6d2ea60f3870ca01baba3dbe047af18e7f8",
-      "sha256": "1ki6c8vz8kmnrbw5j2hy9mc7w9cdn77q9ghnvmsc8fjw1nqp3p5a"
+    "path": "com/google/guava/guava-testlib/31.1-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-testlib-31.1-jre.pom": {
+        "sha1": "5e4e72ce96bbb4564930f70906636bb7c3167628",
+        "sha256": "1c9d20i0yp1fmlnfwdr7zn4vy13ja3ch4w2c1z9jcbqm9gmja4x5"
+      },
+      "guava-testlib-31.1-jre.jar": {
+        "sha1": "64d8b6d2ea60f3870ca01baba3dbe047af18e7f8",
+        "sha256": "1ki6c8vz8kmnrbw5j2hy9mc7w9cdn77q9ghnvmsc8fjw1nqp3p5a"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava/17.0/guava-17.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0f534dabee0b40b25715869c5e1287e38c7e1e4a",
-      "sha256": "0nxpdkb27m770j0c4xlg7l34aj87h7qja7dbmqrcf99q1l0ic39a"
-    },
-    "jar": {
-      "sha1": "9c6ef172e8de35fd8d4d8783e4821e57cdef7445",
-      "sha256": "1g7bhyvzsx61lrca01hvpivkdgjvgj1wy5qa0jwbdl0klq7ahdlc"
+    "path": "com/google/guava/guava/17.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-17.0.pom": {
+        "sha1": "0f534dabee0b40b25715869c5e1287e38c7e1e4a",
+        "sha256": "0nxpdkb27m770j0c4xlg7l34aj87h7qja7dbmqrcf99q1l0ic39a"
+      },
+      "guava-17.0.jar": {
+        "sha1": "9c6ef172e8de35fd8d4d8783e4821e57cdef7445",
+        "sha256": "1g7bhyvzsx61lrca01hvpivkdgjvgj1wy5qa0jwbdl0klq7ahdlc"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava/22.0/guava-22.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b87878db57d5cfc2ca7d3972cc8f7486bf02fbca",
-      "sha256": "0cxzz1aq5wprdhag9vkfqyb160slpgw2jsvdcvhnvpb51ysb7bdz"
-    },
-    "jar": {
-      "sha1": "3564ef3803de51fb0530a8377ec6100b33b0d073",
-      "sha256": "17jpmgwz19jq9b4jr45ishihsk513m5apd7hfc44inp4gm6fjn0i"
+    "path": "com/google/guava/guava/22.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-22.0.pom": {
+        "sha1": "b87878db57d5cfc2ca7d3972cc8f7486bf02fbca",
+        "sha256": "0cxzz1aq5wprdhag9vkfqyb160slpgw2jsvdcvhnvpb51ysb7bdz"
+      },
+      "guava-22.0.jar": {
+        "sha1": "3564ef3803de51fb0530a8377ec6100b33b0d073",
+        "sha256": "17jpmgwz19jq9b4jr45ishihsk513m5apd7hfc44inp4gm6fjn0i"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava/23.0/guava-23.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "05ce65d93433db6ef45746bcfbcef6656698851f",
-      "sha256": "0kijfr2a28qpxf9zkd7i2fcpzfybpbxy50vcgh4yak3bg8mc8amc"
-    },
-    "jar": {
-      "sha1": "c947004bb13d18182be60077ade044099e4f26f1",
-      "sha256": "15k53fyw6ikrcpzmilqvh2vsfpm8cz9ri6xi8nwya5s153gq1akv"
+    "path": "com/google/guava/guava/23.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-23.0.pom": {
+        "sha1": "05ce65d93433db6ef45746bcfbcef6656698851f",
+        "sha256": "0kijfr2a28qpxf9zkd7i2fcpzfybpbxy50vcgh4yak3bg8mc8amc"
+      },
+      "guava-23.0.jar": {
+        "sha1": "c947004bb13d18182be60077ade044099e4f26f1",
+        "sha256": "15k53fyw6ikrcpzmilqvh2vsfpm8cz9ri6xi8nwya5s153gq1akv"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava/26.0-jre/guava-26.0-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7883e19f8b0cca8c4498d476743e31b107674155",
-      "sha256": "02g1gsm1xbxxvk2q84mpgin99f41cn9qbnl1v92bid2akbf7lcqw"
-    },
-    "jar": {
-      "sha1": "6a806eff209f36f635f943e16d97491f00f6bfab",
-      "sha256": "0b7a7c1hgx5rmnx0ma5f2dp7agy0by7107xhsay21g35ssxcmsd0"
+    "path": "com/google/guava/guava/26.0-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-26.0-jre.pom": {
+        "sha1": "7883e19f8b0cca8c4498d476743e31b107674155",
+        "sha256": "02g1gsm1xbxxvk2q84mpgin99f41cn9qbnl1v92bid2akbf7lcqw"
+      },
+      "guava-26.0-jre.jar": {
+        "sha1": "6a806eff209f36f635f943e16d97491f00f6bfab",
+        "sha256": "0b7a7c1hgx5rmnx0ma5f2dp7agy0by7107xhsay21g35ssxcmsd0"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava/27.0.1-jre/guava-27.0.1-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a6ccf3af1d34509e5fb1f5bff675b9ae707ad628",
-      "sha256": "0dlg2lwzzc1w1an0syimf4ibcdrmk75zqh74hr5b2srsy90x13ba"
-    },
-    "jar": {
-      "sha1": "bd41a290787b5301e63929676d792c507bbc00ae",
-      "sha256": "1d07j5nav47y03j3j0h1r079aghvmazfl5q3iv1jfaj90kyi9j71"
+    "path": "com/google/guava/guava/27.0.1-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-27.0.1-jre.pom": {
+        "sha1": "a6ccf3af1d34509e5fb1f5bff675b9ae707ad628",
+        "sha256": "0dlg2lwzzc1w1an0syimf4ibcdrmk75zqh74hr5b2srsy90x13ba"
+      },
+      "guava-27.0.1-jre.jar": {
+        "sha1": "bd41a290787b5301e63929676d792c507bbc00ae",
+        "sha256": "1d07j5nav47y03j3j0h1r079aghvmazfl5q3iv1jfaj90kyi9j71"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/guava/31.1-jre/guava-31.1-jre",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "03a6ac93765fbbc416179f7c7127b9ddddbf38d9",
-      "sha256": "1qhd4xpkf5hrwac4wwynh17f6i0vs8kqpraqff6i0q7nyixx14wi"
-    },
-    "jar": {
-      "sha1": "60458f877d055d0c9114d9e1a2efb737b4bc282c",
-      "sha256": "1aq099yb19bb3n7gg2ksz1zibvamlvyg755v77z3jbkrmffdqbm4"
+    "path": "com/google/guava/guava/31.1-jre",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "guava-31.1-jre.pom": {
+        "sha1": "03a6ac93765fbbc416179f7c7127b9ddddbf38d9",
+        "sha256": "1qhd4xpkf5hrwac4wwynh17f6i0vs8kqpraqff6i0q7nyixx14wi"
+      },
+      "guava-31.1-jre.jar": {
+        "sha1": "60458f877d055d0c9114d9e1a2efb737b4bc282c",
+        "sha256": "1aq099yb19bb3n7gg2ksz1zibvamlvyg755v77z3jbkrmffdqbm4"
+      }
     }
   },
 
   {
-    "path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1b77ba79f9b2b7dfd4e15ea7bb0d568d5eb9cb8d",
-      "sha256": "16v7p0wgzi5wijl596ggcawcs1gyn5mzgqcw0xalwg8m4vdv3m0q"
-    },
-    "jar": {
-      "sha1": "b421526c5f297295adef1c886e5246c39d4ac629",
-      "sha256": "169zydsbk48cs370lpdq5l69qgqjsq7z7ppzprzsa2i3shvs0wmk"
+    "path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom": {
+        "sha1": "1b77ba79f9b2b7dfd4e15ea7bb0d568d5eb9cb8d",
+        "sha256": "16v7p0wgzi5wijl596ggcawcs1gyn5mzgqcw0xalwg8m4vdv3m0q"
+      },
+      "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar": {
+        "sha1": "b421526c5f297295adef1c886e5246c39d4ac629",
+        "sha256": "169zydsbk48cs370lpdq5l69qgqjsq7z7ppzprzsa2i3shvs0wmk"
+      }
     }
   },
 
   {
-    "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b964a9414771661bdf35a3f10692a2fb0dd2c866",
-      "sha256": "1gnn7b80krv19qjd9hhacahffqq9iwqgmw4ds56wp9wk3rbqrjgh"
-    },
-    "jar": {
-      "sha1": "ed28ded51a8b1c6b112568def5f4b455e6809019",
-      "sha256": "1xpcvmnw2y3fa56hhk8dmknrq8afr6r3kdmzsg9hnwgjg3msg519"
+    "path": "com/google/j2objc/j2objc-annotations/1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "j2objc-annotations-1.1.pom": {
+        "sha1": "b964a9414771661bdf35a3f10692a2fb0dd2c866",
+        "sha256": "1gnn7b80krv19qjd9hhacahffqq9iwqgmw4ds56wp9wk3rbqrjgh"
+      },
+      "j2objc-annotations-1.1.jar": {
+        "sha1": "ed28ded51a8b1c6b112568def5f4b455e6809019",
+        "sha256": "1xpcvmnw2y3fa56hhk8dmknrq8afr6r3kdmzsg9hnwgjg3msg519"
+      }
     }
   },
 
   {
-    "path": "com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c8daacea97066c6826844e2175ec89857e598122",
-      "sha256": "1y0ipx6xa6f501c9p17sz1g76l7yfq99xylbj4y131c3n6c7gy1p"
-    },
-    "jar": {
-      "sha1": "c85270e307e7b822f1086b93689124b89768e273",
-      "sha256": "1vfnyjvjmkjdnzwfz42jlchx22gpgpxx17w5xnryv5ay3bx9aaph"
+    "path": "com/google/j2objc/j2objc-annotations/2.8",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "j2objc-annotations-2.8.pom": {
+        "sha1": "c8daacea97066c6826844e2175ec89857e598122",
+        "sha256": "1y0ipx6xa6f501c9p17sz1g76l7yfq99xylbj4y131c3n6c7gy1p"
+      },
+      "j2objc-annotations-2.8.jar": {
+        "sha1": "c85270e307e7b822f1086b93689124b89768e273",
+        "sha256": "1vfnyjvjmkjdnzwfz42jlchx22gpgpxx17w5xnryv5ay3bx9aaph"
+      }
     }
   },
 
   {
-    "path": "com/google/jimfs/jimfs-parent/1.1/jimfs-parent-1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "2283f99a6aa73205190a20cfd35078e9f7d6cec9",
-      "sha256": "1g96idyskcl3ryfc3fd5lq12ay5f4nbars3h528yzq2p3rsma5f7"
+    "path": "com/google/jimfs/jimfs-parent/1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jimfs-parent-1.1.pom": {
+        "sha1": "2283f99a6aa73205190a20cfd35078e9f7d6cec9",
+        "sha256": "1g96idyskcl3ryfc3fd5lq12ay5f4nbars3h528yzq2p3rsma5f7"
+      }
     }
   },
 
   {
-    "path": "com/google/jimfs/jimfs/1.1/jimfs-1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "380866e1e495f899631b6e1d437e4b0a69e4faa3",
-      "sha256": "0i3sgapm9r7wgmrm0qlb2hzarm6q6irfbjnz5x3ppw92v5f6xa7g"
-    },
-    "jar": {
-      "sha1": "8fbd0579dc68aba6186935cc1bee21d2f3e7ec1c",
-      "sha256": "1pbx4lf1y24bgdfaf9bw9p0abnm7mlxhnlc7jfpk1af0swl8x0n4"
+    "path": "com/google/jimfs/jimfs/1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jimfs-1.1.pom": {
+        "sha1": "380866e1e495f899631b6e1d437e4b0a69e4faa3",
+        "sha256": "0i3sgapm9r7wgmrm0qlb2hzarm6q6irfbjnz5x3ppw92v5f6xa7g"
+      },
+      "jimfs-1.1.jar": {
+        "sha1": "8fbd0579dc68aba6186935cc1bee21d2f3e7ec1c",
+        "sha256": "1pbx4lf1y24bgdfaf9bw9p0abnm7mlxhnlc7jfpk1af0swl8x0n4"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-bom/4.0.0-rc-2/protobuf-bom-4.0.0-rc-2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "1cf14b7774313bc34805dd58fffa3cbc35601184",
-      "sha256": "0ck1197969n6s21q52kdysxnqh4gwk9nxkw4jbq43vxhh94yk7z3"
+    "path": "com/google/protobuf/protobuf-bom/4.0.0-rc-2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-bom-4.0.0-rc-2.pom": {
+        "sha1": "1cf14b7774313bc34805dd58fffa3cbc35601184",
+        "sha256": "0ck1197969n6s21q52kdysxnqh4gwk9nxkw4jbq43vxhh94yk7z3"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java-util/3.4.0/protobuf-java-util-3.4.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "72b93eb17c1d5337ec0f4497313a14b315b9e76c",
-      "sha256": "1f1wvrr4lpp0mrbf3l5r3gcfbpxznvhnm8x4faxfm87awxrk1i49"
-    },
-    "jar": {
-      "sha1": "96aba8ab71c16018c6adf66771ce15c6491bc0fe",
-      "sha256": "0ll0lslidkl0hp78yf48y4a7b8swqyylzckh1wrz4p5ibazf12a1"
+    "path": "com/google/protobuf/protobuf-java-util/3.4.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-java-util-3.4.0.pom": {
+        "sha1": "72b93eb17c1d5337ec0f4497313a14b315b9e76c",
+        "sha256": "1f1wvrr4lpp0mrbf3l5r3gcfbpxznvhnm8x4faxfm87awxrk1i49"
+      },
+      "protobuf-java-util-3.4.0.jar": {
+        "sha1": "96aba8ab71c16018c6adf66771ce15c6491bc0fe",
+        "sha256": "0ll0lslidkl0hp78yf48y4a7b8swqyylzckh1wrz4p5ibazf12a1"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/3.0.0/protobuf-java-3.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cd049bdc1680b9419359a73be694bac35a12942c",
-      "sha256": "1k6f973cdghqag5cnwq9h9fm5c69q8f02anl329ibanpy2waziz4"
-    },
-    "jar": {
-      "sha1": "6d325aa7c921661d84577c0a93d82da4df9fa4c8",
-      "sha256": "1nsmiiisyp0s9149lb7k86nd05vzfpwfq58vixy3qw61xyrxdrx1"
+    "path": "com/google/protobuf/protobuf-java/3.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-java-3.0.0.pom": {
+        "sha1": "cd049bdc1680b9419359a73be694bac35a12942c",
+        "sha256": "1k6f973cdghqag5cnwq9h9fm5c69q8f02anl329ibanpy2waziz4"
+      },
+      "protobuf-java-3.0.0.jar": {
+        "sha1": "6d325aa7c921661d84577c0a93d82da4df9fa4c8",
+        "sha256": "1nsmiiisyp0s9149lb7k86nd05vzfpwfq58vixy3qw61xyrxdrx1"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/3.4.0/protobuf-java-3.4.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "100272b91d96ed5b41df4bb11ba543140c36bd30",
-      "sha256": "01llqnrfxa04q1ndnrcvsg0j3vs2rva3101w79da38azdjl7pwc3"
-    },
-    "jar": {
-      "sha1": "b32aba0cbe737a4ca953f71688725972e3ee927c",
-      "sha256": "194hchg28sckqycfg4c3cm41bdxcm3rsy36sk08insj569mydryw"
+    "path": "com/google/protobuf/protobuf-java/3.4.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-java-3.4.0.pom": {
+        "sha1": "100272b91d96ed5b41df4bb11ba543140c36bd30",
+        "sha256": "01llqnrfxa04q1ndnrcvsg0j3vs2rva3101w79da38azdjl7pwc3"
+      },
+      "protobuf-java-3.4.0.jar": {
+        "sha1": "b32aba0cbe737a4ca953f71688725972e3ee927c",
+        "sha256": "194hchg28sckqycfg4c3cm41bdxcm3rsy36sk08insj569mydryw"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/4.0.0-rc-2/protobuf-java-4.0.0-rc-2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8fab0fe0746b1d370663a3db7dd483c2c4d34a6f",
-      "sha256": "17agfgbdfxdk304fgzk0iwsf7ggwqrwb44b3nnjc0xjdgqlxmzxb"
-    },
-    "jar": {
-      "sha1": "ae590f34383d2d6fde2b3b8e2ffb668e64579099",
-      "sha256": "0al23s9s97sxlrrndb91cnra07fdchbcgvhcacyd6yjzysz55hiw"
+    "path": "com/google/protobuf/protobuf-java/4.0.0-rc-2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-java-4.0.0-rc-2.pom": {
+        "sha1": "8fab0fe0746b1d370663a3db7dd483c2c4d34a6f",
+        "sha256": "17agfgbdfxdk304fgzk0iwsf7ggwqrwb44b3nnjc0xjdgqlxmzxb"
+      },
+      "protobuf-java-4.0.0-rc-2.jar": {
+        "sha1": "ae590f34383d2d6fde2b3b8e2ffb668e64579099",
+        "sha256": "0al23s9s97sxlrrndb91cnra07fdchbcgvhcacyd6yjzysz55hiw"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/3.0.0/protobuf-parent-3.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "fa9a080c3ed2997cd84df8effd6cb8af9e4ed020",
-      "sha256": "0wpjg6ai9dz9n7xa6jqws5rv90yh0jgf5dxxifavr9r4kamnnblk"
+    "path": "com/google/protobuf/protobuf-parent/3.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-parent-3.0.0.pom": {
+        "sha1": "fa9a080c3ed2997cd84df8effd6cb8af9e4ed020",
+        "sha256": "0wpjg6ai9dz9n7xa6jqws5rv90yh0jgf5dxxifavr9r4kamnnblk"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/3.4.0/protobuf-parent-3.4.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "5d9f2b22310a535c4597b4ed3691e000221b3a17",
-      "sha256": "0irsayf19snivcmhyr6122d5mvyb8cd677bn9ixfph2251arr414"
+    "path": "com/google/protobuf/protobuf-parent/3.4.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-parent-3.4.0.pom": {
+        "sha1": "5d9f2b22310a535c4597b4ed3691e000221b3a17",
+        "sha256": "0irsayf19snivcmhyr6122d5mvyb8cd677bn9ixfph2251arr414"
+      }
     }
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/4.0.0-rc-2/protobuf-parent-4.0.0-rc-2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c5391c7917ca1197cbbda4efc6454a87e7e7107e",
-      "sha256": "0bvynr52xjyd42n23ih635h2cmyillfbac0yjymhlp505f0p1lp0"
+    "path": "com/google/protobuf/protobuf-parent/4.0.0-rc-2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "protobuf-parent-4.0.0-rc-2.pom": {
+        "sha1": "c5391c7917ca1197cbbda4efc6454a87e7e7107e",
+        "sha256": "0bvynr52xjyd42n23ih635h2cmyillfbac0yjymhlp505f0p1lp0"
+      }
     }
   },
 
   {
-    "path": "com/google/truth/truth-parent/1.1.3/truth-parent-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c6d1b2aae7ea915ea285d6224914087775782f3c",
-      "sha256": "1xg7mzwlbvfwnlphaa7knsajrrsgcllab9nmf3f5a4rpmsq13hls"
+    "path": "com/google/truth/truth-parent/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "truth-parent-1.1.3.pom": {
+        "sha1": "c6d1b2aae7ea915ea285d6224914087775782f3c",
+        "sha256": "1xg7mzwlbvfwnlphaa7knsajrrsgcllab9nmf3f5a4rpmsq13hls"
+      }
     }
   },
 
   {
-    "path": "com/google/truth/truth/1.1.3/truth-1.1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8cc9b5eacd0afba4d4914cb222c587811f117651",
-      "sha256": "02v6bxfcr9mrysy08dq0dqajn1p6p1s5455bywgrm2snh8frb21p"
-    },
-    "jar": {
-      "sha1": "5e2491cc44dce7380165963a24e91a0af4556a17",
-      "sha256": "1wzlp03v254j936ky5291n4xqpnd3pzrxygxvnzsm8l949w6f2zw"
+    "path": "com/google/truth/truth/1.1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "truth-1.1.3.pom": {
+        "sha1": "8cc9b5eacd0afba4d4914cb222c587811f117651",
+        "sha256": "02v6bxfcr9mrysy08dq0dqajn1p6p1s5455bywgrm2snh8frb21p"
+      },
+      "truth-1.1.3.jar": {
+        "sha1": "5e2491cc44dce7380165963a24e91a0af4556a17",
+        "sha256": "1wzlp03v254j936ky5291n4xqpnd3pzrxygxvnzsm8l949w6f2zw"
+      }
     }
   },
 
   {
-    "path": "com/google/zxing/core/3.3.0/core-3.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1ddcd08882c0da8e917d92087e5651e234b5c79f",
-      "sha256": "1gxa83cz49p03jbgcps7s8k4pahqph91qc7sb973sxs89163w76a"
-    },
-    "jar": {
-      "sha1": "73c49077166faa4c3c0059c5f583d1d7bd1475fe",
-      "sha256": "03gf24zsjkvaq75pxypmbh6lpqp87q9pgbqkhb1wx5x9097759xv"
+    "path": "com/google/zxing/core/3.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "core-3.3.0.pom": {
+        "sha1": "1ddcd08882c0da8e917d92087e5651e234b5c79f",
+        "sha256": "1gxa83cz49p03jbgcps7s8k4pahqph91qc7sb973sxs89163w76a"
+      },
+      "core-3.3.0.jar": {
+        "sha1": "73c49077166faa4c3c0059c5f583d1d7bd1475fe",
+        "sha256": "03gf24zsjkvaq75pxypmbh6lpqp87q9pgbqkhb1wx5x9097759xv"
+      }
     }
   },
 
   {
-    "path": "com/google/zxing/zxing-parent/3.3.0/zxing-parent-3.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c69d8576d8ec725cd091d25cbae2f276d44667db",
-      "sha256": "1xhzxlwgdxmgmjs792vg0vkva6mhy3h2cgcqyv28mxl42sr52sbw"
+    "path": "com/google/zxing/zxing-parent/3.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "zxing-parent-3.3.0.pom": {
+        "sha1": "c69d8576d8ec725cd091d25cbae2f276d44667db",
+        "sha256": "1xhzxlwgdxmgmjs792vg0vkva6mhy3h2cgcqyv28mxl42sr52sbw"
+      }
     }
   },
 
   {
-    "path": "com/intellij/annotations/12.0/annotations-12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "aaa1796465aa46f478176c06456397418b34d2b3",
-      "sha256": "11lhm19lbcscmfrq1qpwacp6njamfbrm7mkw6apc1q02vkh2vy7s"
-    },
-    "jar": {
-      "sha1": "bbcf6448f6d40abe506e2c83b70a3e8bfd2b4539",
-      "sha256": "0vgdfmihsggnbmcmrspf9ldll3knk5ayb43zc4pzx0709fqi7azq"
+    "path": "com/intellij/annotations/12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotations-12.0.pom": {
+        "sha1": "aaa1796465aa46f478176c06456397418b34d2b3",
+        "sha256": "11lhm19lbcscmfrq1qpwacp6njamfbrm7mkw6apc1q02vkh2vy7s"
+      },
+      "annotations-12.0.jar": {
+        "sha1": "bbcf6448f6d40abe506e2c83b70a3e8bfd2b4539",
+        "sha256": "0vgdfmihsggnbmcmrspf9ldll3knk5ayb43zc4pzx0709fqi7azq"
+      }
     }
   },
 
   {
-    "path": "com/parse/bolts/bolts-applinks/1.4.0/bolts-applinks-1.4.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9a7b6fa518be36c41eeb71e9ccb960da962a161f",
-      "sha256": "0i5wx80zk3wf9bh5myl7853dny286gjw6six4bwyfv66i07d5cg5"
-    },
-    "jar": {
-      "sha1": "8ad21bf21784dacce5f2043afb97218cc377e835",
-      "sha256": "19al8dpq7qqwbkmhi76axwd0vml6m65rh5cpj37vdpzfgkv40mxy"
+    "path": "com/parse/bolts/bolts-applinks/1.4.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bolts-applinks-1.4.0.pom": {
+        "sha1": "9a7b6fa518be36c41eeb71e9ccb960da962a161f",
+        "sha256": "0i5wx80zk3wf9bh5myl7853dny286gjw6six4bwyfv66i07d5cg5"
+      },
+      "bolts-applinks-1.4.0.jar": {
+        "sha1": "8ad21bf21784dacce5f2043afb97218cc377e835",
+        "sha256": "19al8dpq7qqwbkmhi76axwd0vml6m65rh5cpj37vdpzfgkv40mxy"
+      }
     }
   },
 
   {
-    "path": "com/parse/bolts/bolts-tasks/1.4.0/bolts-tasks-1.4.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "db60026ffef8aae5e2bac952e74a106a784ea5ae",
-      "sha256": "1q0jhg5wv0gdii0aq1vfwy7ymzvsrsvhgv6q1pjvkhb22630gc4c"
-    },
-    "jar": {
-      "sha1": "d85884acf6810a3bbbecb587f239005cbc846dc4",
-      "sha256": "1qnfmkd460j460f57dcmkdhymjdjglqw4qmczgr9sfl5r8z1xicv"
+    "path": "com/parse/bolts/bolts-tasks/1.4.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bolts-tasks-1.4.0.pom": {
+        "sha1": "db60026ffef8aae5e2bac952e74a106a784ea5ae",
+        "sha256": "1q0jhg5wv0gdii0aq1vfwy7ymzvsrsvhgv6q1pjvkhb22630gc4c"
+      },
+      "bolts-tasks-1.4.0.jar": {
+        "sha1": "d85884acf6810a3bbbecb587f239005cbc846dc4",
+        "sha256": "1qnfmkd460j460f57dcmkdhymjdjglqw4qmczgr9sfl5r8z1xicv"
+      }
     }
   },
 
   {
-    "path": "com/squareup/javapoet/1.8.0/javapoet-1.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "60f3a32fabfe6c4b7572d8e2d94010ea44af4843",
-      "sha256": "0ixnvd7bd5cn3hm9h41y87cx29nr6minbxqqshn5nwwyy500yxmk"
-    },
-    "jar": {
-      "sha1": "e858dc62ef484048540d27d36f3ec2177a3fa9b1",
-      "sha256": "12fpvxgkhy92cmnh3wkai9jgg2g5zg7i3yhhdwcjid3v0a98q44f"
+    "path": "com/squareup/javapoet/1.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "javapoet-1.8.0.pom": {
+        "sha1": "60f3a32fabfe6c4b7572d8e2d94010ea44af4843",
+        "sha256": "0ixnvd7bd5cn3hm9h41y87cx29nr6minbxqqshn5nwwyy500yxmk"
+      },
+      "javapoet-1.8.0.jar": {
+        "sha1": "e858dc62ef484048540d27d36f3ec2177a3fa9b1",
+        "sha256": "12fpvxgkhy92cmnh3wkai9jgg2g5zg7i3yhhdwcjid3v0a98q44f"
+      }
     }
   },
 
   {
-    "path": "com/squareup/javawriter/2.5.0/javawriter-2.5.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d932f2476f65ecd95dcd6fd8c568b3f466f6a482",
-      "sha256": "1c57k79i2dcyjm63k8xjjr1ck3i0i4hkwsa7k72y1xbc27qxgaz1"
-    },
-    "jar": {
-      "sha1": "81241ff7078ef14f42ea2a8995fa09c096256e6b",
-      "sha256": "1w4p04j3z05k7ihb69pid3j4h4q8k0ipksp7rz9rgam01vxhkyzw"
+    "path": "com/squareup/javawriter/2.5.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "javawriter-2.5.0.pom": {
+        "sha1": "d932f2476f65ecd95dcd6fd8c568b3f466f6a482",
+        "sha256": "1c57k79i2dcyjm63k8xjjr1ck3i0i4hkwsa7k72y1xbc27qxgaz1"
+      },
+      "javawriter-2.5.0.jar": {
+        "sha1": "81241ff7078ef14f42ea2a8995fa09c096256e6b",
+        "sha256": "1w4p04j3z05k7ihb69pid3j4h4q8k0ipksp7rz9rgam01vxhkyzw"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp-jvm/5.0.0-alpha.11/okhttp-jvm-5.0.0-alpha.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5ae4f0042d68acdbe76fb3a1312cef5bb030c2fb",
-      "sha256": "1x6ji9dwic2y78qjf1jjxvvhmmb7csaswxzxzsw3gb6ccvywffqk"
-    },
-    "jar": {
-      "sha1": "d29775a9116a8239cea8b969e63bfe7ea8794f94",
-      "sha256": "106gnkylwirqp7am147j65jr8i4sswy83y67f1avb6czp8x1ssjh"
+    "path": "com/squareup/okhttp3/okhttp-jvm/5.0.0-alpha.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-jvm-5.0.0-alpha.11.pom": {
+        "sha1": "5ae4f0042d68acdbe76fb3a1312cef5bb030c2fb",
+        "sha256": "1x6ji9dwic2y78qjf1jjxvvhmmb7csaswxzxzsw3gb6ccvywffqk"
+      },
+      "okhttp-jvm-5.0.0-alpha.11.jar": {
+        "sha1": "d29775a9116a8239cea8b969e63bfe7ea8794f94",
+        "sha256": "106gnkylwirqp7am147j65jr8i4sswy83y67f1avb6czp8x1ssjh"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp-tls/3.12.12/okhttp-tls-3.12.12",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "46fd244a7b499ca9c9915617267bf5bb67709816",
-      "sha256": "0lq2fwzq3i8h5361x9zbgnc0z3nqkczbh4kk5qxiwqnl5wgfq7xb"
-    },
-    "jar": {
-      "sha1": "05abcbe1626d83fb6c82306396ec479b49683675",
-      "sha256": "1cm73al26q0vv2dpb258yjbc375161bhbjrsjqn93mbca006c42f"
+    "path": "com/squareup/okhttp3/okhttp-tls/3.12.12",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-tls-3.12.12.pom": {
+        "sha1": "46fd244a7b499ca9c9915617267bf5bb67709816",
+        "sha256": "0lq2fwzq3i8h5361x9zbgnc0z3nqkczbh4kk5qxiwqnl5wgfq7xb"
+      },
+      "okhttp-tls-3.12.12.jar": {
+        "sha1": "05abcbe1626d83fb6c82306396ec479b49683675",
+        "sha256": "1cm73al26q0vv2dpb258yjbc375161bhbjrsjqn93mbca006c42f"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp-urlconnection/3.12.12/okhttp-urlconnection-3.12.12",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ed7d83320e8f070b8c475467e068173cd72afcf6",
-      "sha256": "0fjr38zbpskwmv756bc6fzbbgpybkrr7n18qwb10zxih0k8xvxp6"
-    },
-    "jar": {
-      "sha1": "3cfbe11fb8c48d30600a70f90b3283fc858aea72",
-      "sha256": "0w19spy3cy08vk9wwfzkcbj0dfycybnpfllmj22w0agdyj2c400x"
+    "path": "com/squareup/okhttp3/okhttp-urlconnection/3.12.12",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-urlconnection-3.12.12.pom": {
+        "sha1": "ed7d83320e8f070b8c475467e068173cd72afcf6",
+        "sha256": "0fjr38zbpskwmv756bc6fzbbgpybkrr7n18qwb10zxih0k8xvxp6"
+      },
+      "okhttp-urlconnection-3.12.12.jar": {
+        "sha1": "3cfbe11fb8c48d30600a70f90b3283fc858aea72",
+        "sha256": "0w19spy3cy08vk9wwfzkcbj0dfycybnpfllmj22w0agdyj2c400x"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7a34bfe0899e4b1a4b84f4e9e79c221bd37e9808",
-      "sha256": "1vjwzaf5y4qfc5pvbsa79m11zjvzhn1b3rszvv6xxky1rpha3hdw"
-    },
-    "jar": {
-      "sha1": "84b4b7d1c4a238e7899972b7446c250691e65f1f",
-      "sha256": "0pkqnz1dmfrhvr17qbv1dr5nylvfnf5l8vgw0zjjdfiblhbi1l50"
+    "path": "com/squareup/okhttp3/okhttp/3.9.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-3.9.1.pom": {
+        "sha1": "7a34bfe0899e4b1a4b84f4e9e79c221bd37e9808",
+        "sha256": "1vjwzaf5y4qfc5pvbsa79m11zjvzhn1b3rszvv6xxky1rpha3hdw"
+      },
+      "okhttp-3.9.1.jar": {
+        "sha1": "84b4b7d1c4a238e7899972b7446c250691e65f1f",
+        "sha256": "0pkqnz1dmfrhvr17qbv1dr5nylvfnf5l8vgw0zjjdfiblhbi1l50"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp/3.12.1/okhttp-3.12.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "975e0606bfccdffb6dcf5ccb6a823f70be6be18d",
-      "sha256": "19lrms9hq7q86rd8kbahwdzxrmw25h3vxybnfnnsivm84jqpc1ll"
-    },
-    "jar": {
-      "sha1": "dc6d02e4e68514eff5631963e28ca7742ac69efe",
-      "sha256": "0ihai288y8a0bp7yvkv0mrln23w6qxyq1nmj00pp5x7alwndihq7"
+    "path": "com/squareup/okhttp3/okhttp/3.12.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-3.12.1.pom": {
+        "sha1": "975e0606bfccdffb6dcf5ccb6a823f70be6be18d",
+        "sha256": "19lrms9hq7q86rd8kbahwdzxrmw25h3vxybnfnnsivm84jqpc1ll"
+      },
+      "okhttp-3.12.1.jar": {
+        "sha1": "dc6d02e4e68514eff5631963e28ca7742ac69efe",
+        "sha256": "0ihai288y8a0bp7yvkv0mrln23w6qxyq1nmj00pp5x7alwndihq7"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp/3.12.12/okhttp-3.12.12",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "90c81c59b2eb943ddbe58bc717e3e75bccd518c2",
-      "sha256": "174vp3isgdpj3nsd5ky921i7y3zn2rfdz7k5ks57w9nfqym1iflq"
-    },
-    "jar": {
-      "sha1": "d3e1ce1d2b3119adf270b2d00d947beb03fe3321",
-      "sha256": "0jsyw4g3v9rhr8c5ggl263vpjn2dcgibzl49w5diw8zvk03wvw9n"
+    "path": "com/squareup/okhttp3/okhttp/3.12.12",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-3.12.12.pom": {
+        "sha1": "90c81c59b2eb943ddbe58bc717e3e75bccd518c2",
+        "sha256": "174vp3isgdpj3nsd5ky921i7y3zn2rfdz7k5ks57w9nfqym1iflq"
+      },
+      "okhttp-3.12.12.jar": {
+        "sha1": "d3e1ce1d2b3119adf270b2d00d947beb03fe3321",
+        "sha256": "0jsyw4g3v9rhr8c5ggl263vpjn2dcgibzl49w5diw8zvk03wvw9n"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/okhttp/5.0.0-alpha.11/okhttp-5.0.0-alpha.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a0b59e69a18b0d5e919cf259085181f7327c583e",
-      "sha256": "1g8y1yf42i0rj8q7812g8yw87vg20p6rgaxlbgmcmd8agr2pza6l"
-    },
-    "jar": {
-      "sha1": "c971e8f02ddb288a0311cc80b6268091e20299fc",
-      "sha256": "13mv7bfkrs1ds4r36jxqvgzzajs0ayrl8zshyp838mf12x2cz5wk"
+    "path": "com/squareup/okhttp3/okhttp/5.0.0-alpha.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okhttp-5.0.0-alpha.11.pom": {
+        "sha1": "a0b59e69a18b0d5e919cf259085181f7327c583e",
+        "sha256": "1g8y1yf42i0rj8q7812g8yw87vg20p6rgaxlbgmcmd8agr2pza6l"
+      },
+      "okhttp-5.0.0-alpha.11.jar": {
+        "sha1": "c971e8f02ddb288a0311cc80b6268091e20299fc",
+        "sha256": "13mv7bfkrs1ds4r36jxqvgzzajs0ayrl8zshyp838mf12x2cz5wk"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/parent/3.9.1/parent-3.9.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "e55ee2b70a7a64431236eac139096e369db69bb6",
-      "sha256": "0lqm0gpbxfkw7n530hfr2jxr7r4cgiia2ahd0m1kb6kwdfzf05gm"
+    "path": "com/squareup/okhttp3/parent/3.9.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "parent-3.9.1.pom": {
+        "sha1": "e55ee2b70a7a64431236eac139096e369db69bb6",
+        "sha256": "0lqm0gpbxfkw7n530hfr2jxr7r4cgiia2ahd0m1kb6kwdfzf05gm"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/parent/3.12.1/parent-3.12.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a118bcb30283e6df0fa33574d3eeb69804e0f3dd",
-      "sha256": "1g7lzfqfpq3jrpm9lgcsmq2lbrwck5kp3jns7jvvbvgfkc46yz7m"
+    "path": "com/squareup/okhttp3/parent/3.12.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "parent-3.12.1.pom": {
+        "sha1": "a118bcb30283e6df0fa33574d3eeb69804e0f3dd",
+        "sha256": "1g7lzfqfpq3jrpm9lgcsmq2lbrwck5kp3jns7jvvbvgfkc46yz7m"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okhttp3/parent/3.12.12/parent-3.12.12",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "75e6add0d5bac7736ef7ae70c1d992270ec6c28f",
-      "sha256": "18apmj22hw58fcd0912f5x52yxq48wfkm22j3nw3pf7va5val0k7"
+    "path": "com/squareup/okhttp3/parent/3.12.12",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "parent-3.12.12.pom": {
+        "sha1": "75e6add0d5bac7736ef7ae70c1d992270ec6c28f",
+        "sha256": "18apmj22hw58fcd0912f5x52yxq48wfkm22j3nw3pf7va5val0k7"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio-jvm/3.2.0/okio-jvm-3.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "749720d97fe3dc16e0d84a05628f4c818b375a85",
-      "sha256": "17a85p5cf4zdvymmarf8d1cm803jypl89gzjdqdqdskblya1yiaw"
-    },
-    "jar": {
-      "sha1": "332d1c5dc82b0241cb1d35bb0901d28470cc89ca",
-      "sha256": "1915c2h1lsb3l12n61pq3y8fvp0n5dxndldk9kg5a02p9kpvlhmn"
+    "path": "com/squareup/okio/okio-jvm/3.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-jvm-3.2.0.pom": {
+        "sha1": "749720d97fe3dc16e0d84a05628f4c818b375a85",
+        "sha256": "17a85p5cf4zdvymmarf8d1cm803jypl89gzjdqdqdskblya1yiaw"
+      },
+      "okio-jvm-3.2.0.jar": {
+        "sha1": "332d1c5dc82b0241cb1d35bb0901d28470cc89ca",
+        "sha256": "1915c2h1lsb3l12n61pq3y8fvp0n5dxndldk9kg5a02p9kpvlhmn"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio-jvm/3.3.0/okio-jvm-3.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "441db5e3f85f26d8891b7ae05cffb9a1a67ee54f",
-      "sha256": "1khq6z9w0mlbvi6kzg3vm0k5c593z7iv360f9kdvflgyj05hw026"
-    },
-    "jar": {
-      "sha1": "2d175add2d06a67bda111ae5455e49b42d0bb287",
-      "sha256": "08kj4ggh8kv2k1i4yxd9i0jxlf3b4ajdfsjcqxmx9mr0xhbq9ynz"
+    "path": "com/squareup/okio/okio-jvm/3.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-jvm-3.3.0.pom": {
+        "sha1": "441db5e3f85f26d8891b7ae05cffb9a1a67ee54f",
+        "sha256": "1khq6z9w0mlbvi6kzg3vm0k5c593z7iv360f9kdvflgyj05hw026"
+      },
+      "okio-jvm-3.3.0.jar": {
+        "sha1": "2d175add2d06a67bda111ae5455e49b42d0bb287",
+        "sha256": "08kj4ggh8kv2k1i4yxd9i0jxlf3b4ajdfsjcqxmx9mr0xhbq9ynz"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio-parent/1.15.0/okio-parent-1.15.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "5eb9d8103fd3e21923bcf157066957337d6ca71e",
-      "sha256": "1ckd0lhrvgzzjlhj36i607cdmv3slh2hsiwrycfp5kdal8z9mq1l"
+    "path": "com/squareup/okio/okio-parent/1.15.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-parent-1.15.0.pom": {
+        "sha1": "5eb9d8103fd3e21923bcf157066957337d6ca71e",
+        "sha256": "1ckd0lhrvgzzjlhj36i607cdmv3slh2hsiwrycfp5kdal8z9mq1l"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio-parent/1.17.4/okio-parent-1.17.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "18eae90824681bf12cb8359b0a1ecef9149de1e3",
-      "sha256": "04g6gdc2549iq98pc7fmfh0qypqxpr7pzjx0sfy8pkrspkdkj3mb"
+    "path": "com/squareup/okio/okio-parent/1.17.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-parent-1.17.4.pom": {
+        "sha1": "18eae90824681bf12cb8359b0a1ecef9149de1e3",
+        "sha256": "04g6gdc2549iq98pc7fmfh0qypqxpr7pzjx0sfy8pkrspkdkj3mb"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio/1.15.0/okio-1.15.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "87f1520a39a954a9aa185c7fe8f144fa7d597690",
-      "sha256": "1kmzw5q3p0z6hgp0f5kyx4jjbnkwwdrv41qs0pxpbayih0a0phgi"
-    },
-    "jar": {
-      "sha1": "bc28b5a964c8f5721eb58ee3f3c47a9bcbf4f4d8",
-      "sha256": "1llb25k2n887b3fz4xxmpip10kv7nwil081bc0037178lwcs6gv9"
+    "path": "com/squareup/okio/okio/1.15.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-1.15.0.pom": {
+        "sha1": "87f1520a39a954a9aa185c7fe8f144fa7d597690",
+        "sha256": "1kmzw5q3p0z6hgp0f5kyx4jjbnkwwdrv41qs0pxpbayih0a0phgi"
+      },
+      "okio-1.15.0.jar": {
+        "sha1": "bc28b5a964c8f5721eb58ee3f3c47a9bcbf4f4d8",
+        "sha256": "1llb25k2n887b3fz4xxmpip10kv7nwil081bc0037178lwcs6gv9"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio/1.17.4/okio-1.17.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cda5234d77b44144201f4c77ab46f79422884d81",
-      "sha256": "1ilmakclwpp0l3v9ghvvg7af0n5shaxb3y560mv7nmbv317g9b90"
-    },
-    "jar": {
-      "sha1": "50077892fbc179bc69c0ac488442fd3a864e897f",
-      "sha256": "0nz8xvcnab3pfwx1li968r1nfp1py3jizsc2djg0kz2qhicar3yp"
+    "path": "com/squareup/okio/okio/1.17.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-1.17.4.pom": {
+        "sha1": "cda5234d77b44144201f4c77ab46f79422884d81",
+        "sha256": "1ilmakclwpp0l3v9ghvvg7af0n5shaxb3y560mv7nmbv317g9b90"
+      },
+      "okio-1.17.4.jar": {
+        "sha1": "50077892fbc179bc69c0ac488442fd3a864e897f",
+        "sha256": "0nz8xvcnab3pfwx1li968r1nfp1py3jizsc2djg0kz2qhicar3yp"
+      }
     }
   },
 
   {
-    "path": "com/squareup/okio/okio/3.3.0/okio-3.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8b5abd4bc3965b81e4c8c718bfabdac9afbebe7b",
-      "sha256": "17y5pjl0iaykk6m6sbkhv8xz674kmwpy8vdgqpkxldrjk6hq9a6m"
-    },
-    "jar": {
-      "sha1": "c3ad4568143c88518e82eb63de30e2d3de011439",
-      "sha256": "1idbgxrq7lhx38hn13s8kxx9qkh2bn86kflbw5ch2wz59q4m488g"
+    "path": "com/squareup/okio/okio/3.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "okio-3.3.0.pom": {
+        "sha1": "8b5abd4bc3965b81e4c8c718bfabdac9afbebe7b",
+        "sha256": "17y5pjl0iaykk6m6sbkhv8xz674kmwpy8vdgqpkxldrjk6hq9a6m"
+      },
+      "okio-3.3.0.jar": {
+        "sha1": "c3ad4568143c88518e82eb63de30e2d3de011439",
+        "sha256": "1idbgxrq7lhx38hn13s8kxx9qkh2bn86kflbw5ch2wz59q4m488g"
+      }
     }
   },
 
   {
-    "path": "com/sun/activation/all/1.2.0/all-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "9b1023e38195ea19d1a0ac79192d486da1904f97",
-      "sha256": "1i62n3icq23pssrvvii30x9jx63wygg7ggppwh2a2ckmmkiii18x"
+    "path": "com/sun/activation/all/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "all-1.2.0.pom": {
+        "sha1": "9b1023e38195ea19d1a0ac79192d486da1904f97",
+        "sha256": "1i62n3icq23pssrvvii30x9jx63wygg7ggppwh2a2ckmmkiii18x"
+      }
     }
   },
 
   {
-    "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bdb776ae9b888b7ad8f9f424b9e67837eae916c5",
-      "sha256": "0piadm0mqh1p9747mzapw7kkvayphj1irvnvn006jk458plvcygq"
-    },
-    "jar": {
-      "sha1": "bf744c1e2776ed1de3c55c8dac1057ec331ef744",
-      "sha256": "1km9if90zdgjzgc3rxqfj2s0p0as2xymgk3rwwhny1fpdjqh4cwr"
+    "path": "com/sun/activation/javax.activation/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "javax.activation-1.2.0.pom": {
+        "sha1": "bdb776ae9b888b7ad8f9f424b9e67837eae916c5",
+        "sha256": "0piadm0mqh1p9747mzapw7kkvayphj1irvnvn006jk458plvcygq"
+      },
+      "javax.activation-1.2.0.jar": {
+        "sha1": "bf744c1e2776ed1de3c55c8dac1057ec331ef744",
+        "sha256": "1km9if90zdgjzgc3rxqfj2s0p0as2xymgk3rwwhny1fpdjqh4cwr"
+      }
     }
   },
 
   {
-    "path": "com/sun/istack/istack-commons-runtime/2.21/istack-commons-runtime-2.21",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "04c234cf684a202c5c9bb7f0a198ba97e958f8f4",
-      "sha256": "073dc9605ak2zns72l3mac5ynnz5k8rkyzwsbxa51l5zbxxi7rzb"
-    },
-    "jar": {
-      "sha1": "c969d8f15c467f0ef7d7b04889afbe7b5d48e22f",
-      "sha256": "1x2hm4dq75jg8cz4n1ac3b6gki6p5m0kk89d1qmg15bhh2h6fgn3"
+    "path": "com/sun/istack/istack-commons-runtime/2.21",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "istack-commons-runtime-2.21.pom": {
+        "sha1": "04c234cf684a202c5c9bb7f0a198ba97e958f8f4",
+        "sha256": "073dc9605ak2zns72l3mac5ynnz5k8rkyzwsbxa51l5zbxxi7rzb"
+      },
+      "istack-commons-runtime-2.21.jar": {
+        "sha1": "c969d8f15c467f0ef7d7b04889afbe7b5d48e22f",
+        "sha256": "1x2hm4dq75jg8cz4n1ac3b6gki6p5m0kk89d1qmg15bhh2h6fgn3"
+      }
     }
   },
 
   {
-    "path": "com/sun/istack/istack-commons-runtime/4.1.1/istack-commons-runtime-4.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "35c136c863b9591c4d5374b76c724e871cbc57aa",
-      "sha256": "17nvihq7f24xrvlqkzxq23qkb4g5f9sl0pq7wsvspl78gbv4ciq1"
-    },
-    "jar": {
-      "sha1": "9b3769c76235bc283b060da4fae2318c6d53f07e",
-      "sha256": "1lyw30wh3w1xazp0kzb4j5zvz01fz1rihk2kqkwfcnjxpz2li0by"
+    "path": "com/sun/istack/istack-commons-runtime/4.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "istack-commons-runtime-4.1.1.pom": {
+        "sha1": "35c136c863b9591c4d5374b76c724e871cbc57aa",
+        "sha256": "17nvihq7f24xrvlqkzxq23qkb4g5f9sl0pq7wsvspl78gbv4ciq1"
+      },
+      "istack-commons-runtime-4.1.1.jar": {
+        "sha1": "9b3769c76235bc283b060da4fae2318c6d53f07e",
+        "sha256": "1lyw30wh3w1xazp0kzb4j5zvz01fz1rihk2kqkwfcnjxpz2li0by"
+      }
     }
   },
 
   {
-    "path": "com/sun/istack/istack-commons/2.21/istack-commons-2.21",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "125168cc27946f32374cef253dbe607486aa3919",
-      "sha256": "1341mibhpgaibhvdq6xzdkxjw8bp434nakkbc212j5lvz1vi41y3"
+    "path": "com/sun/istack/istack-commons/2.21",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "istack-commons-2.21.pom": {
+        "sha1": "125168cc27946f32374cef253dbe607486aa3919",
+        "sha256": "1341mibhpgaibhvdq6xzdkxjw8bp434nakkbc212j5lvz1vi41y3"
+      }
     }
   },
 
   {
-    "path": "com/sun/istack/istack-commons/4.1.1/istack-commons-4.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "645608b459500510bd8d75686cd4b3a9e9ee36a0",
-      "sha256": "0303sa2xi5ln0ypnwpqizs6zrni8s0dr7wj0d41nkbrg6152fxnf"
+    "path": "com/sun/istack/istack-commons/4.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "istack-commons-4.1.1.pom": {
+        "sha1": "645608b459500510bd8d75686cd4b3a9e9ee36a0",
+        "sha256": "0303sa2xi5ln0ypnwpqizs6zrni8s0dr7wj0d41nkbrg6152fxnf"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/jaxb-bom-ext/2.2.11/jaxb-bom-ext-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "158223fd61f720cf172e1984147b62aa8f2bdf4e",
-      "sha256": "1sav7gq6a54zvkb113qhff3zp435767n1r5276q95jr1vs9hcpmj"
+    "path": "com/sun/xml/bind/jaxb-bom-ext/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-bom-ext-2.2.11.pom": {
+        "sha1": "158223fd61f720cf172e1984147b62aa8f2bdf4e",
+        "sha256": "1sav7gq6a54zvkb113qhff3zp435767n1r5276q95jr1vs9hcpmj"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/jaxb-bom-ext/4.0.2/jaxb-bom-ext-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "600924984be6a63e1c38d5f6ef0637a070002937",
-      "sha256": "1jsdpynkd7d7bqp81ajcy7fa2riz9wnl8rb81icd8shv7awnkbfx"
+    "path": "com/sun/xml/bind/jaxb-bom-ext/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-bom-ext-4.0.2.pom": {
+        "sha1": "600924984be6a63e1c38d5f6ef0637a070002937",
+        "sha256": "1jsdpynkd7d7bqp81ajcy7fa2riz9wnl8rb81icd8shv7awnkbfx"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/mvn/jaxb-parent/2.2.11/jaxb-parent-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "9496f6747e6d5ab5da869941dea4143969122b91",
-      "sha256": "10041gr7ra0777sp4cyflhs5slpf6849lpv13dbpwm013iqinc5m"
+    "path": "com/sun/xml/bind/mvn/jaxb-parent/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-parent-2.2.11.pom": {
+        "sha1": "9496f6747e6d5ab5da869941dea4143969122b91",
+        "sha256": "10041gr7ra0777sp4cyflhs5slpf6849lpv13dbpwm013iqinc5m"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/mvn/jaxb-parent/4.0.2/jaxb-parent-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "160938bb66dc61a4839edaad77a5b7b7f9f5171d",
-      "sha256": "184avj0jpjz1rsxrrw88yn31yxkvw1l3blyq6fs4sbmgac12dvqc"
+    "path": "com/sun/xml/bind/mvn/jaxb-parent/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-parent-4.0.2.pom": {
+        "sha1": "160938bb66dc61a4839edaad77a5b7b7f9f5171d",
+        "sha256": "184avj0jpjz1rsxrrw88yn31yxkvw1l3blyq6fs4sbmgac12dvqc"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/mvn/jaxb-runtime-parent/2.2.11/jaxb-runtime-parent-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "dd7834f63d08408fde8fbb58f1ea557bbb31d444",
-      "sha256": "144fllvdhajj6fzzzi046vch28k7h5frm40y4lj7z9pdwjw8r491"
+    "path": "com/sun/xml/bind/mvn/jaxb-runtime-parent/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-runtime-parent-2.2.11.pom": {
+        "sha1": "dd7834f63d08408fde8fbb58f1ea557bbb31d444",
+        "sha256": "144fllvdhajj6fzzzi046vch28k7h5frm40y4lj7z9pdwjw8r491"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/mvn/jaxb-txw-parent/2.2.11/jaxb-txw-parent-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "3fdc8adc054c5418bd76858dce64350bb8655ac5",
-      "sha256": "0b1nn9m3wwvklk1ap3nr295dj9fy1s4nhv05y5b3ngsxk9lqqfcs"
+    "path": "com/sun/xml/bind/mvn/jaxb-txw-parent/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-txw-parent-2.2.11.pom": {
+        "sha1": "3fdc8adc054c5418bd76858dce64350bb8655ac5",
+        "sha256": "0b1nn9m3wwvklk1ap3nr295dj9fy1s4nhv05y5b3ngsxk9lqqfcs"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/bind/mvn/jaxb-txw-parent/4.0.2/jaxb-txw-parent-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c9c99b4e33782535b5988616bc3b452543cb48e5",
-      "sha256": "0xxyqayffjwdmagqa6jqca8ykl3iz2vhw59l6478nv8ir268x2rn"
+    "path": "com/sun/xml/bind/mvn/jaxb-txw-parent/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-txw-parent-4.0.2.pom": {
+        "sha1": "c9c99b4e33782535b5988616bc3b452543cb48e5",
+        "sha256": "0xxyqayffjwdmagqa6jqca8ykl3iz2vhw59l6478nv8ir268x2rn"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/fastinfoset/FastInfoset/1.2.13/FastInfoset-1.2.13",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bc1ac953addb710ec08dcca6465bb1f6fcfd7ee9",
-      "sha256": "1lsm4vzj4n82la9bs72kvj4sgl8i2vvnjr9ym96mnjbxrw75wl5p"
-    },
-    "jar": {
-      "sha1": "098f56b9354e27bd2941cc5d461344e240ae51ae",
-      "sha256": "0f70phr6cysnrsbfsbmd318h81nvy5dcadqs1cy87hpk16wpv9r7"
+    "path": "com/sun/xml/fastinfoset/FastInfoset/1.2.13",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "FastInfoset-1.2.13.pom": {
+        "sha1": "bc1ac953addb710ec08dcca6465bb1f6fcfd7ee9",
+        "sha256": "1lsm4vzj4n82la9bs72kvj4sgl8i2vvnjr9ym96mnjbxrw75wl5p"
+      },
+      "FastInfoset-1.2.13.jar": {
+        "sha1": "098f56b9354e27bd2941cc5d461344e240ae51ae",
+        "sha256": "0f70phr6cysnrsbfsbmd318h81nvy5dcadqs1cy87hpk16wpv9r7"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/fastinfoset/FastInfoset/2.1.0/FastInfoset-2.1.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8a3328cc394e06c71de7147d4b8954f5fb3c4326",
-      "sha256": "15x95nrs7nlmq0p0s286zhr5lngj34k67fvgyim598fvhkmfbfch"
-    },
-    "jar": {
-      "sha1": "cd92e93ef4ee608bffe4ba41b1247846a3d42227",
-      "sha256": "08cdfkcib6840g7j7kpph4kdcqnpnn23sam6ljhixsvbmcd1cs5r"
+    "path": "com/sun/xml/fastinfoset/FastInfoset/2.1.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "FastInfoset-2.1.0.pom": {
+        "sha1": "8a3328cc394e06c71de7147d4b8954f5fb3c4326",
+        "sha256": "15x95nrs7nlmq0p0s286zhr5lngj34k67fvgyim598fvhkmfbfch"
+      },
+      "FastInfoset-2.1.0.jar": {
+        "sha1": "cd92e93ef4ee608bffe4ba41b1247846a3d42227",
+        "sha256": "08cdfkcib6840g7j7kpph4kdcqnpnn23sam6ljhixsvbmcd1cs5r"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/fastinfoset/fastinfoset-project/1.2.13/fastinfoset-project-1.2.13",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "db60407ed97748ffda8b69aee0dd10a82851640d",
-      "sha256": "0qf2kzp2qx62a13a70sv82yjcylnizir3z9gghlf0rqhky4mf27x"
+    "path": "com/sun/xml/fastinfoset/fastinfoset-project/1.2.13",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fastinfoset-project-1.2.13.pom": {
+        "sha1": "db60407ed97748ffda8b69aee0dd10a82851640d",
+        "sha256": "0qf2kzp2qx62a13a70sv82yjcylnizir3z9gghlf0rqhky4mf27x"
+      }
     }
   },
 
   {
-    "path": "com/sun/xml/fastinfoset/fastinfoset-project/2.1.0/fastinfoset-project-2.1.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "170bbdc773e5317f258728a71a4629e6ee17a0d1",
-      "sha256": "1skvxwcb5gm8ycxdnlni8dgpj5v1fld9azcfqwprn9kb9hhhq96c"
+    "path": "com/sun/xml/fastinfoset/fastinfoset-project/2.1.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fastinfoset-project-2.1.0.pom": {
+        "sha1": "170bbdc773e5317f258728a71a4629e6ee17a0d1",
+        "sha256": "1skvxwcb5gm8ycxdnlni8dgpj5v1fld9azcfqwprn9kb9hhhq96c"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4-annotations/4.5/antlr4-annotations-4.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3dfac370b3fca6f90861f3a10fd5445ca6f8cc1b",
-      "sha256": "1agr98zh9c7yjji5a5i99bcbdjx2zs7jj2vzj8lk8ms7rxia2l8s"
-    },
-    "jar": {
-      "sha1": "2c5996120a0ac690de575bd8ac36250e6720a6b8",
-      "sha256": "1h49j3bdmlrzfznwqg20bf1xx94ba602wnd94hk40lcxfs0v8b8b"
+    "path": "com/tunnelvisionlabs/antlr4-annotations/4.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-annotations-4.5.pom": {
+        "sha1": "3dfac370b3fca6f90861f3a10fd5445ca6f8cc1b",
+        "sha256": "1agr98zh9c7yjji5a5i99bcbdjx2zs7jj2vzj8lk8ms7rxia2l8s"
+      },
+      "antlr4-annotations-4.5.jar": {
+        "sha1": "2c5996120a0ac690de575bd8ac36250e6720a6b8",
+        "sha256": "1h49j3bdmlrzfznwqg20bf1xx94ba602wnd94hk40lcxfs0v8b8b"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4-annotations/4.9.0/antlr4-annotations-4.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a14e662f4a9928d9242c9bc9fbbe512bb561121e",
-      "sha256": "0kdimdpbyw06jzzfqirib0zinl7bf3vi2xjid0aqlid866vln4gx"
-    },
-    "jar": {
-      "sha1": "ef4a4a6528a74cc24b6f7f0f1711876e32ab54b7",
-      "sha256": "0y6bicws9kmihq0zhjz8cqv4fcgjbbzbya3jnw3b92qpqga57l07"
+    "path": "com/tunnelvisionlabs/antlr4-annotations/4.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-annotations-4.9.0.pom": {
+        "sha1": "a14e662f4a9928d9242c9bc9fbbe512bb561121e",
+        "sha256": "0kdimdpbyw06jzzfqirib0zinl7bf3vi2xjid0aqlid866vln4gx"
+      },
+      "antlr4-annotations-4.9.0.jar": {
+        "sha1": "ef4a4a6528a74cc24b6f7f0f1711876e32ab54b7",
+        "sha256": "0y6bicws9kmihq0zhjz8cqv4fcgjbbzbya3jnw3b92qpqga57l07"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4-master/4.5/antlr4-master-4.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "6dadb90adc9b3879a4fb9625b08711e578252dfb",
-      "sha256": "0cyhq62xqhlkivm5h29j4b48zcaglpmgdwfrg2jlqvvjax0h7lmv"
+    "path": "com/tunnelvisionlabs/antlr4-master/4.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-master-4.5.pom": {
+        "sha1": "6dadb90adc9b3879a4fb9625b08711e578252dfb",
+        "sha256": "0cyhq62xqhlkivm5h29j4b48zcaglpmgdwfrg2jlqvvjax0h7lmv"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4-master/4.9.0/antlr4-master-4.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "97a80ecc34d75a66b47753108406a0a1ef00a192",
-      "sha256": "108c4hbihlwvc8i18xznn72kr49xh8ibnl162rqiv7q5bgixcq1w"
+    "path": "com/tunnelvisionlabs/antlr4-master/4.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-master-4.9.0.pom": {
+        "sha1": "97a80ecc34d75a66b47753108406a0a1ef00a192",
+        "sha256": "108c4hbihlwvc8i18xznn72kr49xh8ibnl162rqiv7q5bgixcq1w"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4-runtime/4.5/antlr4-runtime-4.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4c01c62d899d8bd5112a182624fca9ae62d42c8e",
-      "sha256": "17hpdp5821c4hf22alm4j4slv42nlifc5f5y6qlis1i01scw1bpw"
-    },
-    "jar": {
-      "sha1": "5067478827a98f5ab77d9fc577903edc57af3da4",
-      "sha256": "1gfp423s00i5iaflhsyw51jllm4h56r5pgkrkrpvykyis9vrcwdq"
+    "path": "com/tunnelvisionlabs/antlr4-runtime/4.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-runtime-4.5.pom": {
+        "sha1": "4c01c62d899d8bd5112a182624fca9ae62d42c8e",
+        "sha256": "17hpdp5821c4hf22alm4j4slv42nlifc5f5y6qlis1i01scw1bpw"
+      },
+      "antlr4-runtime-4.5.jar": {
+        "sha1": "5067478827a98f5ab77d9fc577903edc57af3da4",
+        "sha256": "1gfp423s00i5iaflhsyw51jllm4h56r5pgkrkrpvykyis9vrcwdq"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4-runtime/4.9.0/antlr4-runtime-4.9.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "97e6da6d8bc827b5d9f6590fbfa8565511a8da5e",
-      "sha256": "07vgcbrfplqg50zsn206ri39bzlpfv0arbdab77np24zp57svddf"
-    },
-    "jar": {
-      "sha1": "17e19535a875a2a1014197d2bb35faeecf4e50f4",
-      "sha256": "1azzydlxx622galppy4rz5kxg5shia5k3nsvj0hgkvac0fl3n6g4"
+    "path": "com/tunnelvisionlabs/antlr4-runtime/4.9.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-runtime-4.9.0.pom": {
+        "sha1": "97e6da6d8bc827b5d9f6590fbfa8565511a8da5e",
+        "sha256": "07vgcbrfplqg50zsn206ri39bzlpfv0arbdab77np24zp57svddf"
+      },
+      "antlr4-runtime-4.9.0.jar": {
+        "sha1": "17e19535a875a2a1014197d2bb35faeecf4e50f4",
+        "sha256": "1azzydlxx622galppy4rz5kxg5shia5k3nsvj0hgkvac0fl3n6g4"
+      }
     }
   },
 
   {
-    "path": "com/tunnelvisionlabs/antlr4/4.5/antlr4-4.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2370f47fd57fbea37385e241dd7292bdcfbe8353",
-      "sha256": "1fq2v58lf2c4hqxdm3kvpf9h3p8x9p00sjh7qfipsj04hz7r2y1z"
-    },
-    "jar": {
-      "sha1": "a0e860e317147848e69ac145bc5196901a9993bf",
-      "sha256": "0vlqbcihfsgvkzsczp0h6ynz7wnf2d88kvhqfbn1hibry1y7h9wh"
+    "path": "com/tunnelvisionlabs/antlr4/4.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-4.5.pom": {
+        "sha1": "2370f47fd57fbea37385e241dd7292bdcfbe8353",
+        "sha256": "1fq2v58lf2c4hqxdm3kvpf9h3p8x9p00sjh7qfipsj04hz7r2y1z"
+      },
+      "antlr4-4.5.jar": {
+        "sha1": "a0e860e317147848e69ac145bc5196901a9993bf",
+        "sha256": "0vlqbcihfsgvkzsczp0h6ynz7wnf2d88kvhqfbn1hibry1y7h9wh"
+      }
     }
   },
 
   {
-    "path": "de/undercouch/gradle-download-task/3.4.3/gradle-download-task-3.4.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5de056d460c87dda189856743e9bb6708bc1b1b0",
-      "sha256": "1rd9g541fx9bw8yq2a039mh7qzpn0rpsg22smrg0y96jd6zhyc68"
-    },
-    "jar": {
-      "sha1": "87aa1c57a1dd0da91488afe630058efb5d8068b1",
-      "sha256": "0gnl604csyb7kqzbwdwglw9icbligvwarcn7nwi524889c2kfdj5"
+    "path": "de/undercouch/gradle-download-task/3.4.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-download-task-3.4.3.pom": {
+        "sha1": "5de056d460c87dda189856743e9bb6708bc1b1b0",
+        "sha256": "1rd9g541fx9bw8yq2a039mh7qzpn0rpsg22smrg0y96jd6zhyc68"
+      },
+      "gradle-download-task-3.4.3.jar": {
+        "sha1": "87aa1c57a1dd0da91488afe630058efb5d8068b1",
+        "sha256": "0gnl604csyb7kqzbwdwglw9icbligvwarcn7nwi524889c2kfdj5"
+      }
     }
   },
 
   {
-    "path": "de/undercouch/gradle-download-task/4.0.2/gradle-download-task-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b10fd2808b4fb28de573daecd9231d4db3bd205e",
-      "sha256": "01ql9iq9bypkdf3j3n4kfzc2lj60fi4y75byfbzbq07mdskwaq81"
-    },
-    "jar": {
-      "sha1": "2aaf2b081cd0dd5b3cf25fde69a20b043dd46fbd",
-      "sha256": "0yp86iysar3x116x87a4b29862dg92k5pk15b75yrgi1bz6byb4m"
+    "path": "de/undercouch/gradle-download-task/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "gradle-download-task-4.0.2.pom": {
+        "sha1": "b10fd2808b4fb28de573daecd9231d4db3bd205e",
+        "sha256": "01ql9iq9bypkdf3j3n4kfzc2lj60fi4y75byfbzbq07mdskwaq81"
+      },
+      "gradle-download-task-4.0.2.jar": {
+        "sha1": "2aaf2b081cd0dd5b3cf25fde69a20b043dd46fbd",
+        "sha256": "0yp86iysar3x116x87a4b29862dg92k5pk15b75yrgi1bz6byb4m"
+      }
     }
   },
 
   {
-    "path": "it/unimi/dsi/fastutil/7.2.0/fastutil-7.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e068a0be19991231f5020d2748e709325bb745f2",
-      "sha256": "1xry05xcp4r1r0kk16idpf4b0bw9db1z5qwhx7p7add745ji2fwm"
-    },
-    "jar": {
-      "sha1": "5ad3a2bb04143f70aa0765fc29fc29571a7d6b34",
-      "sha256": "072r9dp1605ixwh31kjh5ynihlln2nxgl2gbwvvl41kl8f021ykl"
+    "path": "it/unimi/dsi/fastutil/7.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "fastutil-7.2.0.pom": {
+        "sha1": "e068a0be19991231f5020d2748e709325bb745f2",
+        "sha256": "1xry05xcp4r1r0kk16idpf4b0bw9db1z5qwhx7p7add745ji2fwm"
+      },
+      "fastutil-7.2.0.jar": {
+        "sha1": "5ad3a2bb04143f70aa0765fc29fc29571a7d6b34",
+        "sha256": "072r9dp1605ixwh31kjh5ynihlln2nxgl2gbwvvl41kl8f021ykl"
+      }
     }
   },
 
   {
-    "path": "jakarta/activation/jakarta.activation-api/2.1.1/jakarta.activation-api-2.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0c6e1dbee7b7faf7c9c8b7274a8b6279415cac6a",
-      "sha256": "006awx3sv5lc6ngsnrvgij6m9dhhrxqwy1gkkf3p9agdxzw5jck9"
-    },
-    "jar": {
-      "sha1": "88c774ab863a21fb2fc4219af95379fafe499a31",
-      "sha256": "010s9784kcs97whlpyy7pd2dp71m62hh5n41zix5mfrdy7qf7fik"
+    "path": "jakarta/activation/jakarta.activation-api/2.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jakarta.activation-api-2.1.1.pom": {
+        "sha1": "0c6e1dbee7b7faf7c9c8b7274a8b6279415cac6a",
+        "sha256": "006awx3sv5lc6ngsnrvgij6m9dhhrxqwy1gkkf3p9agdxzw5jck9"
+      },
+      "jakarta.activation-api-2.1.1.jar": {
+        "sha1": "88c774ab863a21fb2fc4219af95379fafe499a31",
+        "sha256": "010s9784kcs97whlpyy7pd2dp71m62hh5n41zix5mfrdy7qf7fik"
+      }
     }
   },
 
   {
-    "path": "jakarta/xml/bind/jakarta.xml.bind-api-parent/4.0.0/jakarta.xml.bind-api-parent-4.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "858b9345f7027aa676178d259ddc09081fbbbd0b",
-      "sha256": "1409w657g09lzmzjwgs1pw5bjwnamv6vmiyiy2ydr2hyavfvhmg2"
+    "path": "jakarta/xml/bind/jakarta.xml.bind-api-parent/4.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jakarta.xml.bind-api-parent-4.0.0.pom": {
+        "sha1": "858b9345f7027aa676178d259ddc09081fbbbd0b",
+        "sha256": "1409w657g09lzmzjwgs1pw5bjwnamv6vmiyiy2ydr2hyavfvhmg2"
+      }
     }
   },
 
   {
-    "path": "jakarta/xml/bind/jakarta.xml.bind-api/4.0.0/jakarta.xml.bind-api-4.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c59c050f02c9c214baf1d1917999672289484bc1",
-      "sha256": "0aq0jk3b65sr9f8g9gxzrk45zkzwrk65y2mn4r5a9j6rdsaavmkb"
-    },
-    "jar": {
-      "sha1": "bbb399208d288b15ec101fa4fcfc4bd77cedc97a",
-      "sha256": "08m1b98sa69yx8lhbnfsnx8c5wl3q59kr7aziw440dkmsmm7kqsp"
+    "path": "jakarta/xml/bind/jakarta.xml.bind-api/4.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jakarta.xml.bind-api-4.0.0.pom": {
+        "sha1": "c59c050f02c9c214baf1d1917999672289484bc1",
+        "sha256": "0aq0jk3b65sr9f8g9gxzrk45zkzwrk65y2mn4r5a9j6rdsaavmkb"
+      },
+      "jakarta.xml.bind-api-4.0.0.jar": {
+        "sha1": "bbb399208d288b15ec101fa4fcfc4bd77cedc97a",
+        "sha256": "08m1b98sa69yx8lhbnfsnx8c5wl3q59kr7aziw440dkmsmm7kqsp"
+      }
     }
   },
 
   {
-    "path": "javax/activation/activation/1.1/activation-1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fd9dd0faa8f03f3ce0dc4eec22e57e818d8b9897",
-      "sha256": "1858z9c6s1wvacj0hab14f0fcgbvxxgwic8q2zbvj10ml50fb46l"
-    },
-    "jar": {
-      "sha1": "e6cb541461c2834bdea3eb920f1884d1eb508b50",
-      "sha256": "1lydzpg7crvfmncc2bvgl6xbij0sklza3vibwrc1rw3fknfcg098"
+    "path": "javax/activation/activation/1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "activation-1.1.pom": {
+        "sha1": "fd9dd0faa8f03f3ce0dc4eec22e57e818d8b9897",
+        "sha256": "1858z9c6s1wvacj0hab14f0fcgbvxxgwic8q2zbvj10ml50fb46l"
+      },
+      "activation-1.1.jar": {
+        "sha1": "e6cb541461c2834bdea3eb920f1884d1eb508b50",
+        "sha256": "1lydzpg7crvfmncc2bvgl6xbij0sklza3vibwrc1rw3fknfcg098"
+      }
     }
   },
 
   {
-    "path": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1aa9ef58e50ba6868b2e955d61fcd73be5b4cea5",
-      "sha256": "1fbivrmb0xq1z9q5fwxjgyjm20qbvv3dxb0hri1qd2dyr3rjcafs"
-    },
-    "jar": {
-      "sha1": "85262acf3ca9816f9537ca47d5adeabaead7cb16",
-      "sha256": "14s3rasvibnkdwzppsyfqbx5iavl1j9qn82b8aq33svcbc5yzza3"
+    "path": "javax/activation/javax.activation-api/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "javax.activation-api-1.2.0.pom": {
+        "sha1": "1aa9ef58e50ba6868b2e955d61fcd73be5b4cea5",
+        "sha256": "1fbivrmb0xq1z9q5fwxjgyjm20qbvv3dxb0hri1qd2dyr3rjcafs"
+      },
+      "javax.activation-api-1.2.0.jar": {
+        "sha1": "85262acf3ca9816f9537ca47d5adeabaead7cb16",
+        "sha256": "14s3rasvibnkdwzppsyfqbx5iavl1j9qn82b8aq33svcbc5yzza3"
+      }
     }
   },
 
   {
-    "path": "javax/inject/javax.inject/1/javax.inject-1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b8e00a8a0deb0ebef447570e37ff8146ccd92cbe",
-      "sha256": "1ylb39if9gqyj98fccb54s0ad25p19d811d2ixih8y3202qi4gll"
-    },
-    "jar": {
-      "sha1": "6975da39a7040257bd51d21a231b76c915872d38",
-      "sha256": "1zz7gnahy2352345411rjlhsf64ikkc6z49dqcv1cj0clm271iwi"
+    "path": "javax/inject/javax.inject/1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "javax.inject-1.pom": {
+        "sha1": "b8e00a8a0deb0ebef447570e37ff8146ccd92cbe",
+        "sha256": "1ylb39if9gqyj98fccb54s0ad25p19d811d2ixih8y3202qi4gll"
+      },
+      "javax.inject-1.jar": {
+        "sha1": "6975da39a7040257bd51d21a231b76c915872d38",
+        "sha256": "1zz7gnahy2352345411rjlhsf64ikkc6z49dqcv1cj0clm271iwi"
+      }
     }
   },
 
   {
-    "path": "javax/xml/bind/jaxb-api-parent/2.4.0-b180830.0359/jaxb-api-parent-2.4.0-b180830.0359",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0dba9e0dbd65de0095f5be19cf10bd838b11a4c6",
-      "sha256": "1f5lyidfpwzjz5bbr17cx72417177blz2j6h2l7j7ljqr3i35lbj"
+    "path": "javax/xml/bind/jaxb-api-parent/2.4.0-b180830.0359",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-api-parent-2.4.0-b180830.0359.pom": {
+        "sha1": "0dba9e0dbd65de0095f5be19cf10bd838b11a4c6",
+        "sha256": "1f5lyidfpwzjz5bbr17cx72417177blz2j6h2l7j7ljqr3i35lbj"
+      }
     }
   },
 
   {
-    "path": "javax/xml/bind/jaxb-api/2.2.12-b140109.1041/jaxb-api-2.2.12-b140109.1041",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a400fbd62fa68fae267b5641c3e4bb740a0f7335",
-      "sha256": "0nqm2szwfjfmb9dnvrisr145r492csjdwjq9kg2rhmmwv7cag4i0"
-    },
-    "jar": {
-      "sha1": "7ed0e0d01198614194d56dfb03d9d95aa311824c",
-      "sha256": "1whi48cdrzjwp13hnpa9sg719gagiw0dvibl9b703zxmnzc0rrmm"
+    "path": "javax/xml/bind/jaxb-api/2.2.12-b140109.1041",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-api-2.2.12-b140109.1041.pom": {
+        "sha1": "a400fbd62fa68fae267b5641c3e4bb740a0f7335",
+        "sha256": "0nqm2szwfjfmb9dnvrisr145r492csjdwjq9kg2rhmmwv7cag4i0"
+      },
+      "jaxb-api-2.2.12-b140109.1041.jar": {
+        "sha1": "7ed0e0d01198614194d56dfb03d9d95aa311824c",
+        "sha256": "1whi48cdrzjwp13hnpa9sg719gagiw0dvibl9b703zxmnzc0rrmm"
+      }
     }
   },
 
   {
-    "path": "javax/xml/bind/jaxb-api/2.4.0-b180830.0359/jaxb-api-2.4.0-b180830.0359",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8094057c54ba7d482d78c7a5bfe2c9e316713808",
-      "sha256": "01rphzzw612mhcizb4gwzxza6795k4r9bl8kvr6gxxfp071kzjdi"
-    },
-    "jar": {
-      "sha1": "b54184b7dcab2031add3f525550c7f1b7e12209d",
-      "sha256": "0dmq8z2ishf06bq21fbar3pwzvsmh1wflqji8c3k0xjk4xqfkfan"
+    "path": "javax/xml/bind/jaxb-api/2.4.0-b180830.0359",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-api-2.4.0-b180830.0359.pom": {
+        "sha1": "8094057c54ba7d482d78c7a5bfe2c9e316713808",
+        "sha256": "01rphzzw612mhcizb4gwzxza6795k4r9bl8kvr6gxxfp071kzjdi"
+      },
+      "jaxb-api-2.4.0-b180830.0359.jar": {
+        "sha1": "b54184b7dcab2031add3f525550c7f1b7e12209d",
+        "sha256": "0dmq8z2ishf06bq21fbar3pwzvsmh1wflqji8c3k0xjk4xqfkfan"
+      }
     }
   },
 
   {
-    "path": "javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5379b69f557c5ab7c144d22bf7c3768bd2adb93d",
-      "sha256": "18plb968iz0gfvjb8gmcrayfqbcvfxqpl6assxijgmagm2fz2r18"
-    },
-    "jar": {
-      "sha1": "d6337b0de8b25e53e81b922352fbea9f9f57ba0b",
-      "sha256": "1dw90348ijbzgg5sbp54lic7sjp1dk7q5vw259cck0prfsyhxiz8"
+    "path": "javax/xml/stream/stax-api/1.0-2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "stax-api-1.0-2.pom": {
+        "sha1": "5379b69f557c5ab7c144d22bf7c3768bd2adb93d",
+        "sha256": "18plb968iz0gfvjb8gmcrayfqbcvfxqpl6assxijgmagm2fz2r18"
+      },
+      "stax-api-1.0-2.jar": {
+        "sha1": "d6337b0de8b25e53e81b922352fbea9f9f57ba0b",
+        "sha256": "1dw90348ijbzgg5sbp54lic7sjp1dk7q5vw259cck0prfsyhxiz8"
+      }
     }
   },
 
   {
-    "path": "junit/junit/4.12/junit-4.12",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "35fb238baee3f3af739074d723279ebea2028398",
-      "sha256": "1i29aji7rribs7b8a6ql0xca5vm4xgkyjzfrg8f6zyrzivvn7wch"
-    },
-    "jar": {
-      "sha1": "2973d150c0dc1fefe998f834810d68f278ea58ec",
-      "sha256": "0shibkq1faqc7j8cl0n5swscazanzzcqfy37j15xh8z20l41ywjr"
+    "path": "junit/junit/4.12",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "junit-4.12.pom": {
+        "sha1": "35fb238baee3f3af739074d723279ebea2028398",
+        "sha256": "1i29aji7rribs7b8a6ql0xca5vm4xgkyjzfrg8f6zyrzivvn7wch"
+      },
+      "junit-4.12.jar": {
+        "sha1": "2973d150c0dc1fefe998f834810d68f278ea58ec",
+        "sha256": "0shibkq1faqc7j8cl0n5swscazanzzcqfy37j15xh8z20l41ywjr"
+      }
     }
   },
 
   {
-    "path": "junit/junit/4.13.2/junit-4.13.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "73bc5be628edeb297a1caf421a5a2e494798b92f",
-      "sha256": "156xxa4wv4nh9nbbc3hnn28r55kfz9c30v64q5jwj0s6xrvnk6sn"
-    },
-    "jar": {
-      "sha1": "8ac9e16d933b6fb43bc7f576336b8f4d7eb5ba12",
-      "sha256": "1lspvhb4rgh723iy2p7mzyhcib6bcnh9ad7smjw4zmk98iimnjcf"
+    "path": "junit/junit/4.13.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "junit-4.13.2.pom": {
+        "sha1": "73bc5be628edeb297a1caf421a5a2e494798b92f",
+        "sha256": "156xxa4wv4nh9nbbc3hnn28r55kfz9c30v64q5jwj0s6xrvnk6sn"
+      },
+      "junit-4.13.2.jar": {
+        "sha1": "8ac9e16d933b6fb43bc7f576336b8f4d7eb5ba12",
+        "sha256": "1lspvhb4rgh723iy2p7mzyhcib6bcnh9ad7smjw4zmk98iimnjcf"
+      }
     }
   },
 
   {
-    "path": "me/zhanghai/android/materialprogressbar/library/1.4.2/library-1.4.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "fdab48c3bb74d27b46bceba3dde7b3a65752ebb2",
-      "sha256": "09xnsbf7jw9knb27iy910zw6bbkwc28vlm3pia759v9sf2kgvc6b"
-    },
-    "jar": {
-      "sha1": "6bd6cd6e9107e22a5d3b4d3d3713a6864aae854e",
-      "sha256": "1l18l8sddwj1gfrf71pbkhlr9356j7rqjn829zi4l9wsf4zinn7p"
+    "path": "me/zhanghai/android/materialprogressbar/library/1.4.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "library-1.4.2.pom": {
+        "sha1": "fdab48c3bb74d27b46bceba3dde7b3a65752ebb2",
+        "sha256": "09xnsbf7jw9knb27iy910zw6bbkwc28vlm3pia759v9sf2kgvc6b"
+      },
+      "library-1.4.2.aar": {
+        "sha1": "6bd6cd6e9107e22a5d3b4d3d3713a6864aae854e",
+        "sha256": "1l18l8sddwj1gfrf71pbkhlr9356j7rqjn829zi4l9wsf4zinn7p"
+      }
     }
   },
 
   {
-    "path": "net/java/jvnet-parent/1/jvnet-parent-1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "b55a1b046dbe82acdee8edde7476eebcba1e57d8",
-      "sha256": "1gv37n9aid7fdhwd0h4py024w8by56cchg3b4sg5vrk82a0l0518"
+    "path": "net/java/jvnet-parent/1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jvnet-parent-1.pom": {
+        "sha1": "b55a1b046dbe82acdee8edde7476eebcba1e57d8",
+        "sha256": "1gv37n9aid7fdhwd0h4py024w8by56cchg3b4sg5vrk82a0l0518"
+      }
     }
   },
 
   {
-    "path": "net/java/jvnet-parent/3/jvnet-parent-3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "f8f3be3e980551a39b5679411e171aeb6931aaec",
-      "sha256": "0nj7958drckwf634cw9gmwgmdi302bya7bas16bbzp9rzag7ix9h"
+    "path": "net/java/jvnet-parent/3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jvnet-parent-3.pom": {
+        "sha1": "f8f3be3e980551a39b5679411e171aeb6931aaec",
+        "sha256": "0nj7958drckwf634cw9gmwgmdi302bya7bas16bbzp9rzag7ix9h"
+      }
     }
   },
 
   {
-    "path": "net/java/jvnet-parent/4/jvnet-parent-4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a80cde31667f91784a6c68a06b5c6a77418f7822",
-      "sha256": "1fwgpdx4jznjhqspgzr040q932z06ad9p4zzr2bm4ja9amrra4s7"
+    "path": "net/java/jvnet-parent/4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jvnet-parent-4.pom": {
+        "sha1": "a80cde31667f91784a6c68a06b5c6a77418f7822",
+        "sha256": "1fwgpdx4jznjhqspgzr040q932z06ad9p4zzr2bm4ja9amrra4s7"
+      }
     }
   },
 
   {
-    "path": "net/java/jvnet-parent/5/jvnet-parent-5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "5343c954d21549d039feebe5fadef023cdfc1388",
-      "sha256": "02nbr5jk9ynaaky5zzbdb8m3dc2yj7bzn0njl3wngayxv7w9kxhs"
+    "path": "net/java/jvnet-parent/5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jvnet-parent-5.pom": {
+        "sha1": "5343c954d21549d039feebe5fadef023cdfc1388",
+        "sha256": "02nbr5jk9ynaaky5zzbdb8m3dc2yj7bzn0njl3wngayxv7w9kxhs"
+      }
     }
   },
 
   {
-    "path": "net/sf/jopt-simple/jopt-simple/4.9/jopt-simple-4.9",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ea3cd0a93e4e8adc1cdadd544c9168bc5aa985a8",
-      "sha256": "14lh0wb5jml18h2w45z0nibpa6xxkx6a4z9b9kq9hisbnbcf5xvs"
-    },
-    "jar": {
-      "sha1": "ee9e9eaa0a35360dcfeac129ff4923215fd65904",
-      "sha256": "1xgjp8k4d258pab0p4zxz7n6x75m35lvh4vgnx6qcpsbjmp8bi96"
+    "path": "net/sf/jopt-simple/jopt-simple/4.9",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jopt-simple-4.9.pom": {
+        "sha1": "ea3cd0a93e4e8adc1cdadd544c9168bc5aa985a8",
+        "sha256": "14lh0wb5jml18h2w45z0nibpa6xxkx6a4z9b9kq9hisbnbcf5xvs"
+      },
+      "jopt-simple-4.9.jar": {
+        "sha1": "ee9e9eaa0a35360dcfeac129ff4923215fd65904",
+        "sha256": "1xgjp8k4d258pab0p4zxz7n6x75m35lvh4vgnx6qcpsbjmp8bi96"
+      }
     }
   },
 
   {
-    "path": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8efa75f9cdc57687076b2125b1a098e6f42e737d",
-      "sha256": "11d66hzaang99y3wkrqxzn2y2qgsg34jf3dvk5i9664m9rpn1kii"
-    },
-    "jar": {
-      "sha1": "ccbc77a5fd907ef863c29f3596c6f54ffa4e9442",
-      "sha256": "1qixcdxqmw7ja9yhp0qw6g4y8jzjxwhk5igcwl6f3zd1g6gxsr7j"
+    "path": "net/sf/kxml/kxml2/2.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kxml2-2.3.0.pom": {
+        "sha1": "8efa75f9cdc57687076b2125b1a098e6f42e737d",
+        "sha256": "11d66hzaang99y3wkrqxzn2y2qgsg34jf3dvk5i9664m9rpn1kii"
+      },
+      "kxml2-2.3.0.jar": {
+        "sha1": "ccbc77a5fd907ef863c29f3596c6f54ffa4e9442",
+        "sha256": "1qixcdxqmw7ja9yhp0qw6g4y8jzjxwhk5igcwl6f3zd1g6gxsr7j"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-base/5.1/proguard-base-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a6348683c2a61ce93afd3715ce29075cdeb8b07e",
-      "sha256": "01j9i5akzpdxm66s0b6s3fzwmf38dz9jvx40yyz4afb0hwa920hb"
-    },
-    "jar": {
-      "sha1": "dc606dd778fe4685be16d5a171782ccfe0ef5637",
-      "sha256": "1cjmzwg2is2lm79ay4pmgb4qkij01sxjwq28kjysiys5wl6c3gpy"
+    "path": "net/sf/proguard/proguard-base/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-base-5.1.pom": {
+        "sha1": "a6348683c2a61ce93afd3715ce29075cdeb8b07e",
+        "sha256": "01j9i5akzpdxm66s0b6s3fzwmf38dz9jvx40yyz4afb0hwa920hb"
+      },
+      "proguard-base-5.1.jar": {
+        "sha1": "dc606dd778fe4685be16d5a171782ccfe0ef5637",
+        "sha256": "1cjmzwg2is2lm79ay4pmgb4qkij01sxjwq28kjysiys5wl6c3gpy"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-base/5.2.1/proguard-base-5.2.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "03e04f64ce189b9cfa7e08baae0d6f657a0204fd",
-      "sha256": "1hrsv9fkjyn11sbrizqzlyppckr2hfc271j5vzlbx10ddrsfr0bg"
-    },
-    "jar": {
-      "sha1": "4f61348b4e7c943b85679dcb697f3a5fc3101921",
-      "sha256": "1gzkcgg9aamxnda5vjzahaylv6dl0bbga55bi6vwkjsq7kbvsqzi"
+    "path": "net/sf/proguard/proguard-base/5.2.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-base-5.2.1.pom": {
+        "sha1": "03e04f64ce189b9cfa7e08baae0d6f657a0204fd",
+        "sha256": "1hrsv9fkjyn11sbrizqzlyppckr2hfc271j5vzlbx10ddrsfr0bg"
+      },
+      "proguard-base-5.2.1.jar": {
+        "sha1": "4f61348b4e7c943b85679dcb697f3a5fc3101921",
+        "sha256": "1gzkcgg9aamxnda5vjzahaylv6dl0bbga55bi6vwkjsq7kbvsqzi"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-base/5.3.3/proguard-base-5.3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6216930869e6faab2954ce7075727f64c606f3a8",
-      "sha256": "1jnr6zsxfimb8wglqlwa6rrdc3g3nqf1dyw0k2dq9cj0q4pgn7p5"
-    },
-    "jar": {
-      "sha1": "988b6b0636ce343d4962b3b37f6319dcc6e99a61",
-      "sha256": "11nwdb9y84cghcx319nsjjf9m035s4s1184zrhzpvaxq2wvqhbhx"
+    "path": "net/sf/proguard/proguard-base/5.3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-base-5.3.3.pom": {
+        "sha1": "6216930869e6faab2954ce7075727f64c606f3a8",
+        "sha256": "1jnr6zsxfimb8wglqlwa6rrdc3g3nqf1dyw0k2dq9cj0q4pgn7p5"
+      },
+      "proguard-base-5.3.3.jar": {
+        "sha1": "988b6b0636ce343d4962b3b37f6319dcc6e99a61",
+        "sha256": "11nwdb9y84cghcx319nsjjf9m035s4s1184zrhzpvaxq2wvqhbhx"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-base/6.0.3/proguard-base-6.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d53b864b20f6ab75c66017adcb06c44a912a2076",
-      "sha256": "01s9xmjv2v7hc5p0zgpghabr6php3dnlcffmi2lq4mb7y9wkv0ia"
-    },
-    "jar": {
-      "sha1": "7135739d2d3834964c543ed21e2936ce34747aca",
-      "sha256": "0r6jm7qb28qaxmp3ip96v2qhlvs00aw3k96d9qvpavm6bxlqkg3m"
+    "path": "net/sf/proguard/proguard-base/6.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-base-6.0.3.pom": {
+        "sha1": "d53b864b20f6ab75c66017adcb06c44a912a2076",
+        "sha256": "01s9xmjv2v7hc5p0zgpghabr6php3dnlcffmi2lq4mb7y9wkv0ia"
+      },
+      "proguard-base-6.0.3.jar": {
+        "sha1": "7135739d2d3834964c543ed21e2936ce34747aca",
+        "sha256": "0r6jm7qb28qaxmp3ip96v2qhlvs00aw3k96d9qvpavm6bxlqkg3m"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-base/6.3.0beta1/proguard-base-6.3.0beta1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6ec223be63e45327a5ec8fdd4620e25f6ce4c82a",
-      "sha256": "19bpziflmlsvbds6hysh0fig7m835chgx8ix500wii728lqpcln6"
-    },
-    "jar": {
-      "sha1": "997b026bff2518c12194d5cd967bd28970d3c3a9",
-      "sha256": "02zrm05slm8y3vhs6s3k5mk31ncgd9c0r0s1qmdbp8nbfff862y4"
+    "path": "net/sf/proguard/proguard-base/6.3.0beta1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-base-6.3.0beta1.pom": {
+        "sha1": "6ec223be63e45327a5ec8fdd4620e25f6ce4c82a",
+        "sha256": "19bpziflmlsvbds6hysh0fig7m835chgx8ix500wii728lqpcln6"
+      },
+      "proguard-base-6.3.0beta1.jar": {
+        "sha1": "997b026bff2518c12194d5cd967bd28970d3c3a9",
+        "sha256": "02zrm05slm8y3vhs6s3k5mk31ncgd9c0r0s1qmdbp8nbfff862y4"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-gradle/5.1/proguard-gradle-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9e149e6d2dea6f6cb582b17d1c444a30bd3945be",
-      "sha256": "0a1sz8idwsa3rasjhcfcxnj5wk60vmvimjs1g907gpcc92vn0aqm"
-    },
-    "jar": {
-      "sha1": "0672d43cbfde4765080e5bea19c51a2cc45dfc00",
-      "sha256": "0yrqzqbxf9jhf04d2mmjsmcj7cac7bg53kgz95hzcs7xxyg7iymh"
+    "path": "net/sf/proguard/proguard-gradle/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-gradle-5.1.pom": {
+        "sha1": "9e149e6d2dea6f6cb582b17d1c444a30bd3945be",
+        "sha256": "0a1sz8idwsa3rasjhcfcxnj5wk60vmvimjs1g907gpcc92vn0aqm"
+      },
+      "proguard-gradle-5.1.jar": {
+        "sha1": "0672d43cbfde4765080e5bea19c51a2cc45dfc00",
+        "sha256": "0yrqzqbxf9jhf04d2mmjsmcj7cac7bg53kgz95hzcs7xxyg7iymh"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-gradle/5.2.1/proguard-gradle-5.2.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3f835379d233d3c8dc6076dcfc5e38d077b8ac4b",
-      "sha256": "0q9d1ayqzcp1g7ypylk3xqnxii2q32dzq4km743f8cpaax7kspbg"
-    },
-    "jar": {
-      "sha1": "5e9956c050fd84fa043517e77c4c0ff175a6b002",
-      "sha256": "1fy7i6ddbd1qjlkz9yahgnymx6ja6lg84sihiqagsrgk0m54rc7g"
+    "path": "net/sf/proguard/proguard-gradle/5.2.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-gradle-5.2.1.pom": {
+        "sha1": "3f835379d233d3c8dc6076dcfc5e38d077b8ac4b",
+        "sha256": "0q9d1ayqzcp1g7ypylk3xqnxii2q32dzq4km743f8cpaax7kspbg"
+      },
+      "proguard-gradle-5.2.1.jar": {
+        "sha1": "5e9956c050fd84fa043517e77c4c0ff175a6b002",
+        "sha256": "1fy7i6ddbd1qjlkz9yahgnymx6ja6lg84sihiqagsrgk0m54rc7g"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-gradle/5.3.3/proguard-gradle-5.3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "57a3eda3d39f004a8cfc724f1a98af89b91f79c2",
-      "sha256": "03v9zm3ykfkyb5cs5ald07ph103fh68d5c33rv070r29p71dwszj"
-    },
-    "jar": {
-      "sha1": "ad23a0505f58d0dfc95bb1472decc397460406c9",
-      "sha256": "0shhpsjfc5gam15jnv1hk718v5c7vi7dwdc3gvmnid6dc85kljzk"
+    "path": "net/sf/proguard/proguard-gradle/5.3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-gradle-5.3.3.pom": {
+        "sha1": "57a3eda3d39f004a8cfc724f1a98af89b91f79c2",
+        "sha256": "03v9zm3ykfkyb5cs5ald07ph103fh68d5c33rv070r29p71dwszj"
+      },
+      "proguard-gradle-5.3.3.jar": {
+        "sha1": "ad23a0505f58d0dfc95bb1472decc397460406c9",
+        "sha256": "0shhpsjfc5gam15jnv1hk718v5c7vi7dwdc3gvmnid6dc85kljzk"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-gradle/6.0.3/proguard-gradle-6.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6583a613d9b6d02a699d4dd24d8b8825da3d8e8b",
-      "sha256": "0msslcrlhqrkwd3529kcn78l4kc1717bvn6980fhvs4csqbp6p2s"
-    },
-    "jar": {
-      "sha1": "e5becf2356695a396b788110e386c38bad523bfc",
-      "sha256": "13qcl1yb819arw80xxran9sghjhsq6zgwz381vfr252jiqbb24nc"
+    "path": "net/sf/proguard/proguard-gradle/6.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-gradle-6.0.3.pom": {
+        "sha1": "6583a613d9b6d02a699d4dd24d8b8825da3d8e8b",
+        "sha256": "0msslcrlhqrkwd3529kcn78l4kc1717bvn6980fhvs4csqbp6p2s"
+      },
+      "proguard-gradle-6.0.3.jar": {
+        "sha1": "e5becf2356695a396b788110e386c38bad523bfc",
+        "sha256": "13qcl1yb819arw80xxran9sghjhsq6zgwz381vfr252jiqbb24nc"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-parent/5.1/proguard-parent-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c65dbd15e3b2300d94ecdae09a6ad61611024ee7",
-      "sha256": "1piwkby3x60jb4z1xkzsfs98h1yd5j313ci6i2ywrx2hkkd7v2ga"
+    "path": "net/sf/proguard/proguard-parent/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-parent-5.1.pom": {
+        "sha1": "c65dbd15e3b2300d94ecdae09a6ad61611024ee7",
+        "sha256": "1piwkby3x60jb4z1xkzsfs98h1yd5j313ci6i2ywrx2hkkd7v2ga"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-parent/5.2.1/proguard-parent-5.2.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "01bc4a2b3094f3e2112e61398e15bfb067841eed",
-      "sha256": "01l30ijq5r8slw6jd9ya6v0lpyr09r3al1nd1a2wixfpmpd0499f"
+    "path": "net/sf/proguard/proguard-parent/5.2.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-parent-5.2.1.pom": {
+        "sha1": "01bc4a2b3094f3e2112e61398e15bfb067841eed",
+        "sha256": "01l30ijq5r8slw6jd9ya6v0lpyr09r3al1nd1a2wixfpmpd0499f"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-parent/5.3.3/proguard-parent-5.3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "45c24fb869b3c809c0a1a00081fc353184c2472c",
-      "sha256": "0mv0zbwyw8xa4mkc5kw69y5xqashkz9gp123akfvh9f6152l3202"
+    "path": "net/sf/proguard/proguard-parent/5.3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-parent-5.3.3.pom": {
+        "sha1": "45c24fb869b3c809c0a1a00081fc353184c2472c",
+        "sha256": "0mv0zbwyw8xa4mkc5kw69y5xqashkz9gp123akfvh9f6152l3202"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-parent/6.0.3/proguard-parent-6.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "f76c32555b227be8f5d8c753ccc7f49c5196345e",
-      "sha256": "1870dlyd0cvsp31jg05irr4c8dgs18qhkisadh1knb1isazncwnq"
+    "path": "net/sf/proguard/proguard-parent/6.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-parent-6.0.3.pom": {
+        "sha1": "f76c32555b227be8f5d8c753ccc7f49c5196345e",
+        "sha256": "1870dlyd0cvsp31jg05irr4c8dgs18qhkisadh1knb1isazncwnq"
+      }
     }
   },
 
   {
-    "path": "net/sf/proguard/proguard-parent/6.3.0beta1/proguard-parent-6.3.0beta1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "6a0ab47c2c7ca00006ca9e69048beb25907daa31",
-      "sha256": "1pz2l1yjcsqdyhzjyxkws0cmzhjl1xnsyfphcxy3c41v2xvkr25y"
+    "path": "net/sf/proguard/proguard-parent/6.3.0beta1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "proguard-parent-6.3.0beta1.pom": {
+        "sha1": "6a0ab47c2c7ca00006ca9e69048beb25907daa31",
+        "sha256": "1pz2l1yjcsqdyhzjyxkws0cmzhjl1xnsyfphcxy3c41v2xvkr25y"
+      }
     }
   },
 
   {
-    "path": "org/abego/treelayout/org.abego.treelayout.core/1.0.1/org.abego.treelayout.core-1.0.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e8da72b4e31c6610ca57fde5f73d5ee4d1d5f957",
-      "sha256": "04gay2b7ma8jggas3z4l0cm6j03cm4b3azr89w6l8w79ck5bz33w"
-    },
-    "jar": {
-      "sha1": "e31e79cba7a5414cf18fa69f3f0a2cf9ee997b61",
-      "sha256": "1l5ihcxdr8ci4bcgh5bzpcfsin40fzwpiyhna88qqw6c39iy7fc2"
+    "path": "org/abego/treelayout/org.abego.treelayout.core/1.0.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "org.abego.treelayout.core-1.0.1.pom": {
+        "sha1": "e8da72b4e31c6610ca57fde5f73d5ee4d1d5f957",
+        "sha256": "04gay2b7ma8jggas3z4l0cm6j03cm4b3azr89w6l8w79ck5bz33w"
+      },
+      "org.abego.treelayout.core-1.0.1.jar": {
+        "sha1": "e31e79cba7a5414cf18fa69f3f0a2cf9ee997b61",
+        "sha256": "1l5ihcxdr8ci4bcgh5bzpcfsin40fzwpiyhna88qqw6c39iy7fc2"
+      }
     }
   },
 
   {
-    "path": "org/antlr/ST4/4.0.8/ST4-4.0.8",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "116663d33389525e932a4ff7adaf66eb06caf277",
-      "sha256": "0z610q9vn39vf408p0110imzy08r6jgcl16llcxynx0iqzg9021w"
-    },
-    "jar": {
-      "sha1": "0a1c55e974f8a94d78e2348fa6ff63f4fa1fae64",
-      "sha256": "0fvszknribdgm98s5rllj1sw0l2ayvh6in1zk6sv0x4z1k2apjjq"
+    "path": "org/antlr/ST4/4.0.8",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ST4-4.0.8.pom": {
+        "sha1": "116663d33389525e932a4ff7adaf66eb06caf277",
+        "sha256": "0z610q9vn39vf408p0110imzy08r6jgcl16llcxynx0iqzg9021w"
+      },
+      "ST4-4.0.8.jar": {
+        "sha1": "0a1c55e974f8a94d78e2348fa6ff63f4fa1fae64",
+        "sha256": "0fvszknribdgm98s5rllj1sw0l2ayvh6in1zk6sv0x4z1k2apjjq"
+      }
     }
   },
 
   {
-    "path": "org/antlr/ST4/4.3.4/ST4-4.3.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "24c80ba529f26698567f91773d24f8c01e1bfa73",
-      "sha256": "0gnamd4wc2g3pazk60pph1zmp7bjcdcrw20kih7486cr90z1yz4y"
-    },
-    "jar": {
-      "sha1": "bf68d049dd4e6e104055a79ac3bf9e6307d29258",
-      "sha256": "0czz2px3pdzd2sb2j29m6401xlmfacm9fs7cnpw4kms69hwaq9zr"
+    "path": "org/antlr/ST4/4.3.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ST4-4.3.4.pom": {
+        "sha1": "24c80ba529f26698567f91773d24f8c01e1bfa73",
+        "sha256": "0gnamd4wc2g3pazk60pph1zmp7bjcdcrw20kih7486cr90z1yz4y"
+      },
+      "ST4-4.3.4.jar": {
+        "sha1": "bf68d049dd4e6e104055a79ac3bf9e6307d29258",
+        "sha256": "0czz2px3pdzd2sb2j29m6401xlmfacm9fs7cnpw4kms69hwaq9zr"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-master/4.5.2-1/antlr4-master-4.5.2-1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "4e87b0d0b499acf795e1304a58dc68bcdd8ed614",
-      "sha256": "0x5ngrv4xiay1ks3kjp7gfbhzd03sqqp5z6pmxbsnm95v1wb8n2k"
+    "path": "org/antlr/antlr4-master/4.5.2-1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-master-4.5.2-1.pom": {
+        "sha1": "4e87b0d0b499acf795e1304a58dc68bcdd8ed614",
+        "sha256": "0x5ngrv4xiay1ks3kjp7gfbhzd03sqqp5z6pmxbsnm95v1wb8n2k"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-master/4.5.3/antlr4-master-4.5.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c7e4123f86c15b492adba2fc5377949c4ea43946",
-      "sha256": "195jkdpq6v34aa1wd3hznlvzcch3x8s89wfgnvlrkm8awzapf620"
+    "path": "org/antlr/antlr4-master/4.5.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-master-4.5.3.pom": {
+        "sha1": "c7e4123f86c15b492adba2fc5377949c4ea43946",
+        "sha256": "195jkdpq6v34aa1wd3hznlvzcch3x8s89wfgnvlrkm8awzapf620"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-master/4.12.0/antlr4-master-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "5cd9d694d06e046886a7a8e54d70b22bc03af4a3",
-      "sha256": "0x3rhw76nrzh35d8liq9wffm74rshxwg944xc55c3qlcwlxg3xj2"
+    "path": "org/antlr/antlr4-master/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-master-4.12.0.pom": {
+        "sha1": "5cd9d694d06e046886a7a8e54d70b22bc03af4a3",
+        "sha256": "0x3rhw76nrzh35d8liq9wffm74rshxwg944xc55c3qlcwlxg3xj2"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-runtime/4.5.2-1/antlr4-runtime-4.5.2-1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6c4013c6b772dd3e8cc00837ccf5edd7619e8d21",
-      "sha256": "07k6rflqc5yc7sxh80dzrr1ybjx8h8kj8hzd0jcmakbipjvckflk"
-    },
-    "jar": {
-      "sha1": "7fe31fde811943a1970cc97359557c57747026ef",
-      "sha256": "1603ap9qds5wggwadf5pfi4vrahxgf97b8f32pcxgvmw0hq42cg8"
+    "path": "org/antlr/antlr4-runtime/4.5.2-1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-runtime-4.5.2-1.pom": {
+        "sha1": "6c4013c6b772dd3e8cc00837ccf5edd7619e8d21",
+        "sha256": "07k6rflqc5yc7sxh80dzrr1ybjx8h8kj8hzd0jcmakbipjvckflk"
+      },
+      "antlr4-runtime-4.5.2-1.jar": {
+        "sha1": "7fe31fde811943a1970cc97359557c57747026ef",
+        "sha256": "1603ap9qds5wggwadf5pfi4vrahxgf97b8f32pcxgvmw0hq42cg8"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-runtime/4.12.0/antlr4-runtime-4.12.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3113149fe4ea467b27f14f2b99096cac9d4ca53a",
-      "sha256": "1r3isigbls4i2ldc4kyq3kzv2klcgz7przyq3knz02aasrzm95n6"
-    },
-    "jar": {
-      "sha1": "dd105cf6ac9f7417b3782c178f6dbd06bf75df57",
-      "sha256": "0d6sd7jrxfxd7qp5gbsd8vdq6wp1r2iww189g76i0vkxj8s3ndfv"
+    "path": "org/antlr/antlr4-runtime/4.12.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-runtime-4.12.0.pom": {
+        "sha1": "3113149fe4ea467b27f14f2b99096cac9d4ca53a",
+        "sha256": "1r3isigbls4i2ldc4kyq3kzv2klcgz7przyq3knz02aasrzm95n6"
+      },
+      "antlr4-runtime-4.12.0.jar": {
+        "sha1": "dd105cf6ac9f7417b3782c178f6dbd06bf75df57",
+        "sha256": "0d6sd7jrxfxd7qp5gbsd8vdq6wp1r2iww189g76i0vkxj8s3ndfv"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr4/4.5.3/antlr4-4.5.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9ecf07c69a057cb13cea8a153d242007f5cc8003",
-      "sha256": "11334fj7p4yxfvqincdpn1fp4hp7vzqjrqaplxv2k9ysxqr4nkla"
-    },
-    "jar": {
-      "sha1": "f35db7e4b2446e4174ba6a73db7bd6b3e6bb5da1",
-      "sha256": "1d2g3f5pyrabib54al6bwlqpfbkxd6limycnwrs5flfzrwwyfbd3"
+    "path": "org/antlr/antlr4/4.5.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr4-4.5.3.pom": {
+        "sha1": "9ecf07c69a057cb13cea8a153d242007f5cc8003",
+        "sha256": "11334fj7p4yxfvqincdpn1fp4hp7vzqjrqaplxv2k9ysxqr4nkla"
+      },
+      "antlr4-4.5.3.jar": {
+        "sha1": "f35db7e4b2446e4174ba6a73db7bd6b3e6bb5da1",
+        "sha256": "1d2g3f5pyrabib54al6bwlqpfbkxd6limycnwrs5flfzrwwyfbd3"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr-master/3.3/antlr-master-3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c6eef5b4a8e7af1c43979108eadd3a6fbb4ac3d2",
-      "sha256": "06mfqggdd1pv6rbh8y2qzri76d4v5fry2q095r75dmn7h7y0wzxx"
+    "path": "org/antlr/antlr-master/3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-master-3.3.pom": {
+        "sha1": "c6eef5b4a8e7af1c43979108eadd3a6fbb4ac3d2",
+        "sha256": "06mfqggdd1pv6rbh8y2qzri76d4v5fry2q095r75dmn7h7y0wzxx"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr-master/3.5.2/antlr-master-3.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0e9d18b3d8c228ff9786ee977f44800897fe15be",
-      "sha256": "1mhv6gqiwdrgypibcwxxhbrfh25rqc1a06jlkfq0w4553r9imna2"
+    "path": "org/antlr/antlr-master/3.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-master-3.5.2.pom": {
+        "sha1": "0e9d18b3d8c228ff9786ee977f44800897fe15be",
+        "sha256": "1mhv6gqiwdrgypibcwxxhbrfh25rqc1a06jlkfq0w4553r9imna2"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr-master/3.5.3/antlr-master-3.5.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a0f2d06c86cd02cb9ff7fb5a1c93fb0ba3eb5cec",
-      "sha256": "15dqhnrhgqlprbrm7psyb3d9nd7kaxxyk2sknrv2wk2w1wjkg7pa"
+    "path": "org/antlr/antlr-master/3.5.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-master-3.5.3.pom": {
+        "sha1": "a0f2d06c86cd02cb9ff7fb5a1c93fb0ba3eb5cec",
+        "sha256": "15dqhnrhgqlprbrm7psyb3d9nd7kaxxyk2sknrv2wk2w1wjkg7pa"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr-runtime/3.3/antlr-runtime-3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2fc09acfad331cd0939b058947a87294762f39c8",
-      "sha256": "1lc4vs2v6134dv6bfs9r3wbnhf1mnxx9b377rbkbz7jjllnxr76h"
-    },
-    "jar": {
-      "sha1": "ccd65b08cbc9b7e90b9facd4d125a133c6f87228",
-      "sha256": "14a5mvmz9jr1jlj7j6w0ravs3cy37kcb2wr0247il15y1273rh1n"
+    "path": "org/antlr/antlr-runtime/3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-runtime-3.3.pom": {
+        "sha1": "2fc09acfad331cd0939b058947a87294762f39c8",
+        "sha256": "1lc4vs2v6134dv6bfs9r3wbnhf1mnxx9b377rbkbz7jjllnxr76h"
+      },
+      "antlr-runtime-3.3.jar": {
+        "sha1": "ccd65b08cbc9b7e90b9facd4d125a133c6f87228",
+        "sha256": "14a5mvmz9jr1jlj7j6w0ravs3cy37kcb2wr0247il15y1273rh1n"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr-runtime/3.5.2/antlr-runtime-3.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "af8ae5172f0c499d932d465673c9833c8777c1dd",
-      "sha256": "09bzm8h181dj9jh53j19hf89k47lgw4sb9sa2bbjpcdq1chc5aa6"
-    },
-    "jar": {
-      "sha1": "cd9cd41361c155f3af0f653009dcecb08d8b4afd",
-      "sha256": "0d47khwbkhvkzvk1h7hb7p6xjwnja3ijrfywrniyjf8gn7nchgyf"
+    "path": "org/antlr/antlr-runtime/3.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-runtime-3.5.2.pom": {
+        "sha1": "af8ae5172f0c499d932d465673c9833c8777c1dd",
+        "sha256": "09bzm8h181dj9jh53j19hf89k47lgw4sb9sa2bbjpcdq1chc5aa6"
+      },
+      "antlr-runtime-3.5.2.jar": {
+        "sha1": "cd9cd41361c155f3af0f653009dcecb08d8b4afd",
+        "sha256": "0d47khwbkhvkzvk1h7hb7p6xjwnja3ijrfywrniyjf8gn7nchgyf"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr-runtime/3.5.3/antlr-runtime-3.5.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1a980d8984cb2d929dbd11d765fbc03ab6092b2a",
-      "sha256": "09bxq0r2yhrw23bzc9v4lfzlzv5nr8kn8h6lyx7l3bxg1878wa8k"
-    },
-    "jar": {
-      "sha1": "9011fb189c5ed6d99e5f3322514848d1ec1e1416",
-      "sha256": "1fczcs83p10ybfgr24k6m8vlxvvb4gk8gicm6h1k9jyz6dd9zgv8"
+    "path": "org/antlr/antlr-runtime/3.5.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-runtime-3.5.3.pom": {
+        "sha1": "1a980d8984cb2d929dbd11d765fbc03ab6092b2a",
+        "sha256": "09bxq0r2yhrw23bzc9v4lfzlzv5nr8kn8h6lyx7l3bxg1878wa8k"
+      },
+      "antlr-runtime-3.5.3.jar": {
+        "sha1": "9011fb189c5ed6d99e5f3322514848d1ec1e1416",
+        "sha256": "1fczcs83p10ybfgr24k6m8vlxvvb4gk8gicm6h1k9jyz6dd9zgv8"
+      }
     }
   },
 
   {
-    "path": "org/antlr/antlr/3.5.2/antlr-3.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d6830744a9a30a9c0afebfb84a5fdd6cc7e9d4ab",
-      "sha256": "1r12z9l1jjqs7ghmww2rjhqxsyr42ivizh6kjn3qbsrgcs05wph6"
-    },
-    "jar": {
-      "sha1": "c4a65c950bfc3e7d04309c515b2177c00baf7764",
-      "sha256": "1ps3ws5p7hh38pa4iih0s3i469hgaxdhpqmggp9z785hrwm6rhss"
+    "path": "org/antlr/antlr/3.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "antlr-3.5.2.pom": {
+        "sha1": "d6830744a9a30a9c0afebfb84a5fdd6cc7e9d4ab",
+        "sha256": "1r12z9l1jjqs7ghmww2rjhqxsyr42ivizh6kjn3qbsrgcs05wph6"
+      },
+      "antlr-3.5.2.jar": {
+        "sha1": "c4a65c950bfc3e7d04309c515b2177c00baf7764",
+        "sha256": "1ps3ws5p7hh38pa4iih0s3i469hgaxdhpqmggp9z785hrwm6rhss"
+      }
     }
   },
 
   {
-    "path": "org/antlr/stringtemplate/3.2.1/stringtemplate-3.2.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "88562344bdb06d01a8f410aa624538e345086595",
-      "sha256": "05kaq4iminqjx9d4pqimbcrmdc96ahsf8hrss4rqz955b9jq4pml"
-    },
-    "jar": {
-      "sha1": "59ec8083721eae215c6f3caee944c410d2be34de",
-      "sha256": "1mzndmmc005zvcqgrjxkj7mnzmvapb9583h21z5h2lsyjqpffv7n"
+    "path": "org/antlr/stringtemplate/3.2.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "stringtemplate-3.2.1.pom": {
+        "sha1": "88562344bdb06d01a8f410aa624538e345086595",
+        "sha256": "05kaq4iminqjx9d4pqimbcrmdc96ahsf8hrss4rqz955b9jq4pml"
+      },
+      "stringtemplate-3.2.1.jar": {
+        "sha1": "59ec8083721eae215c6f3caee944c410d2be34de",
+        "sha256": "1mzndmmc005zvcqgrjxkj7mnzmvapb9583h21z5h2lsyjqpffv7n"
+      }
     }
   },
 
   {
-    "path": "org/antlr/stringtemplate/4.0.2/stringtemplate-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fdf5de19491ec50c9f621ab93c3d3e36879bcfa3",
-      "sha256": "05j96qwqp5z9d7qxnq7gciwa14m0x8xx9h82s0qsvs95wwn6skq2"
-    },
-    "jar": {
-      "sha1": "e28e09e2d44d60506a7bcb004d6c23ff35c6ac08",
-      "sha256": "1y8ycln88kzymalxgx5r1f2jswl51815syrlyvgd660vdrcdaml0"
+    "path": "org/antlr/stringtemplate/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "stringtemplate-4.0.2.pom": {
+        "sha1": "fdf5de19491ec50c9f621ab93c3d3e36879bcfa3",
+        "sha256": "05j96qwqp5z9d7qxnq7gciwa14m0x8xx9h82s0qsvs95wwn6skq2"
+      },
+      "stringtemplate-4.0.2.jar": {
+        "sha1": "e28e09e2d44d60506a7bcb004d6c23ff35c6ac08",
+        "sha256": "1y8ycln88kzymalxgx5r1f2jswl51815syrlyvgd660vdrcdaml0"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/4/apache-4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "602b647986c1d24301bc3d70e5923696bc7f1401",
-      "sha256": "152iri0kbrxir93w23b31045gpvh3g9rc37gxya27sx8dfi274wy"
+    "path": "org/apache/apache/4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-4.pom": {
+        "sha1": "602b647986c1d24301bc3d70e5923696bc7f1401",
+        "sha256": "152iri0kbrxir93w23b31045gpvh3g9rc37gxya27sx8dfi274wy"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/9/apache-9",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "de55d73a30c7521f3d55e8141d360ffbdfd88caa",
-      "sha256": "1p8qrz7swd6ylwfiv6x4kr3gip6sy2vca8xwydlxm3kwah5fcij9"
+    "path": "org/apache/apache/9",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-9.pom": {
+        "sha1": "de55d73a30c7521f3d55e8141d360ffbdfd88caa",
+        "sha256": "1p8qrz7swd6ylwfiv6x4kr3gip6sy2vca8xwydlxm3kwah5fcij9"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/13/apache-13",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "15aff1faaec4963617f07dbe8e603f0adabc3a12",
-      "sha256": "07c4yg52q1qiz2b982pcsiwf9ahmpil4jy7lpqvi5m0z6sq3slgz"
+    "path": "org/apache/apache/13",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-13.pom": {
+        "sha1": "15aff1faaec4963617f07dbe8e603f0adabc3a12",
+        "sha256": "07c4yg52q1qiz2b982pcsiwf9ahmpil4jy7lpqvi5m0z6sq3slgz"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/15/apache-15",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "95c70374817194cabfeec410fe70c3a6b832bafe",
-      "sha256": "156lk89x31r2d6ljpwl1lvrl0sxgkd70wj6bq18b8rxcg7wz5hin"
+    "path": "org/apache/apache/15",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-15.pom": {
+        "sha1": "95c70374817194cabfeec410fe70c3a6b832bafe",
+        "sha256": "156lk89x31r2d6ljpwl1lvrl0sxgkd70wj6bq18b8rxcg7wz5hin"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/16/apache-16",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "8a90e31780e5cd0685ccaf25836c66e3b4e163b7",
-      "sha256": "03m4fjgg98zcyjlsp64z21lyiszhwyg43ys7mabk1jynswpzz1cz"
+    "path": "org/apache/apache/16",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-16.pom": {
+        "sha1": "8a90e31780e5cd0685ccaf25836c66e3b4e163b7",
+        "sha256": "03m4fjgg98zcyjlsp64z21lyiszhwyg43ys7mabk1jynswpzz1cz"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/18/apache-18",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "bd408bbea3840f2c7f914b29403e39a90f84fd5f",
-      "sha256": "05rwyflfsi1dhl7r7mdiacqirwc2g27f62mj6sy5nizxhmr30cbq"
+    "path": "org/apache/apache/18",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-18.pom": {
+        "sha1": "bd408bbea3840f2c7f914b29403e39a90f84fd5f",
+        "sha256": "05rwyflfsi1dhl7r7mdiacqirwc2g27f62mj6sy5nizxhmr30cbq"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/21/apache-21",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "649b700a1b2b4a1d87e7ae8e3f47bfe101b2a4a5",
-      "sha256": "105k6wsi9n95lfbsz8jz4qc1qfjs9cmjpdf7zb51fkq1v84c245g"
+    "path": "org/apache/apache/21",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-21.pom": {
+        "sha1": "649b700a1b2b4a1d87e7ae8e3f47bfe101b2a4a5",
+        "sha256": "105k6wsi9n95lfbsz8jz4qc1qfjs9cmjpdf7zb51fkq1v84c245g"
+      }
     }
   },
 
   {
-    "path": "org/apache/apache/23/apache-23",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0404949e96725e63a10a6d8f9d9b521948d170d5",
-      "sha256": "07298c2jfkdb6gaxidig2pnl0ckdjfi9qqy5z9vnbwr30r76445w"
+    "path": "org/apache/apache/23",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-23.pom": {
+        "sha1": "0404949e96725e63a10a6d8f9d9b521948d170d5",
+        "sha256": "07298c2jfkdb6gaxidig2pnl0ckdjfi9qqy5z9vnbwr30r76445w"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-compress/1.8.1/commons-compress-1.8.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2fb3ea9182911315ee79aa2fb4853c7bdd347407",
-      "sha256": "1f4z7dc667b0d07s1yfiqhvbhbj37q00ihyxphm0nlp82kdpl4qh"
-    },
-    "jar": {
-      "sha1": "a698750c16740fd5b3871425f4cb3bbaa87f529d",
-      "sha256": "1gbzd7aang7xp3k98m3sbjs5d7nm6yqigg8znrncqvpq0dji7jjz"
+    "path": "org/apache/commons/commons-compress/1.8.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-compress-1.8.1.pom": {
+        "sha1": "2fb3ea9182911315ee79aa2fb4853c7bdd347407",
+        "sha256": "1f4z7dc667b0d07s1yfiqhvbhbj37q00ihyxphm0nlp82kdpl4qh"
+      },
+      "commons-compress-1.8.1.jar": {
+        "sha1": "a698750c16740fd5b3871425f4cb3bbaa87f529d",
+        "sha256": "1gbzd7aang7xp3k98m3sbjs5d7nm6yqigg8znrncqvpq0dji7jjz"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-compress/1.12/commons-compress-1.12",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d4ba952b054eef846e7255cc3ac6d4ca76ead72c",
-      "sha256": "0fi1am0cs09axqn5lzzg9a07ksj12spbjs1945v5wl2ir1sdb1xp"
-    },
-    "jar": {
-      "sha1": "84caa68576e345eb5e7ae61a0e5a9229eb100d7b",
-      "sha256": "1dn09ncg5ggxvr57m26kjp8dcwalmv45agcwmdy5n623ygx4459c"
+    "path": "org/apache/commons/commons-compress/1.12",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-compress-1.12.pom": {
+        "sha1": "d4ba952b054eef846e7255cc3ac6d4ca76ead72c",
+        "sha256": "0fi1am0cs09axqn5lzzg9a07ksj12spbjs1945v5wl2ir1sdb1xp"
+      },
+      "commons-compress-1.12.jar": {
+        "sha1": "84caa68576e345eb5e7ae61a0e5a9229eb100d7b",
+        "sha256": "1dn09ncg5ggxvr57m26kjp8dcwalmv45agcwmdy5n623ygx4459c"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "932ed8226f371b204d04a8c4d3d5fe0f2b26339f",
-      "sha256": "0h3r4wajfcx9r6jqw7hhz17hmhq8s6h08hy3vribr7lrfpsmp1z1"
-    },
-    "jar": {
-      "sha1": "90a3822c38ec8c996e84c16a3477ef632cbc87a3",
-      "sha256": "0zfl2fa2nh5l9znmqmik7l6crhh9cmp4h4b0716iipysah3x30bb"
+    "path": "org/apache/commons/commons-lang3/3.3.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-lang3-3.3.2.pom": {
+        "sha1": "932ed8226f371b204d04a8c4d3d5fe0f2b26339f",
+        "sha256": "0h3r4wajfcx9r6jqw7hhz17hmhq8s6h08hy3vribr7lrfpsmp1z1"
+      },
+      "commons-lang3-3.3.2.jar": {
+        "sha1": "90a3822c38ec8c996e84c16a3477ef632cbc87a3",
+        "sha256": "0zfl2fa2nh5l9znmqmik7l6crhh9cmp4h4b0716iipysah3x30bb"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-lang3/3.9/commons-lang3-3.9",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2b7f0896fc2f13bbe7b0022c85738e3b6a3f201a",
-      "sha256": "1dgyinzcpjnlhz2dm2v46h7n2bx5g497458r30qb89c4p4lj80m4"
-    },
-    "jar": {
-      "sha1": "0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
-      "sha256": "0c62qd6s9gh8krzsscwfy92aka96cyh631l5rsl1gy9yrz6isbny"
+    "path": "org/apache/commons/commons-lang3/3.9",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-lang3-3.9.pom": {
+        "sha1": "2b7f0896fc2f13bbe7b0022c85738e3b6a3f201a",
+        "sha256": "1dgyinzcpjnlhz2dm2v46h7n2bx5g497458r30qb89c4p4lj80m4"
+      },
+      "commons-lang3-3.9.jar": {
+        "sha1": "0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+        "sha256": "0c62qd6s9gh8krzsscwfy92aka96cyh631l5rsl1gy9yrz6isbny"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/5/commons-parent-5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a0a168281558e7ae972f113fa128bc46b4973edd",
-      "sha256": "0am0vbkyp6b6srwhvw52xkc4ghaj4kqn0ay26vgag06z1g035mlb"
+    "path": "org/apache/commons/commons-parent/5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-5.pom": {
+        "sha1": "a0a168281558e7ae972f113fa128bc46b4973edd",
+        "sha256": "0am0vbkyp6b6srwhvw52xkc4ghaj4kqn0ay26vgag06z1g035mlb"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/11/commons-parent-11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "3f29657e1e3d6856344728ddbcf696477e943d59",
-      "sha256": "0am014qph77cw2n596d9z8g1naf5a191199zi9di0q1l75pk1q5r"
+    "path": "org/apache/commons/commons-parent/11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-11.pom": {
+        "sha1": "3f29657e1e3d6856344728ddbcf696477e943d59",
+        "sha256": "0am014qph77cw2n596d9z8g1naf5a191199zi9di0q1l75pk1q5r"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/22/commons-parent-22",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0e895fa7ed472b3b2081ef77e2d5ece78c139d54",
-      "sha256": "1frwdic537d95l0ikgkvfpb4wjfjx2h5h211zysdsyhawdamx37v"
+    "path": "org/apache/commons/commons-parent/22",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-22.pom": {
+        "sha1": "0e895fa7ed472b3b2081ef77e2d5ece78c139d54",
+        "sha256": "1frwdic537d95l0ikgkvfpb4wjfjx2h5h211zysdsyhawdamx37v"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/25/commons-parent-25",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "67b84199ca4acf0d8fbc5256d90b80f746737e94",
-      "sha256": "1flhjyg2b14ch0wvsbimqli7vmpxim8yg54h6xkni1rf8i8fcyj6"
+    "path": "org/apache/commons/commons-parent/25",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-25.pom": {
+        "sha1": "67b84199ca4acf0d8fbc5256d90b80f746737e94",
+        "sha256": "1flhjyg2b14ch0wvsbimqli7vmpxim8yg54h6xkni1rf8i8fcyj6"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/32/commons-parent-32",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0e51c4223003c2c7c63f38d7b8823e40eb06bd1f",
-      "sha256": "1s2bdgr10jshy5v0bs03c2d7hw3qxyfkf5fl90hh7x1gifpmilp4"
+    "path": "org/apache/commons/commons-parent/32",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-32.pom": {
+        "sha1": "0e51c4223003c2c7c63f38d7b8823e40eb06bd1f",
+        "sha256": "1s2bdgr10jshy5v0bs03c2d7hw3qxyfkf5fl90hh7x1gifpmilp4"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/33/commons-parent-33",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "a9bd6ae1e11cb313ec4a4c9bcd58c7a9ea60a5cd",
-      "sha256": "1yzqvnngasa9bqqc0hw2yzqcckkmqzdcrbwx6xpi1rg2a89h3l2k"
+    "path": "org/apache/commons/commons-parent/33",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-33.pom": {
+        "sha1": "a9bd6ae1e11cb313ec4a4c9bcd58c7a9ea60a5cd",
+        "sha256": "1yzqvnngasa9bqqc0hw2yzqcckkmqzdcrbwx6xpi1rg2a89h3l2k"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/34/commons-parent-34",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "1f6be162a806d8343e3cd238dd728558532473a5",
-      "sha256": "175p0hnjk93gmgh8fv63z0xmd9jf5sgdq9ii54xiy7b4dp86jbis"
+    "path": "org/apache/commons/commons-parent/34",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-34.pom": {
+        "sha1": "1f6be162a806d8343e3cd238dd728558532473a5",
+        "sha256": "175p0hnjk93gmgh8fv63z0xmd9jf5sgdq9ii54xiy7b4dp86jbis"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/35/commons-parent-35",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "d88c24ebb385e5404f34573f24362b17434e3f33",
-      "sha256": "16p48k5ly6yli1wlzb5qcipwd0lzhsnbrjr1vk4x9v1nhfms363h"
+    "path": "org/apache/commons/commons-parent/35",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-35.pom": {
+        "sha1": "d88c24ebb385e5404f34573f24362b17434e3f33",
+        "sha256": "16p48k5ly6yli1wlzb5qcipwd0lzhsnbrjr1vk4x9v1nhfms363h"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/39/commons-parent-39",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "4bc32d3cda9f07814c548492af7bf19b21798d46",
-      "sha256": "19qxlq7zcvf8cw2hyrcb5d6b9cbbd6ccwnahv2v3wp1al3hjgkc7"
+    "path": "org/apache/commons/commons-parent/39",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-39.pom": {
+        "sha1": "4bc32d3cda9f07814c548492af7bf19b21798d46",
+        "sha256": "19qxlq7zcvf8cw2hyrcb5d6b9cbbd6ccwnahv2v3wp1al3hjgkc7"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/48/commons-parent-48",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "1cdeb626cf4f0cec0f171ec838a69922efc6ef95",
-      "sha256": "1d50giiw014yyyq5i5bzykip9gi22k6xmw98y40pjyqa6zlps7qy"
+    "path": "org/apache/commons/commons-parent/48",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-48.pom": {
+        "sha1": "1cdeb626cf4f0cec0f171ec838a69922efc6ef95",
+        "sha256": "1d50giiw014yyyq5i5bzykip9gi22k6xmw98y40pjyqa6zlps7qy"
+      }
     }
   },
 
   {
-    "path": "org/apache/commons/commons-parent/52/commons-parent-52",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "004ee86dedc66d0010ccdc29e5a4ce014c057854",
-      "sha256": "0bjhnkdhdsdcc12daiqhbwxwvjxlkqplmbns8bzw7r4q9vryinvm"
+    "path": "org/apache/commons/commons-parent/52",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-52.pom": {
+        "sha1": "004ee86dedc66d0010ccdc29e5a4ce014c057854",
+        "sha256": "0bjhnkdhdsdcc12daiqhbwxwvjxlkqplmbns8bzw7r4q9vryinvm"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpclient/4.1.1/httpclient-4.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1468927fa5fbea4d3037422f45eb12cef173ba16",
-      "sha256": "19z21zvaypyi1mg6vc3clmhmq6fq1ybng0pj0p7d95wa6kcigfmd"
-    },
-    "jar": {
-      "sha1": "3d1d918f32709e33ba7ddb2c4e8d1c543ebe713e",
-      "sha256": "0la7iqy72w09h6z8h9s09bnac2xj0l05mm1ql5nbyyb6ib82drga"
+    "path": "org/apache/httpcomponents/httpclient/4.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpclient-4.1.1.pom": {
+        "sha1": "1468927fa5fbea4d3037422f45eb12cef173ba16",
+        "sha256": "19z21zvaypyi1mg6vc3clmhmq6fq1ybng0pj0p7d95wa6kcigfmd"
+      },
+      "httpclient-4.1.1.jar": {
+        "sha1": "3d1d918f32709e33ba7ddb2c4e8d1c543ebe713e",
+        "sha256": "0la7iqy72w09h6z8h9s09bnac2xj0l05mm1ql5nbyyb6ib82drga"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpclient/4.2.6/httpclient-4.2.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fc51b4b649a2f9ab2588e9c1703288479591ade8",
-      "sha256": "0a03lbcyjia7vavlvd4qbh29nzmvblnmdjiym1md63hhmbpa387m"
-    },
-    "jar": {
-      "sha1": "e4ca30a6a3a075053a61c6fc850d2432dc012ba7",
-      "sha256": "0l2m2ijv8d5dwnmsghdjy7rxwzbka9xhf84y4whpwsbwxqj96bin"
+    "path": "org/apache/httpcomponents/httpclient/4.2.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpclient-4.2.6.pom": {
+        "sha1": "fc51b4b649a2f9ab2588e9c1703288479591ade8",
+        "sha256": "0a03lbcyjia7vavlvd4qbh29nzmvblnmdjiym1md63hhmbpa387m"
+      },
+      "httpclient-4.2.6.jar": {
+        "sha1": "e4ca30a6a3a075053a61c6fc850d2432dc012ba7",
+        "sha256": "0l2m2ijv8d5dwnmsghdjy7rxwzbka9xhf84y4whpwsbwxqj96bin"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "56f6338b324e438307e1f2c2b33bd02268310fc2",
-      "sha256": "1w0rxkvljw15ccw4b189izsqjdmirj6x3gpgn0l4p6l246x03028"
-    },
-    "jar": {
-      "sha1": "733db77aa8d9b2d68015189df76ab06304406e50",
-      "sha256": "0ms00zc28pwqk83nwwbafhq6p8zci9mrjzbqalpn6v0d80hwdzqd"
+    "path": "org/apache/httpcomponents/httpclient/4.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpclient-4.5.2.pom": {
+        "sha1": "56f6338b324e438307e1f2c2b33bd02268310fc2",
+        "sha256": "1w0rxkvljw15ccw4b189izsqjdmirj6x3gpgn0l4p6l246x03028"
+      },
+      "httpclient-4.5.2.jar": {
+        "sha1": "733db77aa8d9b2d68015189df76ab06304406e50",
+        "sha256": "0ms00zc28pwqk83nwwbafhq6p8zci9mrjzbqalpn6v0d80hwdzqd"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "27f5d747aad49d36750ef3dffa30687963b4ddcd",
-      "sha256": "171ckzc8ga4vkcqw29g55s6cbls3f9lq3nfh830vlyy0141pbrfd"
-    },
-    "jar": {
-      "sha1": "d1577ae15f01ef5438c5afc62162457c00a34713",
-      "sha256": "0d9i4r4j7m8yakmhb3lv34v0j3ig9s2n3bbpfpa5lpka5mn1ngfv"
+    "path": "org/apache/httpcomponents/httpclient/4.5.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpclient-4.5.3.pom": {
+        "sha1": "27f5d747aad49d36750ef3dffa30687963b4ddcd",
+        "sha256": "171ckzc8ga4vkcqw29g55s6cbls3f9lq3nfh830vlyy0141pbrfd"
+      },
+      "httpclient-4.5.3.jar": {
+        "sha1": "d1577ae15f01ef5438c5afc62162457c00a34713",
+        "sha256": "0d9i4r4j7m8yakmhb3lv34v0j3ig9s2n3bbpfpa5lpka5mn1ngfv"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "db40edda8b95d880d2a810560fd5e46eb4fa6909",
-      "sha256": "0mc81c7jmhrdjvr8az8x0q3wmlzb24nj8czxickbnzrywx0i5z3y"
-    },
-    "jar": {
-      "sha1": "1afe5621985efe90a92d0fbc9be86271efbe796f",
-      "sha256": "1isi2l3lkwavhsc24siar6j9c5mjh3ddipfh10v0xa77jlqq2gy0"
+    "path": "org/apache/httpcomponents/httpclient/4.5.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpclient-4.5.6.pom": {
+        "sha1": "db40edda8b95d880d2a810560fd5e46eb4fa6909",
+        "sha256": "0mc81c7jmhrdjvr8az8x0q3wmlzb24nj8czxickbnzrywx0i5z3y"
+      },
+      "httpclient-4.5.6.jar": {
+        "sha1": "1afe5621985efe90a92d0fbc9be86271efbe796f",
+        "sha256": "1isi2l3lkwavhsc24siar6j9c5mjh3ddipfh10v0xa77jlqq2gy0"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f62c6a311407cc4b47d0ea9eec6cf97ed25b8cee",
-      "sha256": "1dzgpmfzri6vjlh5nwhc12ppw2p98wm79gafy178l2pq9jpmb0zi"
-    },
-    "jar": {
-      "sha1": "1194890e6f56ec29177673f2f12d0b8e627dec98",
-      "sha256": "1mp9g0s4j6rq0i5i0cp7fvz8pdn4y6mvnbhdyircxm56a4f7xg68"
+    "path": "org/apache/httpcomponents/httpclient/4.5.14",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpclient-4.5.14.pom": {
+        "sha1": "f62c6a311407cc4b47d0ea9eec6cf97ed25b8cee",
+        "sha256": "1dzgpmfzri6vjlh5nwhc12ppw2p98wm79gafy178l2pq9jpmb0zi"
+      },
+      "httpclient-4.5.14.jar": {
+        "sha1": "1194890e6f56ec29177673f2f12d0b8e627dec98",
+        "sha256": "1mp9g0s4j6rq0i5i0cp7fvz8pdn4y6mvnbhdyircxm56a4f7xg68"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.1.1/httpcomponents-client-4.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "3e1c598ddde5619cc602d32fffdf34668be071a3",
-      "sha256": "0lra0a51ir2x7ww44qq4hmcjvrrc843ll4qmfxz6sllmx7jq8lj7"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.1.1.pom": {
+        "sha1": "3e1c598ddde5619cc602d32fffdf34668be071a3",
+        "sha256": "0lra0a51ir2x7ww44qq4hmcjvrrc843ll4qmfxz6sllmx7jq8lj7"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.1/httpcomponents-client-4.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "ac363bbcf41af1153745f561aa0feac2b373a017",
-      "sha256": "09wq25fxxrsj8c01313w9f4wr95mpz9l4dnykjdqsv4cg54bc5aj"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.1.pom": {
+        "sha1": "ac363bbcf41af1153745f561aa0feac2b373a017",
+        "sha256": "09wq25fxxrsj8c01313w9f4wr95mpz9l4dnykjdqsv4cg54bc5aj"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.2.6/httpcomponents-client-4.2.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "e40911efc7a573f049475a2beeaf83690bf5ad62",
-      "sha256": "0s9d2yl36q2zyvkyhl7ksrlcc317hjl1ybvmpr6y2h12mwpgvdjj"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.2.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.2.6.pom": {
+        "sha1": "e40911efc7a573f049475a2beeaf83690bf5ad62",
+        "sha256": "0s9d2yl36q2zyvkyhl7ksrlcc317hjl1ybvmpr6y2h12mwpgvdjj"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.2/httpcomponents-client-4.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "55d500e6c1e98ffbb00c35bee72fabc255c22108",
-      "sha256": "00gdpvi7b5dmnkpir2ryp8nkak10nxpmlcwyc4l6pi75q6kcps0x"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.5.2.pom": {
+        "sha1": "55d500e6c1e98ffbb00c35bee72fabc255c22108",
+        "sha256": "00gdpvi7b5dmnkpir2ryp8nkak10nxpmlcwyc4l6pi75q6kcps0x"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.3/httpcomponents-client-4.5.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "238c16d8fd6e8ac85f603d981f5c20efae9dac01",
-      "sha256": "1p138vyf6iiy5izd92lb9y4z38a9ymvki2h5rw0bn98ibabx5is3"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.5.3.pom": {
+        "sha1": "238c16d8fd6e8ac85f603d981f5c20efae9dac01",
+        "sha256": "1p138vyf6iiy5izd92lb9y4z38a9ymvki2h5rw0bn98ibabx5is3"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.6/httpcomponents-client-4.5.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "135a0a91d1ad2909b08196580ef2c363932bb87e",
-      "sha256": "0wqzzv4hbfgps1ccwinjq543c4njmq4ybx7p6l6v1vci4cgv8hmh"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.5.6.pom": {
+        "sha1": "135a0a91d1ad2909b08196580ef2c363932bb87e",
+        "sha256": "0wqzzv4hbfgps1ccwinjq543c4njmq4ybx7p6l6v1vci4cgv8hmh"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.14/httpcomponents-client-4.5.14",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "e36b5c26d9012cce0ba214e06462596585475217",
-      "sha256": "0qd09a8gcl8b85jjsgahril4mmmsril9h24xz1cpci01y7j1vbav"
+    "path": "org/apache/httpcomponents/httpcomponents-client/4.5.14",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-client-4.5.14.pom": {
+        "sha1": "e36b5c26d9012cce0ba214e06462596585475217",
+        "sha256": "0qd09a8gcl8b85jjsgahril4mmmsril9h24xz1cpci01y7j1vbav"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-core/4.1/httpcomponents-core-4.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "166e36966c2cbd6c1867a6eded3f56d70958338c",
-      "sha256": "1r2dyq3bgz1xamv3a167jd55in4z7vkd27zcvgh6s59xkkypyyag"
+    "path": "org/apache/httpcomponents/httpcomponents-core/4.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-core-4.1.pom": {
+        "sha1": "166e36966c2cbd6c1867a6eded3f56d70958338c",
+        "sha256": "1r2dyq3bgz1xamv3a167jd55in4z7vkd27zcvgh6s59xkkypyyag"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-core/4.2.5/httpcomponents-core-4.2.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "1230a8404ed1cb3710ac59734fa2bcad69c166d9",
-      "sha256": "1943dz9r27v4961ahq06f62xclsxjryxpy31r6xn6kisyaf7lkhn"
+    "path": "org/apache/httpcomponents/httpcomponents-core/4.2.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-core-4.2.5.pom": {
+        "sha1": "1230a8404ed1cb3710ac59734fa2bcad69c166d9",
+        "sha256": "1943dz9r27v4961ahq06f62xclsxjryxpy31r6xn6kisyaf7lkhn"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.5/httpcomponents-core-4.4.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "020c728c32a780a0a41ce5ba6e61891aadf25cf1",
-      "sha256": "1p0w158nih5h93cq292v8v0ga6syrky8kbcb6zalh26884sj9n8q"
+    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-core-4.4.5.pom": {
+        "sha1": "020c728c32a780a0a41ce5ba6e61891aadf25cf1",
+        "sha256": "1p0w158nih5h93cq292v8v0ga6syrky8kbcb6zalh26884sj9n8q"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.6/httpcomponents-core-4.4.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "b5cd50c09bc253701c1b38d00582920b99ec229e",
-      "sha256": "1glnvm9pfwvjxdjbbxiv4ljlckzqbzfpwc40y3rz6qyxs0rbag1a"
+    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-core-4.4.6.pom": {
+        "sha1": "b5cd50c09bc253701c1b38d00582920b99ec229e",
+        "sha256": "1glnvm9pfwvjxdjbbxiv4ljlckzqbzfpwc40y3rz6qyxs0rbag1a"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.10/httpcomponents-core-4.4.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "43dd1af3c408840fa4d19679da7db9c8dec9f7fa",
-      "sha256": "0diidhvqz9cjm65zq14v7iqi8fybs4lahszilw3w69p39dyl5sb1"
+    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-core-4.4.10.pom": {
+        "sha1": "43dd1af3c408840fa4d19679da7db9c8dec9f7fa",
+        "sha256": "0diidhvqz9cjm65zq14v7iqi8fybs4lahszilw3w69p39dyl5sb1"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.16/httpcomponents-core-4.4.16",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "e0cbfde0384168cdd90e2633c1f101416d799090",
-      "sha256": "1xxp7llaxmary752yrjajj8l12pqarnna8dz762x2fj25ln5mmzj"
+    "path": "org/apache/httpcomponents/httpcomponents-core/4.4.16",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-core-4.4.16.pom": {
+        "sha1": "e0cbfde0384168cdd90e2633c1f101416d799090",
+        "sha256": "1xxp7llaxmary752yrjajj8l12pqarnna8dz762x2fj25ln5mmzj"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-parent/10/httpcomponents-parent-10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "1ba3c5940f24525444492ae12b6a1015df8a477b",
-      "sha256": "1yirbnv75fnf5j9rdxazh941zg86c84cd0k0yd9igcmgjiyrdbya"
+    "path": "org/apache/httpcomponents/httpcomponents-parent/10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-parent-10.pom": {
+        "sha1": "1ba3c5940f24525444492ae12b6a1015df8a477b",
+        "sha256": "1yirbnv75fnf5j9rdxazh941zg86c84cd0k0yd9igcmgjiyrdbya"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "3ee7a841cc49326e8681089ea7ad6a3b81b88581",
-      "sha256": "1ank6bjz9w9b56p4695g60nv1rr07vvgygp4gq60fmaw25xzh0d9"
+    "path": "org/apache/httpcomponents/httpcomponents-parent/11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcomponents-parent-11.pom": {
+        "sha1": "3ee7a841cc49326e8681089ea7ad6a3b81b88581",
+        "sha256": "1ank6bjz9w9b56p4695g60nv1rr07vvgygp4gq60fmaw25xzh0d9"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcore/4.1/httpcore-4.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "28b423b7882a5c0d5b383903c6ea05d19b3c7c91",
-      "sha256": "09vk7if9fwc6zsmr0912mgk57m23qwmmrx6ck6qgmjg973x6mj2g"
-    },
-    "jar": {
-      "sha1": "33fc26c02f8043ab0ede19eadc8c9885386b255c",
-      "sha256": "1kr95c4q7w32yk81klyj2plgjhc5s2l5fh0qdn66c92f3zjqvqrw"
+    "path": "org/apache/httpcomponents/httpcore/4.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcore-4.1.pom": {
+        "sha1": "28b423b7882a5c0d5b383903c6ea05d19b3c7c91",
+        "sha256": "09vk7if9fwc6zsmr0912mgk57m23qwmmrx6ck6qgmjg973x6mj2g"
+      },
+      "httpcore-4.1.jar": {
+        "sha1": "33fc26c02f8043ab0ede19eadc8c9885386b255c",
+        "sha256": "1kr95c4q7w32yk81klyj2plgjhc5s2l5fh0qdn66c92f3zjqvqrw"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcore/4.2.5/httpcore-4.2.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cbae058677f9e1abfd9060223eb68224f96a7559",
-      "sha256": "1ijb7yalv7c7vd7k1vix7zr08dcyqhspmm80ak5490rb6vqrksxn"
-    },
-    "jar": {
-      "sha1": "472f0f5f8dba5d1962cb9d7739feed739a31c30d",
-      "sha256": "1sfgh7mcqnxnvpdwjzsyfci8bziffp0f6hzppcbxkj36rjj2vs75"
+    "path": "org/apache/httpcomponents/httpcore/4.2.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcore-4.2.5.pom": {
+        "sha1": "cbae058677f9e1abfd9060223eb68224f96a7559",
+        "sha256": "1ijb7yalv7c7vd7k1vix7zr08dcyqhspmm80ak5490rb6vqrksxn"
+      },
+      "httpcore-4.2.5.jar": {
+        "sha1": "472f0f5f8dba5d1962cb9d7739feed739a31c30d",
+        "sha256": "1sfgh7mcqnxnvpdwjzsyfci8bziffp0f6hzppcbxkj36rjj2vs75"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcore/4.4.5/httpcore-4.4.5",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "06137e1c916f6467c943847418f39b1685aadf4e",
-      "sha256": "1lpyhh30s80b7wm3492w3sph56bq1wv8l0ad0m84wlskyy6s2zql"
-    },
-    "jar": {
-      "sha1": "e7501a1b34325abb00d17dde96150604a0658b54",
-      "sha256": "1hyfh02rwrwbhxwb91lpba25646am6lh3jv5f05f9dyafhw4bmb4"
+    "path": "org/apache/httpcomponents/httpcore/4.4.5",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcore-4.4.5.pom": {
+        "sha1": "06137e1c916f6467c943847418f39b1685aadf4e",
+        "sha256": "1lpyhh30s80b7wm3492w3sph56bq1wv8l0ad0m84wlskyy6s2zql"
+      },
+      "httpcore-4.4.5.jar": {
+        "sha1": "e7501a1b34325abb00d17dde96150604a0658b54",
+        "sha256": "1hyfh02rwrwbhxwb91lpba25646am6lh3jv5f05f9dyafhw4bmb4"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d14da1e1f5682c8055b81dc87de20f97536a1d06",
-      "sha256": "0mgn11f98cz9f0wzm4msc828pqph9gsr837jh5dvaksmxz7qb0ir"
-    },
-    "jar": {
-      "sha1": "e3fd8ced1f52c7574af952e2e6da0df8df08eb82",
-      "sha256": "1ys5ly7xp7gisqfgy5mxjw96rdcykfrma26kjdrb103nx3g57y6p"
+    "path": "org/apache/httpcomponents/httpcore/4.4.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcore-4.4.6.pom": {
+        "sha1": "d14da1e1f5682c8055b81dc87de20f97536a1d06",
+        "sha256": "0mgn11f98cz9f0wzm4msc828pqph9gsr837jh5dvaksmxz7qb0ir"
+      },
+      "httpcore-4.4.6.jar": {
+        "sha1": "e3fd8ced1f52c7574af952e2e6da0df8df08eb82",
+        "sha256": "1ys5ly7xp7gisqfgy5mxjw96rdcykfrma26kjdrb103nx3g57y6p"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cbbf1989463d9f3e284c1348e50ea8bf426e4e1c",
-      "sha256": "0arrxaxfp68qxag15rbnx4kid9m93sw051ickal8hfrbvxk21hf5"
-    },
-    "jar": {
-      "sha1": "acc54d9b28bdffe4bbde89ed2e4a1e86b5285e2b",
-      "sha256": "1zgn37d608z6fw94cpfi881l6xl8cjdia2i0aldxnmqrasb11fkq"
+    "path": "org/apache/httpcomponents/httpcore/4.4.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcore-4.4.10.pom": {
+        "sha1": "cbbf1989463d9f3e284c1348e50ea8bf426e4e1c",
+        "sha256": "0arrxaxfp68qxag15rbnx4kid9m93sw051ickal8hfrbvxk21hf5"
+      },
+      "httpcore-4.4.10.jar": {
+        "sha1": "acc54d9b28bdffe4bbde89ed2e4a1e86b5285e2b",
+        "sha256": "1zgn37d608z6fw94cpfi881l6xl8cjdia2i0aldxnmqrasb11fkq"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fdcd45abd94151f990a359e1d367e325cfb50286",
-      "sha256": "1ynpdjf3jzpcdv9b0h8i4v1jdh13qsiavb9ixingxb2xnd4xifiw"
-    },
-    "jar": {
-      "sha1": "51cf043c87253c9f58b539c9f7e44c8894223850",
-      "sha256": "0ks69r3jmr96y1ll8415a6wg583mdynrmlrsw9lc97d08b8kv6vc"
+    "path": "org/apache/httpcomponents/httpcore/4.4.16",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpcore-4.4.16.pom": {
+        "sha1": "fdcd45abd94151f990a359e1d367e325cfb50286",
+        "sha256": "1ynpdjf3jzpcdv9b0h8i4v1jdh13qsiavb9ixingxb2xnd4xifiw"
+      },
+      "httpcore-4.4.16.jar": {
+        "sha1": "51cf043c87253c9f58b539c9f7e44c8894223850",
+        "sha256": "0ks69r3jmr96y1ll8415a6wg583mdynrmlrsw9lc97d08b8kv6vc"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpmime/4.1/httpmime-4.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a9e269c38cd5736d1db3a0e50adf87fafa8504a8",
-      "sha256": "1lbkfv2qdkhsijfgswmn5gx15rs2hlz89wjk2rg6008hxidxjg6v"
-    },
-    "jar": {
-      "sha1": "9ba2dcdf94ce35c8a8e9bff242db0618ca932e92",
-      "sha256": "1ahmkd6g4jw202ybwcsvs4z7ik9yph544fz4i9l4g2lf2ik9aqii"
+    "path": "org/apache/httpcomponents/httpmime/4.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpmime-4.1.pom": {
+        "sha1": "a9e269c38cd5736d1db3a0e50adf87fafa8504a8",
+        "sha256": "1lbkfv2qdkhsijfgswmn5gx15rs2hlz89wjk2rg6008hxidxjg6v"
+      },
+      "httpmime-4.1.jar": {
+        "sha1": "9ba2dcdf94ce35c8a8e9bff242db0618ca932e92",
+        "sha256": "1ahmkd6g4jw202ybwcsvs4z7ik9yph544fz4i9l4g2lf2ik9aqii"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpmime/4.5.2/httpmime-4.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9bfedb5d7d9aab32d9ed2377ed8bde2e49ef9e51",
-      "sha256": "111pbflfshg414sx0m0bk62s8ipchqhskapwvsd0486qf9i5njq0"
-    },
-    "jar": {
-      "sha1": "22b4c53dd9b6761024258de8f9240c3dce6ea368",
-      "sha256": "01wg3zi4i8q3m2nximvx7a54bz385r1daqc4psr3s1b295z3y6i3"
+    "path": "org/apache/httpcomponents/httpmime/4.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpmime-4.5.2.pom": {
+        "sha1": "9bfedb5d7d9aab32d9ed2377ed8bde2e49ef9e51",
+        "sha256": "111pbflfshg414sx0m0bk62s8ipchqhskapwvsd0486qf9i5njq0"
+      },
+      "httpmime-4.5.2.jar": {
+        "sha1": "22b4c53dd9b6761024258de8f9240c3dce6ea368",
+        "sha256": "01wg3zi4i8q3m2nximvx7a54bz385r1daqc4psr3s1b295z3y6i3"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/httpmime/4.5.6/httpmime-4.5.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b9dcad423fba1978379049cf0cf3cf535c667af7",
-      "sha256": "1jm8iafv182mdyfy7g85p0h86mwagym6aqy42yccm157wbzxdgyz"
-    },
-    "jar": {
-      "sha1": "164343da11db817e81e24e0d9869527e069850c9",
-      "sha256": "0gjmlznpcrr51r761raa2xb60vqsa2vvj53jlw2pwg4dq4112aqb"
+    "path": "org/apache/httpcomponents/httpmime/4.5.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "httpmime-4.5.6.pom": {
+        "sha1": "b9dcad423fba1978379049cf0cf3cf535c667af7",
+        "sha256": "1jm8iafv182mdyfy7g85p0h86mwagym6aqy42yccm157wbzxdgyz"
+      },
+      "httpmime-4.5.6.jar": {
+        "sha1": "164343da11db817e81e24e0d9869527e069850c9",
+        "sha256": "0gjmlznpcrr51r761raa2xb60vqsa2vvj53jlw2pwg4dq4112aqb"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/project/4.1.1/project-4.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "34c04480e3e97bccf10777c94651479b5ff55278",
-      "sha256": "1v7qi1k2g9zbadaap6ln02p04hkika2nkbqigjik6kpmvx24vfr1"
+    "path": "org/apache/httpcomponents/project/4.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "project-4.1.1.pom": {
+        "sha1": "34c04480e3e97bccf10777c94651479b5ff55278",
+        "sha256": "1v7qi1k2g9zbadaap6ln02p04hkika2nkbqigjik6kpmvx24vfr1"
+      }
     }
   },
 
   {
-    "path": "org/apache/httpcomponents/project/7/project-7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c486760d8e0eafe8d4932450e386c2805364f782",
-      "sha256": "1hs8m8cgyypd6vb882zjyns58nhzrkm7cpbb0kg5i9amhm1blvix"
+    "path": "org/apache/httpcomponents/project/7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "project-7.pom": {
+        "sha1": "c486760d8e0eafe8d4932450e386c2805364f782",
+        "sha256": "1hs8m8cgyypd6vb882zjyns58nhzrkm7cpbb0kg5i9amhm1blvix"
+      }
     }
   },
 
   {
-    "path": "org/bouncycastle/bcpkix-jdk15on/1.48/bcpkix-jdk15on-1.48",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8fc7cecdba5ea3df0e29b659613dc21222a910fa",
-      "sha256": "0z91vn29rq51r1p14kndr1p47kb7xc01smd1p2p44ba8mjdgyz5z"
-    },
-    "jar": {
-      "sha1": "28b7614b908a47844bb27e3c94b45b6893656265",
-      "sha256": "0dxss10nkpwyg5w1hyp5yd1vrk8m9p2id2x1d1wxgap5nhv36isk"
+    "path": "org/bouncycastle/bcpkix-jdk15on/1.48",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bcpkix-jdk15on-1.48.pom": {
+        "sha1": "8fc7cecdba5ea3df0e29b659613dc21222a910fa",
+        "sha256": "0z91vn29rq51r1p14kndr1p47kb7xc01smd1p2p44ba8mjdgyz5z"
+      },
+      "bcpkix-jdk15on-1.48.jar": {
+        "sha1": "28b7614b908a47844bb27e3c94b45b6893656265",
+        "sha256": "0dxss10nkpwyg5w1hyp5yd1vrk8m9p2id2x1d1wxgap5nhv36isk"
+      }
     }
   },
 
   {
-    "path": "org/bouncycastle/bcpkix-jdk15on/1.56/bcpkix-jdk15on-1.56",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2e2e47a19e0c53e7d204a6ad071c9e64c7c4c43f",
-      "sha256": "0n82rzpyr0p0vvnkppma904zdfgby5wwfwycp4718wsa8zy6h5ij"
-    },
-    "jar": {
-      "sha1": "4648af70268b6fdb24674fb1fd7c1fcc73db1231",
-      "sha256": "1jn60798vsqnp7l6fmkmbwy8kjqyxjqlavxkw29mw5z7x7jdwhvh"
+    "path": "org/bouncycastle/bcpkix-jdk15on/1.56",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bcpkix-jdk15on-1.56.pom": {
+        "sha1": "2e2e47a19e0c53e7d204a6ad071c9e64c7c4c43f",
+        "sha256": "0n82rzpyr0p0vvnkppma904zdfgby5wwfwycp4718wsa8zy6h5ij"
+      },
+      "bcpkix-jdk15on-1.56.jar": {
+        "sha1": "4648af70268b6fdb24674fb1fd7c1fcc73db1231",
+        "sha256": "1jn60798vsqnp7l6fmkmbwy8kjqyxjqlavxkw29mw5z7x7jdwhvh"
+      }
     }
   },
 
   {
-    "path": "org/bouncycastle/bcprov-jdk15on/1.48/bcprov-jdk15on-1.48",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "645352132b8d239bcc737c3c164f435af97cd9bb",
-      "sha256": "10krh8bnjf2rypqqpfh4ik1jnqpbifcs4g8yakyb9hcf9bkjn4i9"
-    },
-    "jar": {
-      "sha1": "960dea7c9181ba0b17e8bab0c06a43f0a5f04e65",
-      "sha256": "12129q8rmqwlvj6z4j0gc3w0hq5ccrkf2gdlsggp3iws7cp7wjw0"
+    "path": "org/bouncycastle/bcprov-jdk15on/1.48",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bcprov-jdk15on-1.48.pom": {
+        "sha1": "645352132b8d239bcc737c3c164f435af97cd9bb",
+        "sha256": "10krh8bnjf2rypqqpfh4ik1jnqpbifcs4g8yakyb9hcf9bkjn4i9"
+      },
+      "bcprov-jdk15on-1.48.jar": {
+        "sha1": "960dea7c9181ba0b17e8bab0c06a43f0a5f04e65",
+        "sha256": "12129q8rmqwlvj6z4j0gc3w0hq5ccrkf2gdlsggp3iws7cp7wjw0"
+      }
     }
   },
 
   {
-    "path": "org/bouncycastle/bcprov-jdk15on/1.56/bcprov-jdk15on-1.56",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "16220ab4e1b41786b0396e908ed91437c620ee3c",
-      "sha256": "0vjw9dx654i469fb87jdjp08sy3xvs3qpi597ccp665hwwv37p4g"
-    },
-    "jar": {
-      "sha1": "a153c6f9744a3e9dd6feab5e210e1c9861362ec7",
-      "sha256": "0jc3hy7p50iy626v2zl6vbfr3yi8vgf8v13xi6czp3w09zhiwgln"
+    "path": "org/bouncycastle/bcprov-jdk15on/1.56",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bcprov-jdk15on-1.56.pom": {
+        "sha1": "16220ab4e1b41786b0396e908ed91437c620ee3c",
+        "sha256": "0vjw9dx654i469fb87jdjp08sy3xvs3qpi597ccp665hwwv37p4g"
+      },
+      "bcprov-jdk15on-1.56.jar": {
+        "sha1": "a153c6f9744a3e9dd6feab5e210e1c9861362ec7",
+        "sha256": "0jc3hy7p50iy626v2zl6vbfr3yi8vgf8v13xi6czp3w09zhiwgln"
+      }
     }
   },
 
   {
-    "path": "org/bouncycastle/bcprov-jdk15on/1.60/bcprov-jdk15on-1.60",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2e5c6ffc32983b3bf170a97d3370b277b9b2ea34",
-      "sha256": "1dm2vj11gihcqvpiw8fj7ryc5bqgblf7spid4nddihz6n5x32x3i"
-    },
-    "jar": {
-      "sha1": "bd47ad3bd14b8e82595c7adaa143501e60842a84",
-      "sha256": "01zfnxrw3kgk6knnff32r272ysv5jvpa1ab7hipncf5bmmmhw6kz"
+    "path": "org/bouncycastle/bcprov-jdk15on/1.60",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bcprov-jdk15on-1.60.pom": {
+        "sha1": "2e5c6ffc32983b3bf170a97d3370b277b9b2ea34",
+        "sha256": "1dm2vj11gihcqvpiw8fj7ryc5bqgblf7spid4nddihz6n5x32x3i"
+      },
+      "bcprov-jdk15on-1.60.jar": {
+        "sha1": "bd47ad3bd14b8e82595c7adaa143501e60842a84",
+        "sha256": "01zfnxrw3kgk6knnff32r272ysv5jvpa1ab7hipncf5bmmmhw6kz"
+      }
     }
   },
 
   {
-    "path": "org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "696dce53f1cd6ea922402e76a6adce522cedda05",
-      "sha256": "1c5b2vhc175kf34qkjq76s0awm3iwn2s435dciv02qlhdnvvbx3d"
-    },
-    "jar": {
-      "sha1": "4636a0d01f74acaf28082fb62b317f1080118371",
-      "sha256": "1m1hmjyv3jkg94k70amn76ngimyh6xx8bm786dpx4rfmwbij0g4g"
+    "path": "org/bouncycastle/bcprov-jdk15on/1.70",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "bcprov-jdk15on-1.70.pom": {
+        "sha1": "696dce53f1cd6ea922402e76a6adce522cedda05",
+        "sha256": "1c5b2vhc175kf34qkjq76s0awm3iwn2s435dciv02qlhdnvvbx3d"
+      },
+      "bcprov-jdk15on-1.70.jar": {
+        "sha1": "4636a0d01f74acaf28082fb62b317f1080118371",
+        "sha256": "1m1hmjyv3jkg94k70amn76ngimyh6xx8bm786dpx4rfmwbij0g4g"
+      }
     }
   },
 
   {
-    "path": "org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7cee753353b0fc94e0300ad3dbf155069260c4d7",
-      "sha256": "1plykj2ikqjyjpl2jdzk00m34ahhdlh8x31kq89x0qk4lcwd8k6w"
-    },
-    "jar": {
-      "sha1": "cea74543d5904a30861a61b4643a5f2bb372efc4",
-      "sha256": "02h4iibbzqwy5i9bfqp6h5p2rsp7vi1fgqlf1xqfgm5rr28jdc34"
+    "path": "org/checkerframework/checker-qual/2.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "checker-qual-2.5.2.pom": {
+        "sha1": "7cee753353b0fc94e0300ad3dbf155069260c4d7",
+        "sha256": "1plykj2ikqjyjpl2jdzk00m34ahhdlh8x31kq89x0qk4lcwd8k6w"
+      },
+      "checker-qual-2.5.2.jar": {
+        "sha1": "cea74543d5904a30861a61b4643a5f2bb372efc4",
+        "sha256": "02h4iibbzqwy5i9bfqp6h5p2rsp7vi1fgqlf1xqfgm5rr28jdc34"
+      }
     }
   },
 
   {
-    "path": "org/checkerframework/checker-qual/3.31.0/checker-qual-3.31.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a600a4210e8c3db6ea45ea0989920b0255dbb6f6",
-      "sha256": "0cajb4ivvw446lc3bcwl49difmpgg1rrcbzklxc87rs7pqz9qms3"
-    },
-    "jar": {
-      "sha1": "eeefd4af42e2f4221d145c1791582f91868f99ab",
-      "sha256": "1fai6kk72j76ivgipgl7ckbcn8g8yl289pbx712zpii2dm3mzvqw"
+    "path": "org/checkerframework/checker-qual/3.32.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "checker-qual-3.32.0.pom": {
+        "sha1": "69d7d01436d892d55b202ccec8a7066f0ac41f98",
+        "sha256": "1kvxly5fpws3prsar57rmjqq6hcy2a0b5fpx60fgmpkf59jqhnkr"
+      },
+      "checker-qual-3.32.0.jar": {
+        "sha1": "54ebd61f46b58b862c779e034073a93489ab3faf",
+        "sha256": "1k9wsy7wvh5304aaqb51hlgpfciahg5avzgmnzq8bgx6l1fh4vmn"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/codehaus-parent/4/codehaus-parent-4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "8b133202d50bec1e59bddc9392cb44d1fe5facc8",
-      "sha256": "1pqlw2ilzagcl5ahq9dv60cxw59yrvrwf9q6z0679qf2x1yj71vb"
+    "path": "org/codehaus/codehaus-parent/4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "codehaus-parent-4.pom": {
+        "sha1": "8b133202d50bec1e59bddc9392cb44d1fe5facc8",
+        "sha256": "1pqlw2ilzagcl5ahq9dv60cxw59yrvrwf9q6z0679qf2x1yj71vb"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/groovy/groovy-all/2.4.15/groovy-all-2.4.15",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c67938b8f20e75a4c025b9519b78c138bd17a758",
-      "sha256": "0yinfr31ybi8c8h0ppf62gqpghrm5a72w71jc82sjz6vgdfm63gw"
-    },
-    "jar": {
-      "sha1": "423a17aeb2f64bc6f76e8e44265a548bec80fd42",
-      "sha256": "1w2siawsbap3aqvp06jynw7ki79majc4k2ci4ds5ds422zkw9mji"
+    "path": "org/codehaus/groovy/groovy-all/2.4.15",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "groovy-all-2.4.15.pom": {
+        "sha1": "c67938b8f20e75a4c025b9519b78c138bd17a758",
+        "sha256": "0yinfr31ybi8c8h0ppf62gqpghrm5a72w71jc82sjz6vgdfm63gw"
+      },
+      "groovy-all-2.4.15.jar": {
+        "sha1": "423a17aeb2f64bc6f76e8e44265a548bec80fd42",
+        "sha256": "1w2siawsbap3aqvp06jynw7ki79majc4k2ci4ds5ds422zkw9mji"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "99a56e3312f8ece1d457c8ca0a3c4b69d173d000",
-      "sha256": "09ianw2880ch3x6xq5d2cz2b15ik6f4ndf8hb7ckw7lr0ndg2y8q"
-    },
-    "jar": {
-      "sha1": "775b7e22fb10026eed3f86e8dc556dfafe35f2d5",
-      "sha256": "0pchd4360mim0f0a6vwr33szigihgvv4ic1scz1l9mxssq5k4s10"
+    "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animal-sniffer-annotations-1.14.pom": {
+        "sha1": "99a56e3312f8ece1d457c8ca0a3c4b69d173d000",
+        "sha256": "09ianw2880ch3x6xq5d2cz2b15ik6f4ndf8hb7ckw7lr0ndg2y8q"
+      },
+      "animal-sniffer-annotations-1.14.jar": {
+        "sha1": "775b7e22fb10026eed3f86e8dc556dfafe35f2d5",
+        "sha256": "0pchd4360mim0f0a6vwr33szigihgvv4ic1scz1l9mxssq5k4s10"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "80948bd07c5db60753d8d5a9164b8b2272e0842a",
-      "sha256": "1rfbfsnn0kfb4f60dhmb84m4lk99sg90q39h2apap3xl5rfsnmp9"
-    },
-    "jar": {
-      "sha1": "f97ce6decaea32b36101e37979f8b647f00681fb",
-      "sha256": "0lvsfhbc0ixrrp1y7hnfsp1qsr47pw74ydbn5q455v6g7r4lyrcj"
+    "path": "org/codehaus/mojo/animal-sniffer-annotations/1.17",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animal-sniffer-annotations-1.17.pom": {
+        "sha1": "80948bd07c5db60753d8d5a9164b8b2272e0842a",
+        "sha256": "1rfbfsnn0kfb4f60dhmb84m4lk99sg90q39h2apap3xl5rfsnmp9"
+      },
+      "animal-sniffer-annotations-1.17.jar": {
+        "sha1": "f97ce6decaea32b36101e37979f8b647f00681fb",
+        "sha256": "0lvsfhbc0ixrrp1y7hnfsp1qsr47pw74ydbn5q455v6g7r4lyrcj"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/animal-sniffer-annotations/1.22/animal-sniffer-annotations-1.22",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "39f7c8fb367b1511444580e0ddb4cbbd4d7d22ed",
-      "sha256": "1m7d7pm2ddpbf0zmh6i140fai1k9nmrjxz5yvdjl8p1dqm8xzcn3"
-    },
-    "jar": {
-      "sha1": "911f763493163e03d750b369cc162085db09b46b",
-      "sha256": "01zijd5g00j9n3fcdpf47b93sh2hjwzshqgwf7m0a4qb2s77lnzj"
+    "path": "org/codehaus/mojo/animal-sniffer-annotations/1.22",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animal-sniffer-annotations-1.22.pom": {
+        "sha1": "39f7c8fb367b1511444580e0ddb4cbbd4d7d22ed",
+        "sha256": "1m7d7pm2ddpbf0zmh6i140fai1k9nmrjxz5yvdjl8p1dqm8xzcn3"
+      },
+      "animal-sniffer-annotations-1.22.jar": {
+        "sha1": "911f763493163e03d750b369cc162085db09b46b",
+        "sha256": "01zijd5g00j9n3fcdpf47b93sh2hjwzshqgwf7m0a4qb2s77lnzj"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/animal-sniffer-parent/1.14/animal-sniffer-parent-1.14",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "c1e91a9c2f36d9e6d3c7087242d8d9ec56052e5d",
-      "sha256": "1skf65rbw52shb2akgs7xykn06lj1ggp23nbc94vs40ldfh505gm"
+    "path": "org/codehaus/mojo/animal-sniffer-parent/1.14",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animal-sniffer-parent-1.14.pom": {
+        "sha1": "c1e91a9c2f36d9e6d3c7087242d8d9ec56052e5d",
+        "sha256": "1skf65rbw52shb2akgs7xykn06lj1ggp23nbc94vs40ldfh505gm"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/animal-sniffer-parent/1.17/animal-sniffer-parent-1.17",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "eea4b805793494ebb025e5a9926ea3cf1ee8b34d",
-      "sha256": "07xq13f36afp6asw313s08a7gyqm7iijbcdp5mc4q61advqkv80q"
+    "path": "org/codehaus/mojo/animal-sniffer-parent/1.17",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animal-sniffer-parent-1.17.pom": {
+        "sha1": "eea4b805793494ebb025e5a9926ea3cf1ee8b34d",
+        "sha256": "07xq13f36afp6asw313s08a7gyqm7iijbcdp5mc4q61advqkv80q"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/animal-sniffer-parent/1.22/animal-sniffer-parent-1.22",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "661dd518f009aa0f8af1fd83a862f8e8558dbf3f",
-      "sha256": "10f9b87lvdc6nss8knbbldabha16xxxp5lav0ry5cr8dg01n3ca9"
+    "path": "org/codehaus/mojo/animal-sniffer-parent/1.22",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "animal-sniffer-parent-1.22.pom": {
+        "sha1": "661dd518f009aa0f8af1fd83a862f8e8558dbf3f",
+        "sha256": "10f9b87lvdc6nss8knbbldabha16xxxp5lav0ry5cr8dg01n3ca9"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/mojo-parent/34/mojo-parent-34",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "803dc5cf36e504c5a48aa9a321f7fba1d6396733",
-      "sha256": "171a71yz4np2h0nlkm9zx82q6f97wm66kj6afhvrmh23pipmsf9y"
+    "path": "org/codehaus/mojo/mojo-parent/34",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "mojo-parent-34.pom": {
+        "sha1": "803dc5cf36e504c5a48aa9a321f7fba1d6396733",
+        "sha256": "171a71yz4np2h0nlkm9zx82q6f97wm66kj6afhvrmh23pipmsf9y"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/mojo-parent/40/mojo-parent-40",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "d2fa7c95447827e9bbcb8c60bd9484c51202732e",
-      "sha256": "0pkmrd1m1s7s2jhvw9qj40c6c5w0z7n18faqw1kbzy04qk6qsr7w"
+    "path": "org/codehaus/mojo/mojo-parent/40",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "mojo-parent-40.pom": {
+        "sha1": "d2fa7c95447827e9bbcb8c60bd9484c51202732e",
+        "sha256": "0pkmrd1m1s7s2jhvw9qj40c6c5w0z7n18faqw1kbzy04qk6qsr7w"
+      }
     }
   },
 
   {
-    "path": "org/codehaus/mojo/mojo-parent/70/mojo-parent-70",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0aeca3b05dd08ecf88d50babc5d35b4321b22553",
-      "sha256": "02lsig9khm9kgmha4r8rgw3hjg7m5lvx8y7lqdj3fs4krzqir3ib"
+    "path": "org/codehaus/mojo/mojo-parent/70",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "mojo-parent-70.pom": {
+        "sha1": "0aeca3b05dd08ecf88d50babc5d35b4321b22553",
+        "sha256": "02lsig9khm9kgmha4r8rgw3hjg7m5lvx8y7lqdj3fs4krzqir3ib"
+      }
     }
   },
 
   {
-    "path": "org/conscrypt/conscrypt-android/2.0.0/conscrypt-android-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "aar",
-    "pom": {
-      "sha1": "25e058e27a29aca4bd7fdc8e5025d7692eddc5ba",
-      "sha256": "1nirj905nlrkbw040kxhpgvsa846lrdjnykzs356a7ga5w10x7l1"
-    },
-    "jar": {
-      "sha1": "663deffff43ca9ff12a73662058fa4f3ed918614",
-      "sha256": "02gwrljmr2brfjgcgrvyryyn81qiwghcw8ibhs10m1lvlicsa320"
+    "path": "org/conscrypt/conscrypt-android/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "conscrypt-android-2.0.0.pom": {
+        "sha1": "25e058e27a29aca4bd7fdc8e5025d7692eddc5ba",
+        "sha256": "1nirj905nlrkbw040kxhpgvsa846lrdjnykzs356a7ga5w10x7l1"
+      },
+      "conscrypt-android-2.0.0.aar": {
+        "sha1": "663deffff43ca9ff12a73662058fa4f3ed918614",
+        "sha256": "02gwrljmr2brfjgcgrvyryyn81qiwghcw8ibhs10m1lvlicsa320"
+      }
     }
   },
 
   {
-    "path": "org/easymock/easymockclassextension/3.2/easymockclassextension-3.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7a11e8397359652228c0d359de72f8238dafd758",
-      "sha256": "0h20y0nrzhwawd01p74mvgawms7cr8k0j1knd631a7hj0kkh4qna"
-    },
-    "jar": {
-      "sha1": "9c922ad77729f27eb7872aa570287e239a8346da",
-      "sha256": "11vcqya5230cvcig8434ry5mawsqn7a8aa87yfr5kn47xknb7bp2"
+    "path": "org/easymock/easymockclassextension/3.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "easymockclassextension-3.2.pom": {
+        "sha1": "7a11e8397359652228c0d359de72f8238dafd758",
+        "sha256": "0h20y0nrzhwawd01p74mvgawms7cr8k0j1knd631a7hj0kkh4qna"
+      },
+      "easymockclassextension-3.2.jar": {
+        "sha1": "9c922ad77729f27eb7872aa570287e239a8346da",
+        "sha256": "11vcqya5230cvcig8434ry5mawsqn7a8aa87yfr5kn47xknb7bp2"
+      }
     }
   },
 
   {
-    "path": "org/easymock/easymock-parent/3.2/easymock-parent-3.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "1d130e585b385841b0ac06f546e0fcd859074620",
-      "sha256": "13mkvvs81ma80djyn8ikpq3652i5dbj56x38avqxb9gbr7hgfbx6"
+    "path": "org/easymock/easymock-parent/3.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "easymock-parent-3.2.pom": {
+        "sha1": "1d130e585b385841b0ac06f546e0fcd859074620",
+        "sha256": "13mkvvs81ma80djyn8ikpq3652i5dbj56x38avqxb9gbr7hgfbx6"
+      }
     }
   },
 
   {
-    "path": "org/easymock/easymock-parent/5.1.0/easymock-parent-5.1.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "aa65d01ea878d85642ac56c6e68504725613933e",
-      "sha256": "1ivahq8x7lihn61nxv9hirqwmpz2mpy8nm6045rfb7w4g2mq93k0"
+    "path": "org/easymock/easymock-parent/5.1.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "easymock-parent-5.1.0.pom": {
+        "sha1": "aa65d01ea878d85642ac56c6e68504725613933e",
+        "sha256": "1ivahq8x7lihn61nxv9hirqwmpz2mpy8nm6045rfb7w4g2mq93k0"
+      }
     }
   },
 
   {
-    "path": "org/easymock/easymock/5.1.0/easymock-5.1.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3f78c28fe129d1af50f3fd3e153ededd0e5c77c2",
-      "sha256": "059pjirrbw2m904ac3402a1nybj8fxp8kj71l5vj29id0pjsp2sg"
-    },
-    "jar": {
-      "sha1": "0b699beae4f519f06c587674b62dcfe5fb437f1c",
-      "sha256": "16nwd28d3yphrckq9n9l8pys6l78jq113c96zgif6nr77syq699z"
+    "path": "org/easymock/easymock/5.1.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "easymock-5.1.0.pom": {
+        "sha1": "3f78c28fe129d1af50f3fd3e153ededd0e5c77c2",
+        "sha256": "059pjirrbw2m904ac3402a1nybj8fxp8kj71l5vj29id0pjsp2sg"
+      },
+      "easymock-5.1.0.jar": {
+        "sha1": "0b699beae4f519f06c587674b62dcfe5fb437f1c",
+        "sha256": "16nwd28d3yphrckq9n9l8pys6l78jq113c96zgif6nr77syq699z"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/angus/angus-activation-project/2.0.0/angus-activation-project-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "6fafee47a73b1ee5dc0f533bcaebc55743bbee84",
-      "sha256": "17ffihwphiw6vzwxb3gkrxbjcsby640wmadj43rbcfamn6icwrjx"
+    "path": "org/eclipse/angus/angus-activation-project/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "angus-activation-project-2.0.0.pom": {
+        "sha1": "6fafee47a73b1ee5dc0f533bcaebc55743bbee84",
+        "sha256": "17ffihwphiw6vzwxb3gkrxbjcsby640wmadj43rbcfamn6icwrjx"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/angus/angus-activation/2.0.0/angus-activation-2.0.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "87500cdbfdcb4758ece7ca2267469a590e2d9fb9",
-      "sha256": "1sb92gyb9fk3fqysrsr021wdan191i6wgq845gkf4lnk4rbgcqsr"
-    },
-    "jar": {
-      "sha1": "72369f4e2314d38de2dcbb277141ef0226f73151",
-      "sha256": "0iwi0y1ksir12z47gc0q7y7bfxnylf9yxdprix2sjnpkl0hx64is"
+    "path": "org/eclipse/angus/angus-activation/2.0.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "angus-activation-2.0.0.pom": {
+        "sha1": "87500cdbfdcb4758ece7ca2267469a590e2d9fb9",
+        "sha256": "1sb92gyb9fk3fqysrsr021wdan191i6wgq845gkf4lnk4rbgcqsr"
+      },
+      "angus-activation-2.0.0.jar": {
+        "sha1": "72369f4e2314d38de2dcbb277141ef0226f73151",
+        "sha256": "0iwi0y1ksir12z47gc0q7y7bfxnylf9yxdprix2sjnpkl0hx64is"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/ee4j/project/1.0.7/project-1.0.7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "b0f6c4bc691a0b694a377edc9bc4777871647253",
-      "sha256": "01gi321g5j0d4s2byxdxa2awz8xk7r44mc5yxxb3bbnb8ad06p10"
+    "path": "org/eclipse/ee4j/project/1.0.7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "project-1.0.7.pom": {
+        "sha1": "b0f6c4bc691a0b694a377edc9bc4777871647253",
+        "sha256": "01gi321g5j0d4s2byxdxa2awz8xk7r44mc5yxxb3bbnb8ad06p10"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/ee4j/project/1.0.8/project-1.0.8",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "41a621037931f9f4aa8768694be9f5cb59df83df",
-      "sha256": "0jv7vwx72mx30ydlhk5ql3q8zb67m2qpw43f4inaypm3aip7n30d"
+    "path": "org/eclipse/ee4j/project/1.0.8",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "project-1.0.8.pom": {
+        "sha1": "41a621037931f9f4aa8768694be9f5cb59df83df",
+        "sha256": "0jv7vwx72mx30ydlhk5ql3q8zb67m2qpw43f4inaypm3aip7n30d"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/jdt/core/compiler/ecj/4.4.2/ecj-4.4.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b0bbf104bd2030ae98a2ec99ff4940cfd0106423",
-      "sha256": "14aman9k2n7zpgab8y40f3rnqwwn822za8yhfndi4hbmjcia1a0g"
-    },
-    "jar": {
-      "sha1": "71d67f5bab9465ec844596ef844f40902ae25392",
-      "sha256": "1lg6lfgh6izblc81rr0404vkbyl7cmpbx0q3dcmh3fmvahay4vid"
+    "path": "org/eclipse/jdt/core/compiler/ecj/4.4.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ecj-4.4.2.pom": {
+        "sha1": "b0bbf104bd2030ae98a2ec99ff4940cfd0106423",
+        "sha256": "14aman9k2n7zpgab8y40f3rnqwwn822za8yhfndi4hbmjcia1a0g"
+      },
+      "ecj-4.4.2.jar": {
+        "sha1": "71d67f5bab9465ec844596ef844f40902ae25392",
+        "sha256": "1lg6lfgh6izblc81rr0404vkbyl7cmpbx0q3dcmh3fmvahay4vid"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/jdt/core/compiler/ecj/4.4/ecj-4.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9dff19e8900783b7e6c520c3e1b44e09523cb0a0",
-      "sha256": "1rdp3hfdn8ra0v2vff5wyb6va65q05m2lcm57k6i72f8jnn6y1ca"
-    },
-    "jar": {
-      "sha1": "fe0a961ce7cca03dd3c9b3775c0133229e8231a6",
-      "sha256": "1g7ys82plhprp0lv73grfnb463v59klny9zvkd0hjjz10824n5hn"
+    "path": "org/eclipse/jdt/core/compiler/ecj/4.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ecj-4.4.pom": {
+        "sha1": "9dff19e8900783b7e6c520c3e1b44e09523cb0a0",
+        "sha256": "1rdp3hfdn8ra0v2vff5wyb6va65q05m2lcm57k6i72f8jnn6y1ca"
+      },
+      "ecj-4.4.jar": {
+        "sha1": "fe0a961ce7cca03dd3c9b3775c0133229e8231a6",
+        "sha256": "1g7ys82plhprp0lv73grfnb463v59klny9zvkd0hjjz10824n5hn"
+      }
     }
   },
 
   {
-    "path": "org/eclipse/jdt/core/compiler/ecj/4.6.1/ecj-4.6.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bdc645b0c5c9c6535844192844245b8de465e8d3",
-      "sha256": "0vvw2gypgf11z8b6cqwp53iz30bz6yabkkvqqhhi7q2dh3l4av2k"
-    },
-    "jar": {
-      "sha1": "5555607add54eb79c5a0729134e663fe2e6300c2",
-      "sha256": "1q5dxv28izkg23wrfiyzazvd15z8ldhpnkplffg4dd51yisxmpcw"
+    "path": "org/eclipse/jdt/core/compiler/ecj/4.6.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ecj-4.6.1.pom": {
+        "sha1": "bdc645b0c5c9c6535844192844245b8de465e8d3",
+        "sha256": "0vvw2gypgf11z8b6cqwp53iz30bz6yabkkvqqhhi7q2dh3l4av2k"
+      },
+      "ecj-4.6.1.jar": {
+        "sha1": "5555607add54eb79c5a0729134e663fe2e6300c2",
+        "sha256": "1q5dxv28izkg23wrfiyzazvd15z8ldhpnkplffg4dd51yisxmpcw"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/jaxb-bom/2.2.11/jaxb-bom-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "eed2bcd59f35f07507c553bbd7da20415cc7f63e",
-      "sha256": "0f4d9p4vgidkq2v6s6gqkc5rpm5gz9fv5l2i59x9zp3hy186hbm5"
+    "path": "org/glassfish/jaxb/jaxb-bom/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-bom-2.2.11.pom": {
+        "sha1": "eed2bcd59f35f07507c553bbd7da20415cc7f63e",
+        "sha256": "0f4d9p4vgidkq2v6s6gqkc5rpm5gz9fv5l2i59x9zp3hy186hbm5"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/jaxb-bom/4.0.2/jaxb-bom-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "12668536ac24e77398bd675a1e458c1824d156c7",
-      "sha256": "08bgmpyhps9h25z6950g7751zg6g5vkvn02v1znamarlaw2niyl6"
+    "path": "org/glassfish/jaxb/jaxb-bom/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-bom-4.0.2.pom": {
+        "sha1": "12668536ac24e77398bd675a1e458c1824d156c7",
+        "sha256": "08bgmpyhps9h25z6950g7751zg6g5vkvn02v1znamarlaw2niyl6"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/jaxb-core/2.2.11/jaxb-core-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f3208abdc61be827cf28838c3881213648807821",
-      "sha256": "094v2z4ai9v6jnq4jwsb9mfqfvapq0g26nagafcvzjiv42gl0cgc"
-    },
-    "jar": {
-      "sha1": "f5745049f5fb9cb9d9b5f513c207727f475983e9",
-      "sha256": "1amjhysjp6hbn6bccr2img6px5l63cigcnra6p464hxhxglaxg1p"
+    "path": "org/glassfish/jaxb/jaxb-core/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-core-2.2.11.pom": {
+        "sha1": "f3208abdc61be827cf28838c3881213648807821",
+        "sha256": "094v2z4ai9v6jnq4jwsb9mfqfvapq0g26nagafcvzjiv42gl0cgc"
+      },
+      "jaxb-core-2.2.11.jar": {
+        "sha1": "f5745049f5fb9cb9d9b5f513c207727f475983e9",
+        "sha256": "1amjhysjp6hbn6bccr2img6px5l63cigcnra6p464hxhxglaxg1p"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/jaxb-core/4.0.2/jaxb-core-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9aecfe4442b96fc3f9cabc25e7c6e310972d674e",
-      "sha256": "00yij4s17cvixysjdjrzc51jd07fpcc11jy4lgg1z8zfvx6zdhma"
-    },
-    "jar": {
-      "sha1": "08c29249f6c10f4ee08967783831580b0f5c5360",
-      "sha256": "1k8c8wf420nmqyhyr6p0ns12mx127bzwq71rp6x0nj3qmma2kzyp"
+    "path": "org/glassfish/jaxb/jaxb-core/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-core-4.0.2.pom": {
+        "sha1": "9aecfe4442b96fc3f9cabc25e7c6e310972d674e",
+        "sha256": "00yij4s17cvixysjdjrzc51jd07fpcc11jy4lgg1z8zfvx6zdhma"
+      },
+      "jaxb-core-4.0.2.jar": {
+        "sha1": "08c29249f6c10f4ee08967783831580b0f5c5360",
+        "sha256": "1k8c8wf420nmqyhyr6p0ns12mx127bzwq71rp6x0nj3qmma2kzyp"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/jaxb-runtime/2.2.11/jaxb-runtime-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6a1651361e4c2392aff30da0df648187f670f8cb",
-      "sha256": "1am4rkx34dli4rxnyrpmgwgbkzl5vz6dadkqx51q3awmnlqpncp5"
-    },
-    "jar": {
-      "sha1": "0065510afc78679e347b0d774617a97fedac94f8",
-      "sha256": "0w7d41amvf7jab7jmfjj3grahvcaq482s073dfaf5a7v3hsz4x58"
+    "path": "org/glassfish/jaxb/jaxb-runtime/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jaxb-runtime-2.2.11.pom": {
+        "sha1": "6a1651361e4c2392aff30da0df648187f670f8cb",
+        "sha256": "1am4rkx34dli4rxnyrpmgwgbkzl5vz6dadkqx51q3awmnlqpncp5"
+      },
+      "jaxb-runtime-2.2.11.jar": {
+        "sha1": "0065510afc78679e347b0d774617a97fedac94f8",
+        "sha256": "0w7d41amvf7jab7jmfjj3grahvcaq482s073dfaf5a7v3hsz4x58"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/txw2/2.2.11/txw2-2.2.11",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4be03527dbf2428f7ea99fb9c2f50f089dffad5e",
-      "sha256": "1n3b8233l5qa5l44866grbrs1l4vacp66ar7ryjmkjjg9drcn545"
-    },
-    "jar": {
-      "sha1": "2df047d8c187a62f2177bf6013f1f9786cdfc8a2",
-      "sha256": "1smgbsxjcmfsahlskir0aa6sng656f32mk9034si2iassk53qai7"
+    "path": "org/glassfish/jaxb/txw2/2.2.11",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "txw2-2.2.11.pom": {
+        "sha1": "4be03527dbf2428f7ea99fb9c2f50f089dffad5e",
+        "sha256": "1n3b8233l5qa5l44866grbrs1l4vacp66ar7ryjmkjjg9drcn545"
+      },
+      "txw2-2.2.11.jar": {
+        "sha1": "2df047d8c187a62f2177bf6013f1f9786cdfc8a2",
+        "sha256": "1smgbsxjcmfsahlskir0aa6sng656f32mk9034si2iassk53qai7"
+      }
     }
   },
 
   {
-    "path": "org/glassfish/jaxb/txw2/4.0.2/txw2-4.0.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f8eef3319522b021e51123ea88d6ab4d484d2c59",
-      "sha256": "1ry99inn7v0fpgfrnhj3h4qnhaccmksn8vsrgfn1ysj6cqrfgc8p"
-    },
-    "jar": {
-      "sha1": "24e167be69c29ebb7ee0a3b1f9b546f1dfd111fc",
-      "sha256": "036gl0lp8y83zxy01pyzvq169i0r03lhm169fw7m6hha9wp92wga"
+    "path": "org/glassfish/jaxb/txw2/4.0.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "txw2-4.0.2.pom": {
+        "sha1": "f8eef3319522b021e51123ea88d6ab4d484d2c59",
+        "sha256": "1ry99inn7v0fpgfrnhj3h4qnhaccmksn8vsrgfn1ysj6cqrfgc8p"
+      },
+      "txw2-4.0.2.jar": {
+        "sha1": "24e167be69c29ebb7ee0a3b1f9b546f1dfd111fc",
+        "sha256": "036gl0lp8y83zxy01pyzvq169i0r03lhm169fw7m6hha9wp92wga"
+      }
     }
   },
 
   {
-    "path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "872e413497b906e7c9fa85ccc96046c5d1ef7ece",
-      "sha256": "14zs9yk20z3qjwkjwa1j1q6vb13mf8hbhsny0fqs2wsij2kqdqzx"
-    },
-    "jar": {
-      "sha1": "42a25dc3219429f0e5d060061f71acb49bf010a0",
-      "sha256": "1sfqqi8p5957hs9yik44an3lwpv8ln2a6sh9gbgli4vkx68yzzb6"
+    "path": "org/hamcrest/hamcrest-core/1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "hamcrest-core-1.3.pom": {
+        "sha1": "872e413497b906e7c9fa85ccc96046c5d1ef7ece",
+        "sha256": "14zs9yk20z3qjwkjwa1j1q6vb13mf8hbhsny0fqs2wsij2kqdqzx"
+      },
+      "hamcrest-core-1.3.jar": {
+        "sha1": "42a25dc3219429f0e5d060061f71acb49bf010a0",
+        "sha256": "1sfqqi8p5957hs9yik44an3lwpv8ln2a6sh9gbgli4vkx68yzzb6"
+      }
     }
   },
 
   {
-    "path": "org/hamcrest/hamcrest-core/2.2/hamcrest-core-2.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "399ab31a6a84f36c84a9f50b9ba82fd890436391",
-      "sha256": "1pg7ikzwdrw9bxv51gf2vl1a4b8wj45q2a4ylg1my6hhypzy5zgp"
-    },
-    "jar": {
-      "sha1": "3f2bd07716a31c395e2837254f37f21f0f0ab24b",
-      "sha256": "0yaqz4xyvxwj9g5pnicr6jffhfi4av9nkk2kpyicindpnj95skq9"
+    "path": "org/hamcrest/hamcrest-core/2.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "hamcrest-core-2.2.pom": {
+        "sha1": "399ab31a6a84f36c84a9f50b9ba82fd890436391",
+        "sha256": "1pg7ikzwdrw9bxv51gf2vl1a4b8wj45q2a4ylg1my6hhypzy5zgp"
+      },
+      "hamcrest-core-2.2.jar": {
+        "sha1": "3f2bd07716a31c395e2837254f37f21f0f0ab24b",
+        "sha256": "0yaqz4xyvxwj9g5pnicr6jffhfi4av9nkk2kpyicindpnj95skq9"
+      }
     }
   },
 
   {
-    "path": "org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "80391bd32bfa4837a15215d5e9f07c60555c379a",
-      "sha256": "16qjwhdvq13mcylsfav41606i52k6d87mwn9havbsqxnxya5ylvd"
+    "path": "org/hamcrest/hamcrest-parent/1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "hamcrest-parent-1.3.pom": {
+        "sha1": "80391bd32bfa4837a15215d5e9f07c60555c379a",
+        "sha256": "16qjwhdvq13mcylsfav41606i52k6d87mwn9havbsqxnxya5ylvd"
+      }
     }
   },
 
   {
-    "path": "org/hamcrest/hamcrest/2.2/hamcrest-2.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "98624f676c4d263b568816b0af5d4f552a2d0501",
-      "sha256": "0zd55y0r76i04rfsnrm93ana54dnqldjlzikvivcygsbdhvkfqdk"
-    },
-    "jar": {
-      "sha1": "1820c0968dba3a11a1b30669bb1f01978a91dedc",
-      "sha256": "1hd1m2bm9z7qs5fla863h21la0nh83rm79f1v66dfp7hi5m88qjy"
+    "path": "org/hamcrest/hamcrest/2.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "hamcrest-2.2.pom": {
+        "sha1": "98624f676c4d263b568816b0af5d4f552a2d0501",
+        "sha256": "0zd55y0r76i04rfsnrm93ana54dnqldjlzikvivcygsbdhvkfqdk"
+      },
+      "hamcrest-2.2.jar": {
+        "sha1": "1820c0968dba3a11a1b30669bb1f01978a91dedc",
+        "sha256": "1hd1m2bm9z7qs5fla863h21la0nh83rm79f1v66dfp7hi5m88qjy"
+      }
     }
   },
 
   {
-    "path": "org/jacoco/org.jacoco.build/0.7.4.201502262128/org.jacoco.build-0.7.4.201502262128",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "f65953b9eb96d0ba6c218b851d4da48374f9d037",
-      "sha256": "0xxi1alqnlr9bavaqg2izzvrnbqd1i8vyjiylqqf5cw1l9hysmph"
+    "path": "org/jacoco/org.jacoco.build/0.7.4.201502262128",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "org.jacoco.build-0.7.4.201502262128.pom": {
+        "sha1": "f65953b9eb96d0ba6c218b851d4da48374f9d037",
+        "sha256": "0xxi1alqnlr9bavaqg2izzvrnbqd1i8vyjiylqqf5cw1l9hysmph"
+      }
     }
   },
 
   {
-    "path": "org/jacoco/org.jacoco.build/0.8.8/org.jacoco.build-0.8.8",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "b1ec2ce6fa11aa065c5c8cea04be7fa745c9fcbc",
-      "sha256": "1vrarvwmzb8gg8k7fmpxx3fh8n9ik1r8ahigfxngq97xhl90pkpl"
+    "path": "org/jacoco/org.jacoco.build/0.8.8",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "org.jacoco.build-0.8.8.pom": {
+        "sha1": "b1ec2ce6fa11aa065c5c8cea04be7fa745c9fcbc",
+        "sha256": "1vrarvwmzb8gg8k7fmpxx3fh8n9ik1r8ahigfxngq97xhl90pkpl"
+      }
     }
   },
 
   {
-    "path": "org/jacoco/org.jacoco.core/0.7.4.201502262128/org.jacoco.core-0.7.4.201502262128",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "28288d676edea9ea4587d9e4b6f5940c5b2afdd1",
-      "sha256": "0xyhchpmj5b13c8p1y9svn92q61prcmdn583rgzxx7cjw4q3czng"
-    },
-    "jar": {
-      "sha1": "31482f50411a3a5769b6c78fa9b97ba731c205e7",
-      "sha256": "1fvsbnq5sax4pycaakpshbhcjd8vz634f5jhcc8wbyhj8dap8k7c"
+    "path": "org/jacoco/org.jacoco.core/0.7.4.201502262128",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "org.jacoco.core-0.7.4.201502262128.pom": {
+        "sha1": "28288d676edea9ea4587d9e4b6f5940c5b2afdd1",
+        "sha256": "0xyhchpmj5b13c8p1y9svn92q61prcmdn583rgzxx7cjw4q3czng"
+      },
+      "org.jacoco.core-0.7.4.201502262128.jar": {
+        "sha1": "31482f50411a3a5769b6c78fa9b97ba731c205e7",
+        "sha256": "1fvsbnq5sax4pycaakpshbhcjd8vz634f5jhcc8wbyhj8dap8k7c"
+      }
     }
   },
 
   {
-    "path": "org/jacoco/org.jacoco.core/0.8.8/org.jacoco.core-0.8.8",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "887670d63e8ac0302fde83422824b5e39736e262",
-      "sha256": "09g2zsc854m5qxy2byqfh20rpk384c1jcl531qybh8zqinjbbypm"
-    },
-    "jar": {
-      "sha1": "fb1257ce77ec2fe326aad639b2253e76f481ea2e",
-      "sha256": "0hqnc5jh8ga60d44hxp59f80ycwxnyng1nyz2d3r524xh0pphk27"
+    "path": "org/jacoco/org.jacoco.core/0.8.8",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "org.jacoco.core-0.8.8.pom": {
+        "sha1": "887670d63e8ac0302fde83422824b5e39736e262",
+        "sha256": "09g2zsc854m5qxy2byqfh20rpk384c1jcl531qybh8zqinjbbypm"
+      },
+      "org.jacoco.core-0.8.8.jar": {
+        "sha1": "fb1257ce77ec2fe326aad639b2253e76f481ea2e",
+        "sha256": "0hqnc5jh8ga60d44hxp59f80ycwxnyng1nyz2d3r524xh0pphk27"
+      }
     }
   },
 
   {
-    "path": "org/jacoco/org.jacoco.report/0.7.4.201502262128/org.jacoco.report-0.7.4.201502262128",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0a99ef0376820e97a5bfe2da266a2f6a68ae5cb5",
-      "sha256": "0hls8g109xj2ykghykjsrmwbdcp13phvjibfi8cjyqsgickillz6"
-    },
-    "jar": {
-      "sha1": "5c6bb5f95ae695dc4510b95f7d5ad0397e4881ad",
-      "sha256": "02gzckmh8hhs3zp2sbry6px4811z4ib4c25i4giyg2700p358dbs"
+    "path": "org/jacoco/org.jacoco.report/0.7.4.201502262128",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "org.jacoco.report-0.7.4.201502262128.pom": {
+        "sha1": "0a99ef0376820e97a5bfe2da266a2f6a68ae5cb5",
+        "sha256": "0hls8g109xj2ykghykjsrmwbdcp13phvjibfi8cjyqsgickillz6"
+      },
+      "org.jacoco.report-0.7.4.201502262128.jar": {
+        "sha1": "5c6bb5f95ae695dc4510b95f7d5ad0397e4881ad",
+        "sha256": "02gzckmh8hhs3zp2sbry6px4811z4ib4c25i4giyg2700p358dbs"
+      }
     }
   },
 
   {
-    "path": "org/jdom/jdom2/2.0.6/jdom2-2.0.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "11e250d112bc9f2a0e1a595a5f6ecd2802af2691",
-      "sha256": "13axlsl2zmqzj885rrq5wib545k8kl26wk23h8dp8srkzrwkmcj7"
-    },
-    "jar": {
-      "sha1": "6f14738ec2e9dd0011e343717fa624a10f8aab64",
-      "sha256": "1xbwm6z7izkifb30wxs0aqhw0iqrqal521blsq1mdl86lqdz2i8k"
+    "path": "org/jdom/jdom2/2.0.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jdom2-2.0.6.pom": {
+        "sha1": "11e250d112bc9f2a0e1a595a5f6ecd2802af2691",
+        "sha256": "13axlsl2zmqzj885rrq5wib545k8kl26wk23h8dp8srkzrwkmcj7"
+      },
+      "jdom2-2.0.6.jar": {
+        "sha1": "6f14738ec2e9dd0011e343717fa624a10f8aab64",
+        "sha256": "1xbwm6z7izkifb30wxs0aqhw0iqrqal521blsq1mdl86lqdz2i8k"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/annotations/13.0/annotations-13.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fa7d3d07cc80547e2d15bf4839d3267c637c642f",
-      "sha256": "15y3p0xicxjx6y38pj39vm3q56xqnfhgf6yyplcrhdpzxlmynnln"
-    },
-    "jar": {
-      "sha1": "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9",
-      "sha256": "0y0l26ys36zlrsw98335a7wc1cl894zc1jjyj8sgvmg2r06s3qmc"
+    "path": "org/jetbrains/annotations/13.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "annotations-13.0.pom": {
+        "sha1": "fa7d3d07cc80547e2d15bf4839d3267c637c642f",
+        "sha256": "15y3p0xicxjx6y38pj39vm3q56xqnfhgf6yyplcrhdpzxlmynnln"
+      },
+      "annotations-13.0.jar": {
+        "sha1": "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9",
+        "sha256": "0y0l26ys36zlrsw98335a7wc1cl894zc1jjyj8sgvmg2r06s3qmc"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ad9cb821b804f05ed013ce89e3ec4d32d101bd79",
-      "sha256": "16h11jpakvz58wl3x8pwrmfyknhfrncgrwa6iwmw6d05v6i6l2ii"
-    },
-    "jar": {
-      "sha1": "216c2e14b070f334479d800987affe4054cd563f",
-      "sha256": "009n13g1iaypik04p4wk2a9xqqqzw56vinzikzvdqyy8lf2pryxg"
+    "path": "org/jetbrains/intellij/deps/trove4j/1.0.20181211",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "trove4j-1.0.20181211.pom": {
+        "sha1": "ad9cb821b804f05ed013ce89e3ec4d32d101bd79",
+        "sha256": "16h11jpakvz58wl3x8pwrmfyknhfrncgrwa6iwmw6d05v6i6l2ii"
+      },
+      "trove4j-1.0.20181211.jar": {
+        "sha1": "216c2e14b070f334479d800987affe4054cd563f",
+        "sha256": "009n13g1iaypik04p4wk2a9xqqqzw56vinzikzvdqyy8lf2pryxg"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-android/1.5.2/kotlinx-coroutines-android-1.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f2aa94138aa8b932c65b8f0ea18a1da1b6616bbb",
-      "sha256": "1rp0k6r3xpad71k2ql1n2zbn01bn04qy4xdxyl5g7753628mhdxz"
-    },
-    "jar": {
-      "sha1": "d246a704a55b7bddb79407cce4348890eaa341d9",
-      "sha256": "0a2r80mpqzc8n1ik1sqrsp3lsqbg6n18mbfpyjl0clxxn299ikw6"
+    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-android/1.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlinx-coroutines-android-1.5.2.pom": {
+        "sha1": "f2aa94138aa8b932c65b8f0ea18a1da1b6616bbb",
+        "sha256": "1rp0k6r3xpad71k2ql1n2zbn01bn04qy4xdxyl5g7753628mhdxz"
+      },
+      "kotlinx-coroutines-android-1.5.2.jar": {
+        "sha1": "d246a704a55b7bddb79407cce4348890eaa341d9",
+        "sha256": "0a2r80mpqzc8n1ik1sqrsp3lsqbg6n18mbfpyjl0clxxn299ikw6"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-common/1.1.1/kotlinx-coroutines-core-common-1.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a0ba9577538052b46751b2e43d23f610b4e4aa9c",
-      "sha256": "0ji3i14vnwk85mjwfl8z33x9aq2ch6f0kirj40f4mb6cwsiima56"
-    },
-    "jar": {
-      "sha1": "7ed04382bdf0c89c5d87ac462aa4935ae8e85243",
-      "sha256": "1rvjhpw1f7ychlm3hnc4mrp564xf0q8k5542g1yqm9nkiwb34dq3"
+    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-common/1.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlinx-coroutines-core-common-1.1.1.pom": {
+        "sha1": "a0ba9577538052b46751b2e43d23f610b4e4aa9c",
+        "sha256": "0ji3i14vnwk85mjwfl8z33x9aq2ch6f0kirj40f4mb6cwsiima56"
+      },
+      "kotlinx-coroutines-core-common-1.1.1.jar": {
+        "sha1": "7ed04382bdf0c89c5d87ac462aa4935ae8e85243",
+        "sha256": "1rvjhpw1f7ychlm3hnc4mrp564xf0q8k5542g1yqm9nkiwb34dq3"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.2/kotlinx-coroutines-core-jvm-1.5.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8affee621ce2df26c98025cbba6fcbf8bc634002",
-      "sha256": "1xdbdcj9vpz2bshacirgl208wd2ylnf5njy2yhdfvjxa331jp9d1"
-    },
-    "jar": {
-      "sha1": "f4cc07a50437659e0043e7da762809a46932b6a0",
-      "sha256": "1h9s5dbw3szcmgzf85230rgp9can7kgmqf1v3z0hb753l65c8513"
+    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlinx-coroutines-core-jvm-1.5.2.pom": {
+        "sha1": "8affee621ce2df26c98025cbba6fcbf8bc634002",
+        "sha256": "1xdbdcj9vpz2bshacirgl208wd2ylnf5njy2yhdfvjxa331jp9d1"
+      },
+      "kotlinx-coroutines-core-jvm-1.5.2.jar": {
+        "sha1": "f4cc07a50437659e0043e7da762809a46932b6a0",
+        "sha256": "1h9s5dbw3szcmgzf85230rgp9can7kgmqf1v3z0hb753l65c8513"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core/1.1.1/kotlinx-coroutines-core-1.1.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "050d1d23e091a12b5aa20f4cbd03c95dcd1a202e",
-      "sha256": "0bw7cklnvl7z1b5x5s53vq6wp3lh8mfn3jlvw8gmd49zgzlmgzl2"
-    },
-    "jar": {
-      "sha1": "3d2b7321cdef9ebf9cb7729ea4f75a6f6457df86",
-      "sha256": "0i3q3yffc9gzbnba30miia61my3i04nghvv9552ygd541a53yhmc"
+    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core/1.1.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlinx-coroutines-core-1.1.1.pom": {
+        "sha1": "050d1d23e091a12b5aa20f4cbd03c95dcd1a202e",
+        "sha256": "0bw7cklnvl7z1b5x5s53vq6wp3lh8mfn3jlvw8gmd49zgzlmgzl2"
+      },
+      "kotlinx-coroutines-core-1.1.1.jar": {
+        "sha1": "3d2b7321cdef9ebf9cb7729ea4f75a6f6457df86",
+        "sha256": "0i3q3yffc9gzbnba30miia61my3i04nghvv9552ygd541a53yhmc"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core/1.3.8/kotlinx-coroutines-core-1.3.8",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4e6547ff543d0b040169fb1c19a03cd6b78504f2",
-      "sha256": "1z87920fjdmi9ds7awy0m780sjaaf6rqzrxjkhs97n5pvxdsdzr4"
-    },
-    "jar": {
-      "sha1": "f62be6d4cbf27781c2969867b4ed952f38378492",
-      "sha256": "1vklc71fi550k8d9w6ca4b9wqkhxkm9lajg9wlw5wmsabm4bgj7q"
+    "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core/1.3.8",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlinx-coroutines-core-1.3.8.pom": {
+        "sha1": "4e6547ff543d0b040169fb1c19a03cd6b78504f2",
+        "sha256": "1z87920fjdmi9ds7awy0m780sjaaf6rqzrxjkhs97n5pvxdsdzr4"
+      },
+      "kotlinx-coroutines-core-1.3.8.jar": {
+        "sha1": "f62be6d4cbf27781c2969867b4ed952f38378492",
+        "sha256": "1vklc71fi550k8d9w6ca4b9wqkhxkm9lajg9wlw5wmsabm4bgj7q"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlinx/kotlinx-metadata-jvm/0.1.0/kotlinx-metadata-jvm-0.1.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b6b8510bd1307e5c859457e7775a864afcc81f80",
-      "sha256": "1jfgg2l8m7qyaac42rrlg2mkfs6qzf2pc4l526gfchkbn71h3k0x"
-    },
-    "jar": {
-      "sha1": "505481587ce23e1d8207734e496632df5c4e6f58",
-      "sha256": "1dg3dcafaq3prfplfjx7vwnbzak9nwy9mpqmbiy9adggxwwvnlwp"
+    "path": "org/jetbrains/kotlinx/kotlinx-metadata-jvm/0.1.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlinx-metadata-jvm-0.1.0.pom": {
+        "sha1": "b6b8510bd1307e5c859457e7775a864afcc81f80",
+        "sha256": "1jfgg2l8m7qyaac42rrlg2mkfs6qzf2pc4l526gfchkbn71h3k0x"
+      },
+      "kotlinx-metadata-jvm-0.1.0.jar": {
+        "sha1": "505481587ce23e1d8207734e496632df5c4e6f58",
+        "sha256": "1dg3dcafaq3prfplfjx7vwnbzak9nwy9mpqmbiy9adggxwwvnlwp"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-android-extensions-runtime/1.4.31/kotlin-android-extensions-runtime-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3a662d24eb03491a1dcec96bcf35462989f93b34",
-      "sha256": "067mg332kiw4d0xavmm4zqcas329rh4lq1j4342h6wzi5spjh3an"
-    },
-    "jar": {
-      "sha1": "14b0c658501829245368d2b8fdef72171e7e3d17",
-      "sha256": "0xvghalwncbxcna079nccfy7qf2s19jwjjz8yfi6j3lpaz55jlrw"
+    "path": "org/jetbrains/kotlin/kotlin-android-extensions-runtime/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-android-extensions-runtime-1.4.31.pom": {
+        "sha1": "3a662d24eb03491a1dcec96bcf35462989f93b34",
+        "sha256": "067mg332kiw4d0xavmm4zqcas329rh4lq1j4342h6wzi5spjh3an"
+      },
+      "kotlin-android-extensions-runtime-1.4.31.jar": {
+        "sha1": "14b0c658501829245368d2b8fdef72171e7e3d17",
+        "sha256": "0xvghalwncbxcna079nccfy7qf2s19jwjjz8yfi6j3lpaz55jlrw"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-android-extensions/1.3.50/kotlin-android-extensions-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5cfefec65dc3b5acaf56ef1beb64b564308c3795",
-      "sha256": "12qnb5kfmhk1waw07dlayd8sjgkcm9h09aj55jsggxxn3di2z6a3"
-    },
-    "jar": {
-      "sha1": "f16428b9ce307d0f5842bd8ed9af1e43a141edd3",
-      "sha256": "01ykg2yi4w893qcdvk6v1lfh2rb1cnv8h0sfzjflypiwp507ydbj"
+    "path": "org/jetbrains/kotlin/kotlin-android-extensions/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-android-extensions-1.3.50.pom": {
+        "sha1": "5cfefec65dc3b5acaf56ef1beb64b564308c3795",
+        "sha256": "12qnb5kfmhk1waw07dlayd8sjgkcm9h09aj55jsggxxn3di2z6a3"
+      },
+      "kotlin-android-extensions-1.3.50.jar": {
+        "sha1": "f16428b9ce307d0f5842bd8ed9af1e43a141edd3",
+        "sha256": "01ykg2yi4w893qcdvk6v1lfh2rb1cnv8h0sfzjflypiwp507ydbj"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-android-extensions/1.4.31/kotlin-android-extensions-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e8daca9188d01ff779a7cba95ec9a31ed8d939d8",
-      "sha256": "05nqxyxjbjaw5f1s95a4pf4gmzbxp17fg6w4bvb06s4slh3xvv79"
-    },
-    "jar": {
-      "sha1": "5837534e7d15215c816bccc74543737b2c0e82ce",
-      "sha256": "145pw71g42xxli27krir2dl1siqwl6l0awpm4yfwdc8gss7f1ms8"
+    "path": "org/jetbrains/kotlin/kotlin-android-extensions/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-android-extensions-1.4.31.pom": {
+        "sha1": "e8daca9188d01ff779a7cba95ec9a31ed8d939d8",
+        "sha256": "05nqxyxjbjaw5f1s95a4pf4gmzbxp17fg6w4bvb06s4slh3xvv79"
+      },
+      "kotlin-android-extensions-1.4.31.jar": {
+        "sha1": "5837534e7d15215c816bccc74543737b2c0e82ce",
+        "sha256": "145pw71g42xxli27krir2dl1siqwl6l0awpm4yfwdc8gss7f1ms8"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-annotation-processing-gradle/1.3.50/kotlin-annotation-processing-gradle-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a17a412371cb1d25bbaa94afe391f5f8d6256abb",
-      "sha256": "1f4bdm36pxrbqhniv34fmrl4zjyf24bq3as82vh0vkih4blndfga"
-    },
-    "jar": {
-      "sha1": "18038b8fd60abf3a80f127596c9ad985b8857edf",
-      "sha256": "1n9n8jgdfy94n8cq6bjnsy7i4x3843in7yvr4lh41dd2vavilm4k"
+    "path": "org/jetbrains/kotlin/kotlin-annotation-processing-gradle/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-annotation-processing-gradle-1.3.50.pom": {
+        "sha1": "a17a412371cb1d25bbaa94afe391f5f8d6256abb",
+        "sha256": "1f4bdm36pxrbqhniv34fmrl4zjyf24bq3as82vh0vkih4blndfga"
+      },
+      "kotlin-annotation-processing-gradle-1.3.50.jar": {
+        "sha1": "18038b8fd60abf3a80f127596c9ad985b8857edf",
+        "sha256": "1n9n8jgdfy94n8cq6bjnsy7i4x3843in7yvr4lh41dd2vavilm4k"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-annotation-processing-gradle/1.4.31/kotlin-annotation-processing-gradle-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "edff249688821d852797b15631212f6b3ad0d201",
-      "sha256": "10n3jhc7iap9i3cvbkrchlsirlcqzaz52m5f138zbpq9cqgqaj8s"
-    },
-    "jar": {
-      "sha1": "1d7a4a1aaafe06e8b62bfb5fc04f66c4afeb7281",
-      "sha256": "0vbh5cd9ilg4q85r2gxjd17ggs6y8q224jn15yxc4ydz7214fp8k"
+    "path": "org/jetbrains/kotlin/kotlin-annotation-processing-gradle/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-annotation-processing-gradle-1.4.31.pom": {
+        "sha1": "edff249688821d852797b15631212f6b3ad0d201",
+        "sha256": "10n3jhc7iap9i3cvbkrchlsirlcqzaz52m5f138zbpq9cqgqaj8s"
+      },
+      "kotlin-annotation-processing-gradle-1.4.31.jar": {
+        "sha1": "1d7a4a1aaafe06e8b62bfb5fc04f66c4afeb7281",
+        "sha256": "0vbh5cd9ilg4q85r2gxjd17ggs6y8q224jn15yxc4ydz7214fp8k"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-build-common/1.3.50/kotlin-build-common-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e5025ee2e0291696a6e239af10f0167d42b6593d",
-      "sha256": "1qdpx1ajwnjwljzhf9yxcflmfs1al2iq3nsqsgjin9g33iv8y50d"
-    },
-    "jar": {
-      "sha1": "b64ece3ce7fad42f2d8fb74e4687c99ca030fe24",
-      "sha256": "0g2xqfnhrggjywq9xj6iyi7c6q9kfq49hdsrgchlvk9gy04afdzw"
+    "path": "org/jetbrains/kotlin/kotlin-build-common/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-build-common-1.3.50.pom": {
+        "sha1": "e5025ee2e0291696a6e239af10f0167d42b6593d",
+        "sha256": "1qdpx1ajwnjwljzhf9yxcflmfs1al2iq3nsqsgjin9g33iv8y50d"
+      },
+      "kotlin-build-common-1.3.50.jar": {
+        "sha1": "b64ece3ce7fad42f2d8fb74e4687c99ca030fe24",
+        "sha256": "0g2xqfnhrggjywq9xj6iyi7c6q9kfq49hdsrgchlvk9gy04afdzw"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-build-common/1.4.31/kotlin-build-common-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "130eaad44fe0e343fab6fe02edb86023e0eccd74",
-      "sha256": "0762q61w7bq56gmqhzskydlnf7rg9vpv6zgszif4m9fwbsk951hc"
-    },
-    "jar": {
-      "sha1": "10e4800d84cb94d26de22ccb4db7aebe7aea1b38",
-      "sha256": "1d1ahrs6psi2vmfj9yzwmqhipzr2q325g0s33la24zdm5yaff1fq"
+    "path": "org/jetbrains/kotlin/kotlin-build-common/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-build-common-1.4.31.pom": {
+        "sha1": "130eaad44fe0e343fab6fe02edb86023e0eccd74",
+        "sha256": "0762q61w7bq56gmqhzskydlnf7rg9vpv6zgszif4m9fwbsk951hc"
+      },
+      "kotlin-build-common-1.4.31.jar": {
+        "sha1": "10e4800d84cb94d26de22ccb4db7aebe7aea1b38",
+        "sha256": "1d1ahrs6psi2vmfj9yzwmqhipzr2q325g0s33la24zdm5yaff1fq"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.50/kotlin-compiler-embeddable-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3c003f60a655f2393bb2b2ad4e9d0de610230448",
-      "sha256": "0m3pgllqhan2w8hb058wd99i258np85p4nx808hp98x90rcc31lv"
-    },
-    "jar": {
-      "sha1": "1251c1768e5769b06c2487d6f6cf8acf6efb8960",
-      "sha256": "1ynixbz6mixd87i16d9qr0a49c1a386zqw318za3kih83xp4ys00"
+    "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-compiler-embeddable-1.3.50.pom": {
+        "sha1": "3c003f60a655f2393bb2b2ad4e9d0de610230448",
+        "sha256": "0m3pgllqhan2w8hb058wd99i258np85p4nx808hp98x90rcc31lv"
+      },
+      "kotlin-compiler-embeddable-1.3.50.jar": {
+        "sha1": "1251c1768e5769b06c2487d6f6cf8acf6efb8960",
+        "sha256": "1ynixbz6mixd87i16d9qr0a49c1a386zqw318za3kih83xp4ys00"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/1.4.31/kotlin-compiler-embeddable-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b2fc49c054b3c13fdbe0efe3c94635e3b3703ea6",
-      "sha256": "094b7364v1i8rbcxcysmbismrfryl0as2rgm83ijlhngy9kkhrqd"
-    },
-    "jar": {
-      "sha1": "06451ea797cef544e81f507b0d9959cd97ae09c0",
-      "sha256": "17irfc3nic63f2z3vnqnmjk0cyvfln27qc8lrpabr5pyfighwjjz"
+    "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-compiler-embeddable-1.4.31.pom": {
+        "sha1": "b2fc49c054b3c13fdbe0efe3c94635e3b3703ea6",
+        "sha256": "094b7364v1i8rbcxcysmbismrfryl0as2rgm83ijlhngy9kkhrqd"
+      },
+      "kotlin-compiler-embeddable-1.4.31.jar": {
+        "sha1": "06451ea797cef544e81f507b0d9959cd97ae09c0",
+        "sha256": "17irfc3nic63f2z3vnqnmjk0cyvfln27qc8lrpabr5pyfighwjjz"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-compiler-runner/1.3.50/kotlin-compiler-runner-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1f24e1320c821eb12869f0f1d0cb9ac4b04122ce",
-      "sha256": "1cr2583lqhdk373ail3m216p4w81nwyga9zb45y99m7cisvwc9pp"
-    },
-    "jar": {
-      "sha1": "2a4774c753d76ad15d58f19e2382228358dbcd6d",
-      "sha256": "186icfszj2z6ywhdzzfmfpbcamzcc9ihcx49ak8cy1qybf3mrvwh"
+    "path": "org/jetbrains/kotlin/kotlin-compiler-runner/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-compiler-runner-1.3.50.pom": {
+        "sha1": "1f24e1320c821eb12869f0f1d0cb9ac4b04122ce",
+        "sha256": "1cr2583lqhdk373ail3m216p4w81nwyga9zb45y99m7cisvwc9pp"
+      },
+      "kotlin-compiler-runner-1.3.50.jar": {
+        "sha1": "2a4774c753d76ad15d58f19e2382228358dbcd6d",
+        "sha256": "186icfszj2z6ywhdzzfmfpbcamzcc9ihcx49ak8cy1qybf3mrvwh"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-compiler-runner/1.4.31/kotlin-compiler-runner-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "30f2d65c9727e1f195fde3a700525dafb87714e3",
-      "sha256": "06sv8i5y68vkpk2b0pi1k8ny8r7f1mdby8v1q42jfx74rshna6b2"
-    },
-    "jar": {
-      "sha1": "8be54c7f3ff7e46e7585e6e756f86c780b3d5e1e",
-      "sha256": "1hcahwvxxvnffvidfgd2iwi3qdammjlr055j7sd65wy8vk9fgfk1"
+    "path": "org/jetbrains/kotlin/kotlin-compiler-runner/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-compiler-runner-1.4.31.pom": {
+        "sha1": "30f2d65c9727e1f195fde3a700525dafb87714e3",
+        "sha256": "06sv8i5y68vkpk2b0pi1k8ny8r7f1mdby8v1q42jfx74rshna6b2"
+      },
+      "kotlin-compiler-runner-1.4.31.jar": {
+        "sha1": "8be54c7f3ff7e46e7585e6e756f86c780b3d5e1e",
+        "sha256": "1hcahwvxxvnffvidfgd2iwi3qdammjlr055j7sd65wy8vk9fgfk1"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-daemon-client/1.3.50/kotlin-daemon-client-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f5809e4f2b5ef27194557f36ae043760e2d06759",
-      "sha256": "1spw467qd3qi090l81f2a13cli012ahhidl31m5m0xl225779dd6"
-    },
-    "jar": {
-      "sha1": "4a33801a3fdd652dc9c4d70ced2c16e0ac35f117",
-      "sha256": "1dpsi95w5f4klb9a1akx8r2cfwlj9wkp6nwiczf2q4kk5391nvxb"
+    "path": "org/jetbrains/kotlin/kotlin-daemon-client/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-daemon-client-1.3.50.pom": {
+        "sha1": "f5809e4f2b5ef27194557f36ae043760e2d06759",
+        "sha256": "1spw467qd3qi090l81f2a13cli012ahhidl31m5m0xl225779dd6"
+      },
+      "kotlin-daemon-client-1.3.50.jar": {
+        "sha1": "4a33801a3fdd652dc9c4d70ced2c16e0ac35f117",
+        "sha256": "1dpsi95w5f4klb9a1akx8r2cfwlj9wkp6nwiczf2q4kk5391nvxb"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-daemon-client/1.4.31/kotlin-daemon-client-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8c777b323d956856c81ee461ef4e596acf109cab",
-      "sha256": "0g4byjklzq4cym8symyk5hjiaqymr0lk7cfq160q2kgsx65kdlkr"
-    },
-    "jar": {
-      "sha1": "419157134d513c69d74693334c39f0550b53f546",
-      "sha256": "02b4xll0j891kx0dn9bn2sb0q33cq74g4rr40sy91p7ibbspw0kx"
+    "path": "org/jetbrains/kotlin/kotlin-daemon-client/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-daemon-client-1.4.31.pom": {
+        "sha1": "8c777b323d956856c81ee461ef4e596acf109cab",
+        "sha256": "0g4byjklzq4cym8symyk5hjiaqymr0lk7cfq160q2kgsx65kdlkr"
+      },
+      "kotlin-daemon-client-1.4.31.jar": {
+        "sha1": "419157134d513c69d74693334c39f0550b53f546",
+        "sha256": "02b4xll0j891kx0dn9bn2sb0q33cq74g4rr40sy91p7ibbspw0kx"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/1.3.50/kotlin-daemon-embeddable-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "1bb8a473ec7550c26552b1612ed7752662644a6c",
-      "sha256": "1p23xdns85n31a4pj87297admms6ivzkgy2kyi2sxvgjs59n2waj"
-    },
-    "jar": {
-      "sha1": "5cb93bb33f4c6f833ead0beca4c831668e00cf52",
-      "sha256": "1yhiv7icvfrm1h9gk4xfidh016czlkl1sifhn77xyvsaw1rbicf7"
+    "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-daemon-embeddable-1.3.50.pom": {
+        "sha1": "1bb8a473ec7550c26552b1612ed7752662644a6c",
+        "sha256": "1p23xdns85n31a4pj87297admms6ivzkgy2kyi2sxvgjs59n2waj"
+      },
+      "kotlin-daemon-embeddable-1.3.50.jar": {
+        "sha1": "5cb93bb33f4c6f833ead0beca4c831668e00cf52",
+        "sha256": "1yhiv7icvfrm1h9gk4xfidh016czlkl1sifhn77xyvsaw1rbicf7"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/1.4.31/kotlin-daemon-embeddable-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e3886390a4d23c318376d2d5b4d4562d5c988596",
-      "sha256": "1sz7wc0bxd2jmg5adajydq7rjbd67wgb5yvn2s28vlgbi6sjgpig"
-    },
-    "jar": {
-      "sha1": "10faf8ac3dd5975ed972b2bc395b4ffc7ffde246",
-      "sha256": "0dng745x3mk6id6vwspvfxw819ca97cgzmqykddb29gxnh25gp4p"
+    "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-daemon-embeddable-1.4.31.pom": {
+        "sha1": "e3886390a4d23c318376d2d5b4d4562d5c988596",
+        "sha256": "1sz7wc0bxd2jmg5adajydq7rjbd67wgb5yvn2s28vlgbi6sjgpig"
+      },
+      "kotlin-daemon-embeddable-1.4.31.jar": {
+        "sha1": "10faf8ac3dd5975ed972b2bc395b4ffc7ffde246",
+        "sha256": "0dng745x3mk6id6vwspvfxw819ca97cgzmqykddb29gxnh25gp4p"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-api/1.3.50/kotlin-gradle-plugin-api-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2515afe0bee6e31f0612fadb3e31f0ba7ff53b9f",
-      "sha256": "0nj5ad8pq1kkv5jypds530j2izxyx62cg6ljq2mdg1fkg0slj3zy"
-    },
-    "jar": {
-      "sha1": "b6f3b92e68150198b8f23ffc813e9c6aae76dd49",
-      "sha256": "1ldir2h2s9kn9m4am5yig3gdqiqcwi7a02l7j2yprn6cqhh0cqqh"
+    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-api/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-gradle-plugin-api-1.3.50.pom": {
+        "sha1": "2515afe0bee6e31f0612fadb3e31f0ba7ff53b9f",
+        "sha256": "0nj5ad8pq1kkv5jypds530j2izxyx62cg6ljq2mdg1fkg0slj3zy"
+      },
+      "kotlin-gradle-plugin-api-1.3.50.jar": {
+        "sha1": "b6f3b92e68150198b8f23ffc813e9c6aae76dd49",
+        "sha256": "1ldir2h2s9kn9m4am5yig3gdqiqcwi7a02l7j2yprn6cqhh0cqqh"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-api/1.4.31/kotlin-gradle-plugin-api-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "79ca3be91c54d63dbc30cb740b5684bfb0b03067",
-      "sha256": "1ixwymagkcr2a3gjbjwci6s1wwrgblaphfjfbpq5k0vcgrli821j"
-    },
-    "jar": {
-      "sha1": "63692dfe4484c4f989319cf3429b357c17f772ae",
-      "sha256": "0qp21lijl30w2rylk78ycd949cgl52i87sgazws66ph7np9qw2vw"
+    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-api/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-gradle-plugin-api-1.4.31.pom": {
+        "sha1": "79ca3be91c54d63dbc30cb740b5684bfb0b03067",
+        "sha256": "1ixwymagkcr2a3gjbjwci6s1wwrgblaphfjfbpq5k0vcgrli821j"
+      },
+      "kotlin-gradle-plugin-api-1.4.31.jar": {
+        "sha1": "63692dfe4484c4f989319cf3429b357c17f772ae",
+        "sha256": "0qp21lijl30w2rylk78ycd949cgl52i87sgazws66ph7np9qw2vw"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-model/1.3.50/kotlin-gradle-plugin-model-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f733f06dc89a3f4ccd1fde77dd5ac95f4479bd17",
-      "sha256": "0nngb0fq5xbg7ns0h2m2bj4vns0ivsqf7mfr0lg2v8clcijzf87z"
-    },
-    "jar": {
-      "sha1": "2c706770a3f5af1bb34496ecda4ca2b8a9bb7f86",
-      "sha256": "1pnybswr7j90pbkgf3n3r6wxlfyncgvkrm5jvn3g9p8vi7ckwa7w"
+    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-model/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-gradle-plugin-model-1.3.50.pom": {
+        "sha1": "f733f06dc89a3f4ccd1fde77dd5ac95f4479bd17",
+        "sha256": "0nngb0fq5xbg7ns0h2m2bj4vns0ivsqf7mfr0lg2v8clcijzf87z"
+      },
+      "kotlin-gradle-plugin-model-1.3.50.jar": {
+        "sha1": "2c706770a3f5af1bb34496ecda4ca2b8a9bb7f86",
+        "sha256": "1pnybswr7j90pbkgf3n3r6wxlfyncgvkrm5jvn3g9p8vi7ckwa7w"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-model/1.4.31/kotlin-gradle-plugin-model-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c434bc9afafce644a8a928ddd1862ee3e3329f1c",
-      "sha256": "1jx7ydh5gg2m9l9v9sia6ydyd3zli32l2nw9f2ylm1vyq6kdajz8"
-    },
-    "jar": {
-      "sha1": "5ef6cc1555b3cafdc5d1edbb932a823289fd5a56",
-      "sha256": "1a96b746dr0v22ajdknxvh2ndipxpqsxj8nfv8l16skvwqnc017l"
+    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-model/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-gradle-plugin-model-1.4.31.pom": {
+        "sha1": "c434bc9afafce644a8a928ddd1862ee3e3329f1c",
+        "sha256": "1jx7ydh5gg2m9l9v9sia6ydyd3zli32l2nw9f2ylm1vyq6kdajz8"
+      },
+      "kotlin-gradle-plugin-model-1.4.31.jar": {
+        "sha1": "5ef6cc1555b3cafdc5d1edbb932a823289fd5a56",
+        "sha256": "1a96b746dr0v22ajdknxvh2ndipxpqsxj8nfv8l16skvwqnc017l"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin/1.3.50/kotlin-gradle-plugin-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "89963a567f68092739e0e09bfdf8d2559a01a36b",
-      "sha256": "19a1nifvwb94wmf1w6akark71dbphnxd5ap8vv7mk589wv7wy082"
-    },
-    "jar": {
-      "sha1": "64a7b2a2027c9ff272c09b24817149faa2b1d535",
-      "sha256": "09hzhxysaas396m3k7v9lgfhbsm14l4c84g6xb4kzifszr564pb3"
+    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-gradle-plugin-1.3.50.pom": {
+        "sha1": "89963a567f68092739e0e09bfdf8d2559a01a36b",
+        "sha256": "19a1nifvwb94wmf1w6akark71dbphnxd5ap8vv7mk589wv7wy082"
+      },
+      "kotlin-gradle-plugin-1.3.50.jar": {
+        "sha1": "64a7b2a2027c9ff272c09b24817149faa2b1d535",
+        "sha256": "09hzhxysaas396m3k7v9lgfhbsm14l4c84g6xb4kzifszr564pb3"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin/1.4.31/kotlin-gradle-plugin-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "70c103233a7c9b2212d4b60e684ac4620dcfff92",
-      "sha256": "0gshvrknkkj5y5rbvv0l7g3w1l4psq7sjr4905azdjy2flxk076g"
-    },
-    "jar": {
-      "sha1": "efd48d079489836346cff69c66c77c81e16985d4",
-      "sha256": "1kvx3pzld91vb32lrzgxqyh74l5c4x4vvczdx4gpk9g8vddh7jzw"
+    "path": "org/jetbrains/kotlin/kotlin-gradle-plugin/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-gradle-plugin-1.4.31.pom": {
+        "sha1": "70c103233a7c9b2212d4b60e684ac4620dcfff92",
+        "sha256": "0gshvrknkkj5y5rbvv0l7g3w1l4psq7sjr4905azdjy2flxk076g"
+      },
+      "kotlin-gradle-plugin-1.4.31.jar": {
+        "sha1": "efd48d079489836346cff69c66c77c81e16985d4",
+        "sha256": "1kvx3pzld91vb32lrzgxqyh74l5c4x4vvczdx4gpk9g8vddh7jzw"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/1.4.31/kotlin-klib-commonizer-embeddable-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "06f35542e31797d5b46d5c00eeb372d9bbb4bb60",
-      "sha256": "1ppssla9sg3zpszhlq9nzb8jx1wi3nrd76b18ffw7g1hdrpq429n"
-    },
-    "jar": {
-      "sha1": "73c17f8fdf8fe87f39f3c5ab859d4bf6d3c749a1",
-      "sha256": "1kx5rm78p22rla7q5jqz8f66g404jsyl4c28rqz4kvav9w5alczk"
+    "path": "org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-klib-commonizer-embeddable-1.4.31.pom": {
+        "sha1": "06f35542e31797d5b46d5c00eeb372d9bbb4bb60",
+        "sha256": "1ppssla9sg3zpszhlq9nzb8jx1wi3nrd76b18ffw7g1hdrpq429n"
+      },
+      "kotlin-klib-commonizer-embeddable-1.4.31.jar": {
+        "sha1": "73c17f8fdf8fe87f39f3c5ab859d4bf6d3c749a1",
+        "sha256": "1kx5rm78p22rla7q5jqz8f66g404jsyl4c28rqz4kvav9w5alczk"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-native-utils/1.3.50/kotlin-native-utils-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e38a3bb6c5d9a662f529b1a52eeabf2c8fca67e6",
-      "sha256": "1pny15s2glhqniw6cqwjh5wylcxyskj5hjdzcwhyprw5q41xrr2f"
-    },
-    "jar": {
-      "sha1": "ecc710c0b7d2d6dac5efcff5e4861612b08f2e8f",
-      "sha256": "16zghz336sc9dimswl2c3nnzyzwj829p1nywz0j0qpnwr7d4ya9h"
+    "path": "org/jetbrains/kotlin/kotlin-native-utils/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-native-utils-1.3.50.pom": {
+        "sha1": "e38a3bb6c5d9a662f529b1a52eeabf2c8fca67e6",
+        "sha256": "1pny15s2glhqniw6cqwjh5wylcxyskj5hjdzcwhyprw5q41xrr2f"
+      },
+      "kotlin-native-utils-1.3.50.jar": {
+        "sha1": "ecc710c0b7d2d6dac5efcff5e4861612b08f2e8f",
+        "sha256": "16zghz336sc9dimswl2c3nnzyzwj829p1nywz0j0qpnwr7d4ya9h"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/1.1.3-2/kotlin-reflect-1.1.3-2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e9bd6a29f4ec38157e3c2d11db6426668c21fc9e",
-      "sha256": "16fpliipjmz73xbrz414sb5k6bqfbp49wpm0jcqclispfl69az54"
-    },
-    "jar": {
-      "sha1": "2104f139db2a2d230c529b004c34a0993c4c2f19",
-      "sha256": "1xmxvdy60js2pjxgybaxmxcik0ig84klsds8kfb6knxyrf8zdr8f"
+    "path": "org/jetbrains/kotlin/kotlin-reflect/1.1.3-2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-reflect-1.1.3-2.pom": {
+        "sha1": "e9bd6a29f4ec38157e3c2d11db6426668c21fc9e",
+        "sha256": "16fpliipjmz73xbrz414sb5k6bqfbp49wpm0jcqclispfl69az54"
+      },
+      "kotlin-reflect-1.1.3-2.jar": {
+        "sha1": "2104f139db2a2d230c529b004c34a0993c4c2f19",
+        "sha256": "1xmxvdy60js2pjxgybaxmxcik0ig84klsds8kfb6knxyrf8zdr8f"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/1.2.0/kotlin-reflect-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2db5145a230bda2fc15d38707f202315efdf6a2f",
-      "sha256": "1pdlcfjas68p8bvzcc0apjjx2b01swhn5mrm0zbf6sgd3gd1alpk"
-    },
-    "jar": {
-      "sha1": "4bbda3b5425aa38a9f6960468a29c5ef3e8a28c9",
-      "sha256": "1pb9c3ri3f2yvl1rmhcdwpbjl0g4246n3bglag0dkr6np9rahj2g"
+    "path": "org/jetbrains/kotlin/kotlin-reflect/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-reflect-1.2.0.pom": {
+        "sha1": "2db5145a230bda2fc15d38707f202315efdf6a2f",
+        "sha256": "1pdlcfjas68p8bvzcc0apjjx2b01swhn5mrm0zbf6sgd3gd1alpk"
+      },
+      "kotlin-reflect-1.2.0.jar": {
+        "sha1": "4bbda3b5425aa38a9f6960468a29c5ef3e8a28c9",
+        "sha256": "1pb9c3ri3f2yvl1rmhcdwpbjl0g4246n3bglag0dkr6np9rahj2g"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/1.3.20/kotlin-reflect-1.3.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7cc0e8dc8e9bf863127aee4501449e25e85a6f78",
-      "sha256": "1qix16mvzqyk8wvwcvwhr2mdl2a2j35v4fnzy9bsypr96n6msdka"
-    },
-    "jar": {
-      "sha1": "cd49eec32cf964333faf59e04b4085eac7008477",
-      "sha256": "0f1j6z9z5ii6h8knhypycj7f1d5kfkajq97hdl7dxrsqsrp946pf"
+    "path": "org/jetbrains/kotlin/kotlin-reflect/1.3.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-reflect-1.3.20.pom": {
+        "sha1": "7cc0e8dc8e9bf863127aee4501449e25e85a6f78",
+        "sha256": "1qix16mvzqyk8wvwcvwhr2mdl2a2j35v4fnzy9bsypr96n6msdka"
+      },
+      "kotlin-reflect-1.3.20.jar": {
+        "sha1": "cd49eec32cf964333faf59e04b4085eac7008477",
+        "sha256": "0f1j6z9z5ii6h8knhypycj7f1d5kfkajq97hdl7dxrsqsrp946pf"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/1.3.50/kotlin-reflect-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "45a559389f73d04351da2ae2986d40078e4a7ab3",
-      "sha256": "0d9662f4v3dg3q9qbfgyg7rm6wnz22wcc2b3skpsy2ryb8g1hic7"
-    },
-    "jar": {
-      "sha1": "b499f22fd7c3e9c2e5b6c4005221fa47fc7f9a7a",
-      "sha256": "196pndsn0701g791sbanxqk44y2zja454nfi3gyswm2sxack2n34"
+    "path": "org/jetbrains/kotlin/kotlin-reflect/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-reflect-1.3.50.pom": {
+        "sha1": "45a559389f73d04351da2ae2986d40078e4a7ab3",
+        "sha256": "0d9662f4v3dg3q9qbfgyg7rm6wnz22wcc2b3skpsy2ryb8g1hic7"
+      },
+      "kotlin-reflect-1.3.50.jar": {
+        "sha1": "b499f22fd7c3e9c2e5b6c4005221fa47fc7f9a7a",
+        "sha256": "196pndsn0701g791sbanxqk44y2zja454nfi3gyswm2sxack2n34"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/1.4.31/kotlin-reflect-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5cfd82ac5a5ee1e1d60c94e7390070301f73853e",
-      "sha256": "15rnc1h2zymcnf2zpgyq468j7jm9572r1qw7bhqmz1fx8fwbljcf"
-    },
-    "jar": {
-      "sha1": "63db9d66c3d20f7b8f66196e7ba86969daae8b8a",
-      "sha256": "1wi821w3l7p8wxnpqw9m88a6n5vff02iz9ih3s0xb9vl56sd1yli"
+    "path": "org/jetbrains/kotlin/kotlin-reflect/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-reflect-1.4.31.pom": {
+        "sha1": "5cfd82ac5a5ee1e1d60c94e7390070301f73853e",
+        "sha256": "15rnc1h2zymcnf2zpgyq468j7jm9572r1qw7bhqmz1fx8fwbljcf"
+      },
+      "kotlin-reflect-1.4.31.jar": {
+        "sha1": "63db9d66c3d20f7b8f66196e7ba86969daae8b8a",
+        "sha256": "1wi821w3l7p8wxnpqw9m88a6n5vff02iz9ih3s0xb9vl56sd1yli"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-common/1.3.50/kotlin-scripting-common-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "03c6c80b5f8055e045d6e827ecf17ca6427ff087",
-      "sha256": "0nj5nrkcy6ry6ydjqwf09q12z1iyb0yn0xd29vn03vb93xpswiq2"
-    },
-    "jar": {
-      "sha1": "b8e0110c386c08f46a8c5e45b8c64aece1914867",
-      "sha256": "1z43r4f8qqx92n6l4pvxmmbx98czrhq2pwxp7kjz7w7jw8gdf5nx"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-common/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-common-1.3.50.pom": {
+        "sha1": "03c6c80b5f8055e045d6e827ecf17ca6427ff087",
+        "sha256": "0nj5nrkcy6ry6ydjqwf09q12z1iyb0yn0xd29vn03vb93xpswiq2"
+      },
+      "kotlin-scripting-common-1.3.50.jar": {
+        "sha1": "b8e0110c386c08f46a8c5e45b8c64aece1914867",
+        "sha256": "1z43r4f8qqx92n6l4pvxmmbx98czrhq2pwxp7kjz7w7jw8gdf5nx"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-common/1.4.31/kotlin-scripting-common-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d998790077787c3eff5d835f7823b23eedaf9faa",
-      "sha256": "1ra08kfzq91svbb9xhvrksdihii1i9ikmnahysnijji45jfpz6s9"
-    },
-    "jar": {
-      "sha1": "6c072554c2d163012478a93278b208c7228ad9a4",
-      "sha256": "0g3zjzq98rkwsxyjn60il9cvpj3b15y9s709phn2bcs19d5g8rpc"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-common/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-common-1.4.31.pom": {
+        "sha1": "d998790077787c3eff5d835f7823b23eedaf9faa",
+        "sha256": "1ra08kfzq91svbb9xhvrksdihii1i9ikmnahysnijji45jfpz6s9"
+      },
+      "kotlin-scripting-common-1.4.31.jar": {
+        "sha1": "6c072554c2d163012478a93278b208c7228ad9a4",
+        "sha256": "0g3zjzq98rkwsxyjn60il9cvpj3b15y9s709phn2bcs19d5g8rpc"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.50/kotlin-scripting-compiler-embeddable-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "dfee0a437087798adea937ca54f6c826957fbdb1",
-      "sha256": "1dc7yq14nssc81qb2awp1j4djxqglzrblzjj4xs2d593zfn646rx"
-    },
-    "jar": {
-      "sha1": "8cf679fe2d8cd6fa57e9ca4ca46222d5477f077c",
-      "sha256": "1ica3kyhim3idpjyl3g68j512dssnwky7mn5i3y7y6qahkf6p9xs"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-compiler-embeddable-1.3.50.pom": {
+        "sha1": "dfee0a437087798adea937ca54f6c826957fbdb1",
+        "sha256": "1dc7yq14nssc81qb2awp1j4djxqglzrblzjj4xs2d593zfn646rx"
+      },
+      "kotlin-scripting-compiler-embeddable-1.3.50.jar": {
+        "sha1": "8cf679fe2d8cd6fa57e9ca4ca46222d5477f077c",
+        "sha256": "1ica3kyhim3idpjyl3g68j512dssnwky7mn5i3y7y6qahkf6p9xs"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.4.31/kotlin-scripting-compiler-embeddable-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e6b41e94b17b8e106c629c5b7e73e8cdb5569b50",
-      "sha256": "05iifwrwwakjgha8kalr12lf8q6b7zjzsfcjq2mx3yvj9v3lrk6k"
-    },
-    "jar": {
-      "sha1": "f279e1c63640df6e24371ae9e009ddbe1ad8b723",
-      "sha256": "14kk723sl7362p9xj5jvhqc4vc7n9h68j0gcphksqiii8p18vpyj"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-compiler-embeddable-1.4.31.pom": {
+        "sha1": "e6b41e94b17b8e106c629c5b7e73e8cdb5569b50",
+        "sha256": "05iifwrwwakjgha8kalr12lf8q6b7zjzsfcjq2mx3yvj9v3lrk6k"
+      },
+      "kotlin-scripting-compiler-embeddable-1.4.31.jar": {
+        "sha1": "f279e1c63640df6e24371ae9e009ddbe1ad8b723",
+        "sha256": "14kk723sl7362p9xj5jvhqc4vc7n9h68j0gcphksqiii8p18vpyj"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/1.3.50/kotlin-scripting-compiler-impl-embeddable-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5f9416038ec25cd4d07a8bf3a7b9000b0bb66816",
-      "sha256": "1r9w9sc424nk56w7jbiscavvwbff6s2al36kkm7wp5siza9898rs"
-    },
-    "jar": {
-      "sha1": "cc87aae13b61cdcf296ac9416b464e44f27b6dc4",
-      "sha256": "03s99ryaagiy08p3cn7p3gi0g20gdw1rczkzfrnswq7z5g6arf2a"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-compiler-impl-embeddable-1.3.50.pom": {
+        "sha1": "5f9416038ec25cd4d07a8bf3a7b9000b0bb66816",
+        "sha256": "1r9w9sc424nk56w7jbiscavvwbff6s2al36kkm7wp5siza9898rs"
+      },
+      "kotlin-scripting-compiler-impl-embeddable-1.3.50.jar": {
+        "sha1": "cc87aae13b61cdcf296ac9416b464e44f27b6dc4",
+        "sha256": "03s99ryaagiy08p3cn7p3gi0g20gdw1rczkzfrnswq7z5g6arf2a"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/1.4.31/kotlin-scripting-compiler-impl-embeddable-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fe7a6a6e0a4d4a57e9c165af822fe69edfd6e957",
-      "sha256": "0l85xgxghp3lir8ig8djvyhx868q9vps88mwrnwcp2bp6cs1snmz"
-    },
-    "jar": {
-      "sha1": "12bd0e32075f54b774975d3e14715017fc7cb0c0",
-      "sha256": "01kwp9bw1bcgwzw2vm154kr03y0grbwd8f9jh42f60q3j9n0srm1"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-compiler-impl-embeddable-1.4.31.pom": {
+        "sha1": "fe7a6a6e0a4d4a57e9c165af822fe69edfd6e957",
+        "sha256": "0l85xgxghp3lir8ig8djvyhx868q9vps88mwrnwcp2bp6cs1snmz"
+      },
+      "kotlin-scripting-compiler-impl-embeddable-1.4.31.jar": {
+        "sha1": "12bd0e32075f54b774975d3e14715017fc7cb0c0",
+        "sha256": "01kwp9bw1bcgwzw2vm154kr03y0grbwd8f9jh42f60q3j9n0srm1"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/1.3.50/kotlin-scripting-jvm-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c449dcaf9b8a6771adc38b8acfe8672ca57c21b8",
-      "sha256": "0hr4qlpyhwk2603arldbv08mpr7rsc7q7ickwhr6ks17v87mygs2"
-    },
-    "jar": {
-      "sha1": "53f579e1bee3dab3df915d923ad1bb43bc37cd18",
-      "sha256": "1hn0hjkjclls2k2l5a6bwr6bc0vy4366fd8la3wydlz0iavs2vzs"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-jvm-1.3.50.pom": {
+        "sha1": "c449dcaf9b8a6771adc38b8acfe8672ca57c21b8",
+        "sha256": "0hr4qlpyhwk2603arldbv08mpr7rsc7q7ickwhr6ks17v87mygs2"
+      },
+      "kotlin-scripting-jvm-1.3.50.jar": {
+        "sha1": "53f579e1bee3dab3df915d923ad1bb43bc37cd18",
+        "sha256": "1hn0hjkjclls2k2l5a6bwr6bc0vy4366fd8la3wydlz0iavs2vzs"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/1.4.31/kotlin-scripting-jvm-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "838a90b9a44c4caa7f3c84325bf60db7bcfd3a2d",
-      "sha256": "0a8zrgbym2h4fi0qp8ndn1rk0lljzzvab838nbsa22ca9wq3a1k7"
-    },
-    "jar": {
-      "sha1": "90f94e43428b14e99123eea93411d2b8da9aa72c",
-      "sha256": "1apzrjrpixj5nxrgrcqj29qzkqjpl14nky679g4wjfh8bpx0y3gw"
+    "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-scripting-jvm-1.4.31.pom": {
+        "sha1": "838a90b9a44c4caa7f3c84325bf60db7bcfd3a2d",
+        "sha256": "0a8zrgbym2h4fi0qp8ndn1rk0lljzzvab838nbsa22ca9wq3a1k7"
+      },
+      "kotlin-scripting-jvm-1.4.31.jar": {
+        "sha1": "90f94e43428b14e99123eea93411d2b8da9aa72c",
+        "sha256": "1apzrjrpixj5nxrgrcqj29qzkqjpl14nky679g4wjfh8bpx0y3gw"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-script-runtime/1.3.50/kotlin-script-runtime-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "66865d5ba1ee04d5194e38fb7cd247c56db34676",
-      "sha256": "12z9p0wlagggnfjh0lv13pqvbasyakgxkcpkpqs8786kc1lp9anx"
-    },
-    "jar": {
-      "sha1": "59492b8dfb92522ba0ddb5dd1c4d0ef0a4fca1af",
-      "sha256": "0k3yzdb7w99p839839279b7v129bp6ln52g7l3hgnah6px90rxvz"
+    "path": "org/jetbrains/kotlin/kotlin-script-runtime/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-script-runtime-1.3.50.pom": {
+        "sha1": "66865d5ba1ee04d5194e38fb7cd247c56db34676",
+        "sha256": "12z9p0wlagggnfjh0lv13pqvbasyakgxkcpkpqs8786kc1lp9anx"
+      },
+      "kotlin-script-runtime-1.3.50.jar": {
+        "sha1": "59492b8dfb92522ba0ddb5dd1c4d0ef0a4fca1af",
+        "sha256": "0k3yzdb7w99p839839279b7v129bp6ln52g7l3hgnah6px90rxvz"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-script-runtime/1.4.31/kotlin-script-runtime-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d74379b5051a6928a5417871683bb8a9ccd0d073",
-      "sha256": "11xk9vjsg41fa4y0j40lv1gsbarkd62lg4npj5gph6n82bvcsyq6"
-    },
-    "jar": {
-      "sha1": "183616b52cfb8ddaa8a2a15bf926e87dfcddcde3",
-      "sha256": "1yfk92n3c3y7jsii5fs28bdpwijd0dazjsxwaw9nq9qmhf9zmy5p"
+    "path": "org/jetbrains/kotlin/kotlin-script-runtime/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-script-runtime-1.4.31.pom": {
+        "sha1": "d74379b5051a6928a5417871683bb8a9ccd0d073",
+        "sha256": "11xk9vjsg41fa4y0j40lv1gsbarkd62lg4npj5gph6n82bvcsyq6"
+      },
+      "kotlin-script-runtime-1.4.31.jar": {
+        "sha1": "183616b52cfb8ddaa8a2a15bf926e87dfcddcde3",
+        "sha256": "1yfk92n3c3y7jsii5fs28bdpwijd0dazjsxwaw9nq9qmhf9zmy5p"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.2.71/kotlin-stdlib-common-1.2.71",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bf37a8a32e78a78734cc86154f4e1de85b122b93",
-      "sha256": "14v6gip58pdj6qrxycmr52bcjx9rjni4sjjjjn9rwaq3j9cfvhx8"
-    },
-    "jar": {
-      "sha1": "ba18ca1aa0e40eb6f1865b324af2f4cbb691c1ec",
-      "sha256": "0a7k7hxwzwsgqz6mak04nhk1rlpiz2xzz06i5mcqmkigzy3rd6b3"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.2.71",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.2.71.pom": {
+        "sha1": "bf37a8a32e78a78734cc86154f4e1de85b122b93",
+        "sha256": "14v6gip58pdj6qrxycmr52bcjx9rjni4sjjjjn9rwaq3j9cfvhx8"
+      },
+      "kotlin-stdlib-common-1.2.71.jar": {
+        "sha1": "ba18ca1aa0e40eb6f1865b324af2f4cbb691c1ec",
+        "sha256": "0a7k7hxwzwsgqz6mak04nhk1rlpiz2xzz06i5mcqmkigzy3rd6b3"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.0/kotlin-stdlib-common-1.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8aa25749d6a085239627a0a18f0502c19a5560d0",
-      "sha256": "16xf747dcx5bqsmqkahkm6ywsfg79bzabq8zjwf012pck058fvkw"
-    },
-    "jar": {
-      "sha1": "84a2e0288dc17cd64d692eb1e5e0de8cd5ff0846",
-      "sha256": "0fgyfmsg8rd70q0qxz9yax1f7x26ir50qkqwkfjd3q7f37v1w5jb"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.3.0.pom": {
+        "sha1": "8aa25749d6a085239627a0a18f0502c19a5560d0",
+        "sha256": "16xf747dcx5bqsmqkahkm6ywsfg79bzabq8zjwf012pck058fvkw"
+      },
+      "kotlin-stdlib-common-1.3.0.jar": {
+        "sha1": "84a2e0288dc17cd64d692eb1e5e0de8cd5ff0846",
+        "sha256": "0fgyfmsg8rd70q0qxz9yax1f7x26ir50qkqwkfjd3q7f37v1w5jb"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.20/kotlin-stdlib-common-1.3.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "507fa9faf5120c5c5247bc1b23476ad91760c09c",
-      "sha256": "0c0aa53z5nw430yb199sji0fv34dh6plkg32fgbigrig4qfdv204"
-    },
-    "jar": {
-      "sha1": "7d7934e26ce34da1a0a8d00e38038d7cf3375e89",
-      "sha256": "0jdn79kgs8d4ysap8sabg1qdpk2l2ah8i7af7vpzczilvapdig86"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.3.20.pom": {
+        "sha1": "507fa9faf5120c5c5247bc1b23476ad91760c09c",
+        "sha256": "0c0aa53z5nw430yb199sji0fv34dh6plkg32fgbigrig4qfdv204"
+      },
+      "kotlin-stdlib-common-1.3.20.jar": {
+        "sha1": "7d7934e26ce34da1a0a8d00e38038d7cf3375e89",
+        "sha256": "0jdn79kgs8d4ysap8sabg1qdpk2l2ah8i7af7vpzczilvapdig86"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.31/kotlin-stdlib-common-1.3.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5cd6de0110a706c04138af5daff820031a3861f8",
-      "sha256": "1z1srialmywg2klhq0spmizjnqgs4d1dsk6ncqfm6am77ax1iwa3"
-    },
-    "jar": {
-      "sha1": "20c34a04ea25cb1ef0139598bd67c764562cb170",
-      "sha256": "1z1lrn19y24ga6knw1zqr2ywci2mcrcfap9rx4dz4kbc3r6cbsfn"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.3.31.pom": {
+        "sha1": "5cd6de0110a706c04138af5daff820031a3861f8",
+        "sha256": "1z1srialmywg2klhq0spmizjnqgs4d1dsk6ncqfm6am77ax1iwa3"
+      },
+      "kotlin-stdlib-common-1.3.31.jar": {
+        "sha1": "20c34a04ea25cb1ef0139598bd67c764562cb170",
+        "sha256": "1z1lrn19y24ga6knw1zqr2ywci2mcrcfap9rx4dz4kbc3r6cbsfn"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.50/kotlin-stdlib-common-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cde9d3a23570b97ee3727865a0dec0ac52a61cf7",
-      "sha256": "1h8zarxa4v5b78hzg6yxsgrb5wvmp5n2cpj8h6ipdg6p0bl6yfdn"
-    },
-    "jar": {
-      "sha1": "3d9cd3e1bc7b92e95f43d45be3bfbcf38e36ab87",
-      "sha256": "0g1jkpr5ynhafqcsia2nw7z7sk8y8x9gkv5cdnv1i82bivl7irlc"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.3.50.pom": {
+        "sha1": "cde9d3a23570b97ee3727865a0dec0ac52a61cf7",
+        "sha256": "1h8zarxa4v5b78hzg6yxsgrb5wvmp5n2cpj8h6ipdg6p0bl6yfdn"
+      },
+      "kotlin-stdlib-common-1.3.50.jar": {
+        "sha1": "3d9cd3e1bc7b92e95f43d45be3bfbcf38e36ab87",
+        "sha256": "0g1jkpr5ynhafqcsia2nw7z7sk8y8x9gkv5cdnv1i82bivl7irlc"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.71/kotlin-stdlib-common-1.3.71",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "dc5b708b195cb44fcb098c96c5ed4774a53d5c93",
-      "sha256": "0hb3yv15d114ypwp1dlrkbd993gfg1i7wj7d8skpvvld2i8cpxck"
-    },
-    "jar": {
-      "sha1": "e71c3fef58e26affeb03d675e91fd8abdd44aa7b",
-      "sha256": "1v4jh2lhnh4zr0q1xy9hhlg64wls46mhxzkfm0qdgqzwgfdqlkwp"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.3.71",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.3.71.pom": {
+        "sha1": "dc5b708b195cb44fcb098c96c5ed4774a53d5c93",
+        "sha256": "0hb3yv15d114ypwp1dlrkbd993gfg1i7wj7d8skpvvld2i8cpxck"
+      },
+      "kotlin-stdlib-common-1.3.71.jar": {
+        "sha1": "e71c3fef58e26affeb03d675e91fd8abdd44aa7b",
+        "sha256": "1v4jh2lhnh4zr0q1xy9hhlg64wls46mhxzkfm0qdgqzwgfdqlkwp"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.4.31/kotlin-stdlib-common-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d954657abc560bd88f1045a5aaa1f9349957ccd7",
-      "sha256": "11ri6m9nqb9ndcglbpcgqqxvmy4r3wy5f5g9na4vpz381c9sp0hm"
-    },
-    "jar": {
-      "sha1": "6dd50665802f54ba9bc3f70ecb20227d1bc81323",
-      "sha256": "02270i5smqqmwbnnk6ny0r92bihjhwm8180qh9knnx0s6x22z5jp"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.4.31.pom": {
+        "sha1": "d954657abc560bd88f1045a5aaa1f9349957ccd7",
+        "sha256": "11ri6m9nqb9ndcglbpcgqqxvmy4r3wy5f5g9na4vpz381c9sp0hm"
+      },
+      "kotlin-stdlib-common-1.4.31.jar": {
+        "sha1": "6dd50665802f54ba9bc3f70ecb20227d1bc81323",
+        "sha256": "02270i5smqqmwbnnk6ny0r92bihjhwm8180qh9knnx0s6x22z5jp"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.5.10/kotlin-stdlib-common-1.5.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "0b78bbcc36abf0770a9e84c9ede6a1be18717352",
-      "sha256": "075yx3c6w9kb7ybpf08dpqvaxal8lr96sl1yxrycz2qnjhdmmm9v"
-    },
-    "jar": {
-      "sha1": "06b84d926e28493be69daf673e40076f89492ef7",
-      "sha256": "153r7v5annig3bbmyqa6a9yxnrj8h0951fczh9jzi1fspsacwn6r"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.5.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.5.10.pom": {
+        "sha1": "0b78bbcc36abf0770a9e84c9ede6a1be18717352",
+        "sha256": "075yx3c6w9kb7ybpf08dpqvaxal8lr96sl1yxrycz2qnjhdmmm9v"
+      },
+      "kotlin-stdlib-common-1.5.10.jar": {
+        "sha1": "06b84d926e28493be69daf673e40076f89492ef7",
+        "sha256": "153r7v5annig3bbmyqa6a9yxnrj8h0951fczh9jzi1fspsacwn6r"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.5.30/kotlin-stdlib-common-1.5.30",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "850c3ca345e0afacbfaf203f5259e3e1be59df9e",
-      "sha256": "1g74j6k1lbnljsy2dif47mmc3hrwqch6j6zi1mdp4mh11r812w6d"
-    },
-    "jar": {
-      "sha1": "649ffab7767038323fec0cc41e2d7b0a8f65a378",
-      "sha256": "1f346x78anwcxyj1lbywjz4vwa66la5sgfyhz3h2514p199srcwf"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.5.30",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.5.30.pom": {
+        "sha1": "850c3ca345e0afacbfaf203f5259e3e1be59df9e",
+        "sha256": "1g74j6k1lbnljsy2dif47mmc3hrwqch6j6zi1mdp4mh11r812w6d"
+      },
+      "kotlin-stdlib-common-1.5.30.jar": {
+        "sha1": "649ffab7767038323fec0cc41e2d7b0a8f65a378",
+        "sha256": "1f346x78anwcxyj1lbywjz4vwa66la5sgfyhz3h2514p199srcwf"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.6.20/kotlin-stdlib-common-1.6.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2f237c62ee4a898a4c3a5904988a90c4408e06e4",
-      "sha256": "1j4rg188hvp032ji04srwg3yp53f7xrzhq608lmc9knma69wq11y"
-    },
-    "jar": {
-      "sha1": "27b4562b6713d70f458c6d7ea39aadacb8e6a92b",
-      "sha256": "00dyyrj6zyxh8c1pxhs6wfihhbg84hyyjvqp288cn3fk40jhm94d"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.6.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.6.20.pom": {
+        "sha1": "2f237c62ee4a898a4c3a5904988a90c4408e06e4",
+        "sha256": "1j4rg188hvp032ji04srwg3yp53f7xrzhq608lmc9knma69wq11y"
+      },
+      "kotlin-stdlib-common-1.6.20.jar": {
+        "sha1": "27b4562b6713d70f458c6d7ea39aadacb8e6a92b",
+        "sha256": "00dyyrj6zyxh8c1pxhs6wfihhbg84hyyjvqp288cn3fk40jhm94d"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.7.10/kotlin-stdlib-common-1.7.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "38af1ac562fefcc5e920fc7c1290b480251c5163",
-      "sha256": "1sx8w3x3rniwwq6c0g3kgc1mbg2rflq3fsarbpzwv57fi0xwc48h"
-    },
-    "jar": {
-      "sha1": "bac80c520d0a9e3f3673bc2658c6ed02ef45a76a",
-      "sha256": "1m4ikzjqdpjvbhl0kjhzz53prr1kqlasslrqqsmqx7v2x7ph5w8r"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.7.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.7.10.pom": {
+        "sha1": "38af1ac562fefcc5e920fc7c1290b480251c5163",
+        "sha256": "1sx8w3x3rniwwq6c0g3kgc1mbg2rflq3fsarbpzwv57fi0xwc48h"
+      },
+      "kotlin-stdlib-common-1.7.10.jar": {
+        "sha1": "bac80c520d0a9e3f3673bc2658c6ed02ef45a76a",
+        "sha256": "1m4ikzjqdpjvbhl0kjhzz53prr1kqlasslrqqsmqx7v2x7ph5w8r"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.8.0/kotlin-stdlib-common-1.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "943e647c5b6a8edafb7fa14d01d414165eba8c76",
-      "sha256": "11bvfnbvhbri34s30y72h9x4j5idnakl2zalwi32izcdri3fqxd0"
-    },
-    "jar": {
-      "sha1": "f7197e7cc76453ac59f8b0f8d5137cc600becd36",
-      "sha256": "1cjc3yy442j939nq1dxkwfncn1vv0d6bvyfya7zc0g30kssr7vvq"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-common-1.8.0.pom": {
+        "sha1": "943e647c5b6a8edafb7fa14d01d414165eba8c76",
+        "sha256": "11bvfnbvhbri34s30y72h9x4j5idnakl2zalwi32izcdri3fqxd0"
+      },
+      "kotlin-stdlib-common-1.8.0.jar": {
+        "sha1": "f7197e7cc76453ac59f8b0f8d5137cc600becd36",
+        "sha256": "1cjc3yy442j939nq1dxkwfncn1vv0d6bvyfya7zc0g30kssr7vvq"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.2.71/kotlin-stdlib-jdk7-1.2.71",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "682677def146529534fe87ca026d317804acd436",
-      "sha256": "1cw0f0cvc2fwx3rg4312w0liybxni6l1s6krjkkjij16apcjc54l"
-    },
-    "jar": {
-      "sha1": "4ce93f539e2133f172f1167291a911f83400a5d0",
-      "sha256": "10l0hm329liw5w624pxzlw048n5z3nyx606fj96pvq20n9hvsdmi"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.2.71",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.2.71.pom": {
+        "sha1": "682677def146529534fe87ca026d317804acd436",
+        "sha256": "1cw0f0cvc2fwx3rg4312w0liybxni6l1s6krjkkjij16apcjc54l"
+      },
+      "kotlin-stdlib-jdk7-1.2.71.jar": {
+        "sha1": "4ce93f539e2133f172f1167291a911f83400a5d0",
+        "sha256": "10l0hm329liw5w624pxzlw048n5z3nyx606fj96pvq20n9hvsdmi"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.20/kotlin-stdlib-jdk7-1.3.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "665178dfa4d04de64edecf5f0dbda61b55f8f4e3",
-      "sha256": "1i8n3q7789h09bfli36zyk4daak2hh25qcq8z546lfjd4q36dns9"
-    },
-    "jar": {
-      "sha1": "aa17d6fd473ce53061a7b2b9d2ae96f547cae93d",
-      "sha256": "07dkkyvr1j37rhcf45kadaijr1s3l4y67vfb0gxj9h1bvl5zfapx"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.3.20.pom": {
+        "sha1": "665178dfa4d04de64edecf5f0dbda61b55f8f4e3",
+        "sha256": "1i8n3q7789h09bfli36zyk4daak2hh25qcq8z546lfjd4q36dns9"
+      },
+      "kotlin-stdlib-jdk7-1.3.20.jar": {
+        "sha1": "aa17d6fd473ce53061a7b2b9d2ae96f547cae93d",
+        "sha256": "07dkkyvr1j37rhcf45kadaijr1s3l4y67vfb0gxj9h1bvl5zfapx"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.50/kotlin-stdlib-jdk7-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2fb57f1beb5676a730f533556c0a5fa28177f4a4",
-      "sha256": "12s3g53nx4mz95d6vg5xjbc8fk3rmgrivd8d25syk5pfi1iz9bm3"
-    },
-    "jar": {
-      "sha1": "50ad05ea1c2595fb31b800e76db464d08d599af3",
-      "sha256": "0yymfmgmrh1l3msi14cpy44y1hllac3mpmc6ggazh4k2wwwnc0ls"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.3.50.pom": {
+        "sha1": "2fb57f1beb5676a730f533556c0a5fa28177f4a4",
+        "sha256": "12s3g53nx4mz95d6vg5xjbc8fk3rmgrivd8d25syk5pfi1iz9bm3"
+      },
+      "kotlin-stdlib-jdk7-1.3.50.jar": {
+        "sha1": "50ad05ea1c2595fb31b800e76db464d08d599af3",
+        "sha256": "0yymfmgmrh1l3msi14cpy44y1hllac3mpmc6ggazh4k2wwwnc0ls"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.4.31/kotlin-stdlib-jdk7-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "09ad248cfa8fe2534a9138aaac3c94a12443031c",
-      "sha256": "06114yfbm6cgb5ygzqmx41kxms4xylh5slhyslipx813pjz54zpn"
-    },
-    "jar": {
-      "sha1": "84ce8e85f6e84270b2b501d44e9f0ba6ff64fa71",
-      "sha256": "0r16ym5biiycxna39njc10jldvpkw02cxzaa07bvgx3cx1a6x5hz"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.4.31.pom": {
+        "sha1": "09ad248cfa8fe2534a9138aaac3c94a12443031c",
+        "sha256": "06114yfbm6cgb5ygzqmx41kxms4xylh5slhyslipx813pjz54zpn"
+      },
+      "kotlin-stdlib-jdk7-1.4.31.jar": {
+        "sha1": "84ce8e85f6e84270b2b501d44e9f0ba6ff64fa71",
+        "sha256": "0r16ym5biiycxna39njc10jldvpkw02cxzaa07bvgx3cx1a6x5hz"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.5.30/kotlin-stdlib-jdk7-1.5.30",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "efbcacb7449201f5df0375ceb38d2a603bd5af6b",
-      "sha256": "0xxc7cnf8i4a38k08cg3xkgxcj81sw86dj8jzcvi5r9pz4hcybmd"
-    },
-    "jar": {
-      "sha1": "525f5a7fa6d7790a571c07dd24214ed2dda352fe",
-      "sha256": "0pc2jgzrz9qgjqb4whjdhfackm6w3a59ifvbr5igd6kbdrj41q3w"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.5.30",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.5.30.pom": {
+        "sha1": "efbcacb7449201f5df0375ceb38d2a603bd5af6b",
+        "sha256": "0xxc7cnf8i4a38k08cg3xkgxcj81sw86dj8jzcvi5r9pz4hcybmd"
+      },
+      "kotlin-stdlib-jdk7-1.5.30.jar": {
+        "sha1": "525f5a7fa6d7790a571c07dd24214ed2dda352fe",
+        "sha256": "0pc2jgzrz9qgjqb4whjdhfackm6w3a59ifvbr5igd6kbdrj41q3w"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.6.20/kotlin-stdlib-jdk7-1.6.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4476b8c551258e66dc12bd68eb03159b80c81f63",
-      "sha256": "08dxmrf4aj27jpw7d30szajsqi4g4vrlx2s20f7f51kh4f5dw6w8"
-    },
-    "jar": {
-      "sha1": "f8629f336bad4001c89e9cffa5ef3d4b5d0f5e22",
-      "sha256": "083nsraii88sxb5v3xbq2ck45y01yjdid8kxv66xki2m2gla4bxa"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.6.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.6.20.pom": {
+        "sha1": "4476b8c551258e66dc12bd68eb03159b80c81f63",
+        "sha256": "08dxmrf4aj27jpw7d30szajsqi4g4vrlx2s20f7f51kh4f5dw6w8"
+      },
+      "kotlin-stdlib-jdk7-1.6.20.jar": {
+        "sha1": "f8629f336bad4001c89e9cffa5ef3d4b5d0f5e22",
+        "sha256": "083nsraii88sxb5v3xbq2ck45y01yjdid8kxv66xki2m2gla4bxa"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0/kotlin-stdlib-jdk7-1.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b8a4b9c31ec89be4e5806db4aa92192a9d592bf0",
-      "sha256": "0jhqh08kiahjh5gw3jg6mrqgg88bhdzgbcav8zp9if75d9569afz"
-    },
-    "jar": {
-      "sha1": "3c91271347f678c239607abb676d4032a7898427",
-      "sha256": "0rin2rcw1zhnp9df3vn9c1vaqs93wsvsd4hmdkmz5x83k0frv22c"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk7-1.8.0.pom": {
+        "sha1": "b8a4b9c31ec89be4e5806db4aa92192a9d592bf0",
+        "sha256": "0jhqh08kiahjh5gw3jg6mrqgg88bhdzgbcav8zp9if75d9569afz"
+      },
+      "kotlin-stdlib-jdk7-1.8.0.jar": {
+        "sha1": "3c91271347f678c239607abb676d4032a7898427",
+        "sha256": "0rin2rcw1zhnp9df3vn9c1vaqs93wsvsd4hmdkmz5x83k0frv22c"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.2.71/kotlin-stdlib-jdk8-1.2.71",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "234a35fd330223e98870d7687bf431f3425ba4a6",
-      "sha256": "1cwljpvn11y44m69ipikbq694x9y7y3kkvfplay6cpzdx7q36p44"
-    },
-    "jar": {
-      "sha1": "5470d1f752cd342edb77e1062bac07e838d2cea4",
-      "sha256": "1abfjjcx2d85aabsa4hnmihy0if1y19rll72yys682vr8yzqlg5c"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.2.71",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk8-1.2.71.pom": {
+        "sha1": "234a35fd330223e98870d7687bf431f3425ba4a6",
+        "sha256": "1cwljpvn11y44m69ipikbq694x9y7y3kkvfplay6cpzdx7q36p44"
+      },
+      "kotlin-stdlib-jdk8-1.2.71.jar": {
+        "sha1": "5470d1f752cd342edb77e1062bac07e838d2cea4",
+        "sha256": "1abfjjcx2d85aabsa4hnmihy0if1y19rll72yys682vr8yzqlg5c"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.3.20/kotlin-stdlib-jdk8-1.3.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5c65523f57e3918ef722a15faae5173fc9a31331",
-      "sha256": "0hha4mq2yklq8vwzz3gzvxs4xnj90b4n5yx3l18jm1bv33fvnpqc"
-    },
-    "jar": {
-      "sha1": "b1f3cb184c4ce4139741454df2f8fca5320f822d",
-      "sha256": "0y64l1lgdr2f98spm00rvs7xq4pj68gxhy9gy85kkamcwgkk223c"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.3.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk8-1.3.20.pom": {
+        "sha1": "5c65523f57e3918ef722a15faae5173fc9a31331",
+        "sha256": "0hha4mq2yklq8vwzz3gzvxs4xnj90b4n5yx3l18jm1bv33fvnpqc"
+      },
+      "kotlin-stdlib-jdk8-1.3.20.jar": {
+        "sha1": "b1f3cb184c4ce4139741454df2f8fca5320f822d",
+        "sha256": "0y64l1lgdr2f98spm00rvs7xq4pj68gxhy9gy85kkamcwgkk223c"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.3.50/kotlin-stdlib-jdk8-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c7e40dc0558eac1f46f1760bd77a7fca0ae1008a",
-      "sha256": "1lra7yway8ydsak9j9va9gaz6by6gscbav2g3jc4habayq1b0x46"
-    },
-    "jar": {
-      "sha1": "bf65725d4ae2cf00010d84e945fcbc201f590e11",
-      "sha256": "036sshiy9rm5ck3pp2rl7kjflhl9yi61yk674mava54ww2v1yd8v"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk8-1.3.50.pom": {
+        "sha1": "c7e40dc0558eac1f46f1760bd77a7fca0ae1008a",
+        "sha256": "1lra7yway8ydsak9j9va9gaz6by6gscbav2g3jc4habayq1b0x46"
+      },
+      "kotlin-stdlib-jdk8-1.3.50.jar": {
+        "sha1": "bf65725d4ae2cf00010d84e945fcbc201f590e11",
+        "sha256": "036sshiy9rm5ck3pp2rl7kjflhl9yi61yk674mava54ww2v1yd8v"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.5.30/kotlin-stdlib-jdk8-1.5.30",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a95e23c8f40c3220953b05956eb96e959a85ca6a",
-      "sha256": "0vfi4rbadnrgsz6skz6z6j3jnb9abybg47fvhhzr3b299nrfa921"
-    },
-    "jar": {
-      "sha1": "5fd47535cc85f9e24996f939c2de6583991481b0",
-      "sha256": "03lrp0vvp2gc14bfx4fbh2x7ba5mg6nc1ivxn0in4cjqki9s1b5k"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.5.30",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk8-1.5.30.pom": {
+        "sha1": "a95e23c8f40c3220953b05956eb96e959a85ca6a",
+        "sha256": "0vfi4rbadnrgsz6skz6z6j3jnb9abybg47fvhhzr3b299nrfa921"
+      },
+      "kotlin-stdlib-jdk8-1.5.30.jar": {
+        "sha1": "5fd47535cc85f9e24996f939c2de6583991481b0",
+        "sha256": "03lrp0vvp2gc14bfx4fbh2x7ba5mg6nc1ivxn0in4cjqki9s1b5k"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.6.20/kotlin-stdlib-jdk8-1.6.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6207ba2d7a89316eafea7f135ef1fc17e41c424b",
-      "sha256": "02f3lg4hli4s5cnn4zs2g41740l9knyvsa113b3y22sbc3wajihq"
-    },
-    "jar": {
-      "sha1": "dab8089bca6ac0e394c37281ea8cff2f99acd421",
-      "sha256": "159n455n7asx76b14di9ly66pv14q3myk23qdnmygdg243qipazx"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.6.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk8-1.6.20.pom": {
+        "sha1": "6207ba2d7a89316eafea7f135ef1fc17e41c424b",
+        "sha256": "02f3lg4hli4s5cnn4zs2g41740l9knyvsa113b3y22sbc3wajihq"
+      },
+      "kotlin-stdlib-jdk8-1.6.20.jar": {
+        "sha1": "dab8089bca6ac0e394c37281ea8cff2f99acd421",
+        "sha256": "159n455n7asx76b14di9ly66pv14q3myk23qdnmygdg243qipazx"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0/kotlin-stdlib-jdk8-1.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "fb9dbe3343144298825b8d9f23a51f4af4be6cb0",
-      "sha256": "09pwnlx2yihczjikvmacznmn77d1g8p5hrlqkw1bmiwp3dawgdib"
-    },
-    "jar": {
-      "sha1": "ed04f49e186a116753ad70d34f0ac2925d1d8020",
-      "sha256": "0ih9j00wliphn4r8wisqc95y5919fg7xbdxn40crl30v8h22idh5"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jdk8-1.8.0.pom": {
+        "sha1": "fb9dbe3343144298825b8d9f23a51f4af4be6cb0",
+        "sha256": "09pwnlx2yihczjikvmacznmn77d1g8p5hrlqkw1bmiwp3dawgdib"
+      },
+      "kotlin-stdlib-jdk8-1.8.0.jar": {
+        "sha1": "ed04f49e186a116753ad70d34f0ac2925d1d8020",
+        "sha256": "0ih9j00wliphn4r8wisqc95y5919fg7xbdxn40crl30v8h22idh5"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jre7/1.2.0/kotlin-stdlib-jre7-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "52d689e2aecf9c5ee2ca40c9512069ea77b4eb06",
-      "sha256": "0j3ka2lfxqxb37dmx4nzm07q88a77yf5wf1mrqs7gayk49y42xr0"
-    },
-    "jar": {
-      "sha1": "ec8b969e26fbcf2265a4d1a1539c4d1d4c5af380",
-      "sha256": "09i91z5r1ynll65sa6v61hqkz875q7vaz049zrx7jdyla6whz8n7"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jre7/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jre7-1.2.0.pom": {
+        "sha1": "52d689e2aecf9c5ee2ca40c9512069ea77b4eb06",
+        "sha256": "0j3ka2lfxqxb37dmx4nzm07q88a77yf5wf1mrqs7gayk49y42xr0"
+      },
+      "kotlin-stdlib-jre7-1.2.0.jar": {
+        "sha1": "ec8b969e26fbcf2265a4d1a1539c4d1d4c5af380",
+        "sha256": "09i91z5r1ynll65sa6v61hqkz875q7vaz049zrx7jdyla6whz8n7"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-jre8/1.2.0/kotlin-stdlib-jre8-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "dd37e31bef41f48317214e93134ff54372bad406",
-      "sha256": "0f5c4jjw8rs5jgyjb2d9j6h1nf5nqcj6aq61s7p5cw6546z78ykb"
-    },
-    "jar": {
-      "sha1": "505f55b9619bbc5f5e26c77427dd24a6a441eef1",
-      "sha256": "0an8j2wwpx0mapmpl179xqf242kvjbipxaqxrgvl26ggwvp28db3"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-jre8/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-jre8-1.2.0.pom": {
+        "sha1": "dd37e31bef41f48317214e93134ff54372bad406",
+        "sha256": "0f5c4jjw8rs5jgyjb2d9j6h1nf5nqcj6aq61s7p5cw6546z78ykb"
+      },
+      "kotlin-stdlib-jre8-1.2.0.jar": {
+        "sha1": "505f55b9619bbc5f5e26c77427dd24a6a441eef1",
+        "sha256": "0an8j2wwpx0mapmpl179xqf242kvjbipxaqxrgvl26ggwvp28db3"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.1.3-2/kotlin-stdlib-1.1.3-2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "652f49d3edbdc251e298b3d1ec74d6488d1ce8da",
-      "sha256": "1js5wyzca5bmnvacjaicmcvbs4k5caa0s6f8bvz5v7f86x68gzgq"
-    },
-    "jar": {
-      "sha1": "9b44c139a4ec57031e0c84ba0e49ba16df6d801c",
-      "sha256": "090cwfvy0my5lyv78sp2bkax0kpjwwm94hn0l0jgi0lzhf45527j"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.1.3-2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.1.3-2.pom": {
+        "sha1": "652f49d3edbdc251e298b3d1ec74d6488d1ce8da",
+        "sha256": "1js5wyzca5bmnvacjaicmcvbs4k5caa0s6f8bvz5v7f86x68gzgq"
+      },
+      "kotlin-stdlib-1.1.3-2.jar": {
+        "sha1": "9b44c139a4ec57031e0c84ba0e49ba16df6d801c",
+        "sha256": "090cwfvy0my5lyv78sp2bkax0kpjwwm94hn0l0jgi0lzhf45527j"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.2.0/kotlin-stdlib-1.2.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "3135147249f1ab93c33c5bce2bf952b4e8ebbba6",
-      "sha256": "083s6ddd4a4j43h6b4awxh562zz4kmy2ajrq14dl5kgv9bd7i5ya"
-    },
-    "jar": {
-      "sha1": "25eb440d6eeb9fc60299121020fe726eb2100d03",
-      "sha256": "1m7wxad6iw86a4fdvzx24ydr15d425r5z4m80c3r2h8bmksxkkq5"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.2.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.2.0.pom": {
+        "sha1": "3135147249f1ab93c33c5bce2bf952b4e8ebbba6",
+        "sha256": "083s6ddd4a4j43h6b4awxh562zz4kmy2ajrq14dl5kgv9bd7i5ya"
+      },
+      "kotlin-stdlib-1.2.0.jar": {
+        "sha1": "25eb440d6eeb9fc60299121020fe726eb2100d03",
+        "sha256": "1m7wxad6iw86a4fdvzx24ydr15d425r5z4m80c3r2h8bmksxkkq5"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.2.20/kotlin-stdlib-1.2.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5bc837f53128e24cfa9a7142db579e4018220a44",
-      "sha256": "1lwxx3clsnyr0wd4bsidjnghij5b4kyl1vz7j0cnrmhg70z9f14v"
-    },
-    "jar": {
-      "sha1": "1ce9e25c74aade0aa039cce459f2906a8c8ffc8e",
-      "sha256": "1r4v0sij1asspidcjcqmhkksc8vl5nqg6s0kmf1p8icxpxckvckr"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.2.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.2.20.pom": {
+        "sha1": "5bc837f53128e24cfa9a7142db579e4018220a44",
+        "sha256": "1lwxx3clsnyr0wd4bsidjnghij5b4kyl1vz7j0cnrmhg70z9f14v"
+      },
+      "kotlin-stdlib-1.2.20.jar": {
+        "sha1": "1ce9e25c74aade0aa039cce459f2906a8c8ffc8e",
+        "sha256": "1r4v0sij1asspidcjcqmhkksc8vl5nqg6s0kmf1p8icxpxckvckr"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.2.71/kotlin-stdlib-1.2.71",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e34c8d5c8e7077a037dadcc70b114e130eb9824b",
-      "sha256": "1bkmzahsp7jxpg4nq7zal2rl5ncv3c2v08swz5qaciqck9ybfgbi"
-    },
-    "jar": {
-      "sha1": "d9717625bb3c731561251f8dd2c67a1011d6764c",
-      "sha256": "12y6zdmb92sq51y54qg93n1fw1slq64isvkrlb1gxxc71ckmr2ac"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.2.71",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.2.71.pom": {
+        "sha1": "e34c8d5c8e7077a037dadcc70b114e130eb9824b",
+        "sha256": "1bkmzahsp7jxpg4nq7zal2rl5ncv3c2v08swz5qaciqck9ybfgbi"
+      },
+      "kotlin-stdlib-1.2.71.jar": {
+        "sha1": "d9717625bb3c731561251f8dd2c67a1011d6764c",
+        "sha256": "12y6zdmb92sq51y54qg93n1fw1slq64isvkrlb1gxxc71ckmr2ac"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.0/kotlin-stdlib-1.3.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "174b5899a832edc66e21e5954339c5098b735567",
-      "sha256": "01svqrx3wcnjzs79pkmiwd09c00jbnwrdn20wb2dxscirxgb4620"
-    },
-    "jar": {
-      "sha1": "a134b0cfe9bb44f98b0b3e889cda07923eea9428",
-      "sha256": "077jhzkbxn7iv0hv1caxj5h89c11mlj8qrhjpamb90s9gywzrw2g"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.3.0.pom": {
+        "sha1": "174b5899a832edc66e21e5954339c5098b735567",
+        "sha256": "01svqrx3wcnjzs79pkmiwd09c00jbnwrdn20wb2dxscirxgb4620"
+      },
+      "kotlin-stdlib-1.3.0.jar": {
+        "sha1": "a134b0cfe9bb44f98b0b3e889cda07923eea9428",
+        "sha256": "077jhzkbxn7iv0hv1caxj5h89c11mlj8qrhjpamb90s9gywzrw2g"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.20/kotlin-stdlib-1.3.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "9d1e01f424795aa471a8def0b5dc8aeeb537aafd",
-      "sha256": "07716p4bm3j9wqcs1qb599x7wnnavmafv5lj2zsflp6p80d9vvrj"
-    },
-    "jar": {
-      "sha1": "eb2a232734e09fcd1b958a5c7520a93c6de38b32",
-      "sha256": "0q9kirl7szl466kf8dza7kc115swpzb4xdnpxal3vyv8m46r27v0"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.3.20.pom": {
+        "sha1": "9d1e01f424795aa471a8def0b5dc8aeeb537aafd",
+        "sha256": "07716p4bm3j9wqcs1qb599x7wnnavmafv5lj2zsflp6p80d9vvrj"
+      },
+      "kotlin-stdlib-1.3.20.jar": {
+        "sha1": "eb2a232734e09fcd1b958a5c7520a93c6de38b32",
+        "sha256": "0q9kirl7szl466kf8dza7kc115swpzb4xdnpxal3vyv8m46r27v0"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.31/kotlin-stdlib-1.3.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e4e40ca37fa7cc6dffeef283f7872cafc345b000",
-      "sha256": "10wldnmnjszxdsrzv1r5i3803a29jbr25sm7pymbval7bxaq50ck"
-    },
-    "jar": {
-      "sha1": "11289d20fd95ae219333f3456072be9f081c30cc",
-      "sha256": "08rv5cywyvlls14iy3h4bbyjg9gwl0zgn82vi7a6xrj3clr8937k"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.3.31.pom": {
+        "sha1": "e4e40ca37fa7cc6dffeef283f7872cafc345b000",
+        "sha256": "10wldnmnjszxdsrzv1r5i3803a29jbr25sm7pymbval7bxaq50ck"
+      },
+      "kotlin-stdlib-1.3.31.jar": {
+        "sha1": "11289d20fd95ae219333f3456072be9f081c30cc",
+        "sha256": "08rv5cywyvlls14iy3h4bbyjg9gwl0zgn82vi7a6xrj3clr8937k"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.50/kotlin-stdlib-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a75b191fa2963dcd96413bab2d0fb385b136a4e6",
-      "sha256": "0qaa94ccn4kfhs52604l1hc4qbhj3jampkcvyql6815fc24xfkvh"
-    },
-    "jar": {
-      "sha1": "b529d1738c7e98bbfa36a4134039528f2ce78ebf",
-      "sha256": "0v4d91v6klav42xkn269h90g9p3lqkx9181552sx0rh3xr35gw76"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.3.50.pom": {
+        "sha1": "a75b191fa2963dcd96413bab2d0fb385b136a4e6",
+        "sha256": "0qaa94ccn4kfhs52604l1hc4qbhj3jampkcvyql6815fc24xfkvh"
+      },
+      "kotlin-stdlib-1.3.50.jar": {
+        "sha1": "b529d1738c7e98bbfa36a4134039528f2ce78ebf",
+        "sha256": "0v4d91v6klav42xkn269h90g9p3lqkx9181552sx0rh3xr35gw76"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.71/kotlin-stdlib-1.3.71",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "47da9a84ba07a4de17cddff5e139f8d120627c62",
-      "sha256": "1ifq9f9b0bk4v9a0fjyjlizg4iz2f6nsm64h9bx40bdakycfj0zz"
-    },
-    "jar": {
-      "sha1": "898273189ad22779da6bed88ded39b14cb5fd432",
-      "sha256": "19z68pkaww0vry4w5jrkdasmff3zja5mbq24mkj2ar590aqj5kjs"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.3.71",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.3.71.pom": {
+        "sha1": "47da9a84ba07a4de17cddff5e139f8d120627c62",
+        "sha256": "1ifq9f9b0bk4v9a0fjyjlizg4iz2f6nsm64h9bx40bdakycfj0zz"
+      },
+      "kotlin-stdlib-1.3.71.jar": {
+        "sha1": "898273189ad22779da6bed88ded39b14cb5fd432",
+        "sha256": "19z68pkaww0vry4w5jrkdasmff3zja5mbq24mkj2ar590aqj5kjs"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.4.31/kotlin-stdlib-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "578554985765fe941f4fab7874e27b62dc1918db",
-      "sha256": "0kmxvnhmicmsqc37rpndvh3a26ig8gmqh171gr901rsymkky66c5"
-    },
-    "jar": {
-      "sha1": "a58e0fb9812a6a93ca24b5da75e4b5a0cb89c957",
-      "sha256": "073zp526a6dx36x9lk3ip9939bf64akxmdkr134qlzhnigc9k9bn"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.4.31.pom": {
+        "sha1": "578554985765fe941f4fab7874e27b62dc1918db",
+        "sha256": "0kmxvnhmicmsqc37rpndvh3a26ig8gmqh171gr901rsymkky66c5"
+      },
+      "kotlin-stdlib-1.4.31.jar": {
+        "sha1": "a58e0fb9812a6a93ca24b5da75e4b5a0cb89c957",
+        "sha256": "073zp526a6dx36x9lk3ip9939bf64akxmdkr134qlzhnigc9k9bn"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.5.10/kotlin-stdlib-1.5.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "ecd518d6ac5e2d91266f71017cdf759a62d61328",
-      "sha256": "1jxvqlqqpbvf063g9rl926hkc6f4v5hria1bqcf9m4p1c4jd6nih"
-    },
-    "jar": {
-      "sha1": "da6a904b132f0402fa4d79169a3c1770598d4702",
-      "sha256": "0bbj3mc4gfbg54cp3karp6sd646mk6bca0qq3y9n0bizrmac91ya"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.5.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.5.10.pom": {
+        "sha1": "ecd518d6ac5e2d91266f71017cdf759a62d61328",
+        "sha256": "1jxvqlqqpbvf063g9rl926hkc6f4v5hria1bqcf9m4p1c4jd6nih"
+      },
+      "kotlin-stdlib-1.5.10.jar": {
+        "sha1": "da6a904b132f0402fa4d79169a3c1770598d4702",
+        "sha256": "0bbj3mc4gfbg54cp3karp6sd646mk6bca0qq3y9n0bizrmac91ya"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.5.30/kotlin-stdlib-1.5.30",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "d4e1f037717ed2c78f8e5982c5dbc33daab87521",
-      "sha256": "06sdi49yx5xv2wn90y3zy7irwjq3ny4vxdnynq1dvx9sn8fn4yrn"
-    },
-    "jar": {
-      "sha1": "d68efdea04955974ac1020f8f66ef8176bfbce1f",
-      "sha256": "0300ds6v0g9rsbbbi1qmyg727iad68fjf7mjfiz35xvdxglhhmn5"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.5.30",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.5.30.pom": {
+        "sha1": "d4e1f037717ed2c78f8e5982c5dbc33daab87521",
+        "sha256": "06sdi49yx5xv2wn90y3zy7irwjq3ny4vxdnynq1dvx9sn8fn4yrn"
+      },
+      "kotlin-stdlib-1.5.30.jar": {
+        "sha1": "d68efdea04955974ac1020f8f66ef8176bfbce1f",
+        "sha256": "0300ds6v0g9rsbbbi1qmyg727iad68fjf7mjfiz35xvdxglhhmn5"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.6.20/kotlin-stdlib-1.6.20",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a7c1d39b812c8867eca579245d797bbfa16a27c9",
-      "sha256": "16bg2vdj87y8y8q7bix13srxsxk48hkda8nyfyc5167jn3f873m0"
-    },
-    "jar": {
-      "sha1": "6cedc143badbb4f1c6b7f5a340b04edff1743208",
-      "sha256": "16dp5hga717xxwy7c189i4c9g17c8j04zg6hh7yk6qmjcwmirdgf"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.6.20",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.6.20.pom": {
+        "sha1": "a7c1d39b812c8867eca579245d797bbfa16a27c9",
+        "sha256": "16bg2vdj87y8y8q7bix13srxsxk48hkda8nyfyc5167jn3f873m0"
+      },
+      "kotlin-stdlib-1.6.20.jar": {
+        "sha1": "6cedc143badbb4f1c6b7f5a340b04edff1743208",
+        "sha256": "16dp5hga717xxwy7c189i4c9g17c8j04zg6hh7yk6qmjcwmirdgf"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.7.10/kotlin-stdlib-1.7.10",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "257059438321a19e567a4593e9fed8a76814c6da",
-      "sha256": "10adfs0syahl7v70l8db7dxbvpf3bx9w745v1q3fwbf05ddczh3c"
-    },
-    "jar": {
-      "sha1": "d2abf9e77736acc4450dc4a3f707fa2c10f5099d",
-      "sha256": "00c9d97y1ab55fi926jx79fbk30xzw0k4wa6cf7kx50a4msgwwg7"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.7.10",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.7.10.pom": {
+        "sha1": "257059438321a19e567a4593e9fed8a76814c6da",
+        "sha256": "10adfs0syahl7v70l8db7dxbvpf3bx9w745v1q3fwbf05ddczh3c"
+      },
+      "kotlin-stdlib-1.7.10.jar": {
+        "sha1": "d2abf9e77736acc4450dc4a3f707fa2c10f5099d",
+        "sha256": "00c9d97y1ab55fi926jx79fbk30xzw0k4wa6cf7kx50a4msgwwg7"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.8.0/kotlin-stdlib-1.8.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "bdf2626ad84d8666184ee777e9b1a997c18fd029",
-      "sha256": "0wpq3r6p7mfzka9bq1dj4m30f4z5h3wkpz9hav8kdrd8amjr1b7i"
-    },
-    "jar": {
-      "sha1": "1796921c7a3e2e2665a83e6c8d33399336cd39bc",
-      "sha256": "0kk5zkpnyl1hnkjd5dxyg2cfbni0yagla5z2sswry2v4fj3yyyy7"
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.8.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-stdlib-1.8.0.pom": {
+        "sha1": "bdf2626ad84d8666184ee777e9b1a997c18fd029",
+        "sha256": "0wpq3r6p7mfzka9bq1dj4m30f4z5h3wkpz9hav8kdrd8amjr1b7i"
+      },
+      "kotlin-stdlib-1.8.0.jar": {
+        "sha1": "1796921c7a3e2e2665a83e6c8d33399336cd39bc",
+        "sha256": "0kk5zkpnyl1hnkjd5dxyg2cfbni0yagla5z2sswry2v4fj3yyyy7"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-util-io/1.3.50/kotlin-util-io-1.3.50",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6067fcb474e304327d3e63bf668c1aa57b81c9dc",
-      "sha256": "0wfkcccr37wzavpjni1sqbww7nsn2xxfwsrdqgiks21x0hc1jinh"
-    },
-    "jar": {
-      "sha1": "6fdca94477606c2aa9e46cc6114d01b90b1282ff",
-      "sha256": "0kbhxmmg7qwi9xnnp23bj0cfpm1pv0ab5b2q8ki770gz4yzax7jl"
+    "path": "org/jetbrains/kotlin/kotlin-util-io/1.3.50",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-util-io-1.3.50.pom": {
+        "sha1": "6067fcb474e304327d3e63bf668c1aa57b81c9dc",
+        "sha256": "0wfkcccr37wzavpjni1sqbww7nsn2xxfwsrdqgiks21x0hc1jinh"
+      },
+      "kotlin-util-io-1.3.50.jar": {
+        "sha1": "6fdca94477606c2aa9e46cc6114d01b90b1282ff",
+        "sha256": "0kbhxmmg7qwi9xnnp23bj0cfpm1pv0ab5b2q8ki770gz4yzax7jl"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-util-io/1.4.31/kotlin-util-io-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6ba56a96fd64b7239d55df3c2e88233b00fe65fa",
-      "sha256": "1mi2yba7wvpfhh1cl8kq0xmq70g3q0rcjk3mzxbhh0qqr7b9x5fh"
-    },
-    "jar": {
-      "sha1": "b3c8349cb6c6f1ca2c82013d375ca7148337ee1d",
-      "sha256": "1h2w7a0jidfm3jg5cga05w594349dis23p6kf0fxwplzkwzqx3gg"
+    "path": "org/jetbrains/kotlin/kotlin-util-io/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-util-io-1.4.31.pom": {
+        "sha1": "6ba56a96fd64b7239d55df3c2e88233b00fe65fa",
+        "sha256": "1mi2yba7wvpfhh1cl8kq0xmq70g3q0rcjk3mzxbhh0qqr7b9x5fh"
+      },
+      "kotlin-util-io-1.4.31.jar": {
+        "sha1": "b3c8349cb6c6f1ca2c82013d375ca7148337ee1d",
+        "sha256": "1h2w7a0jidfm3jg5cga05w594349dis23p6kf0fxwplzkwzqx3gg"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-util-klib/1.4.31/kotlin-util-klib-1.4.31",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "6d810bafc0d153c4ba839a4298da616744be502e",
-      "sha256": "0xzpcsx09j5g9nhgx1l727r6mkvfc1nmfb9bd7cirl0zrjfwfmz1"
-    },
-    "jar": {
-      "sha1": "2c545be047c9863ff560e292c37d00a68925d289",
-      "sha256": "0vfrdd66j307ln5z0jbpn50p3n7sv13fg3fnibgbd37s7ias3j1b"
+    "path": "org/jetbrains/kotlin/kotlin-util-klib/1.4.31",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "kotlin-util-klib-1.4.31.pom": {
+        "sha1": "6d810bafc0d153c4ba839a4298da616744be502e",
+        "sha256": "0xzpcsx09j5g9nhgx1l727r6mkvfc1nmfb9bd7cirl0zrjfwfmz1"
+      },
+      "kotlin-util-klib-1.4.31.jar": {
+        "sha1": "2c545be047c9863ff560e292c37d00a68925d289",
+        "sha256": "0vfrdd66j307ln5z0jbpn50p3n7sv13fg3fnibgbd37s7ias3j1b"
+      }
     }
   },
 
   {
-    "path": "org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "5be49445de412640606e639322600e584162f8ff",
-      "sha256": "1sasg00fjvzz8vlmkk1q3qhqi24h8w9a0iflph4wfw0cg5rhnjy9"
-    },
-    "jar": {
-      "sha1": "33c3e174a9c8368d93761d3d12712db18e903959",
-      "sha256": "1ryvjrjzixf0gwwnv35rn2lgawj5lj3hqs44ll3q6ipbilf8f5qr"
+    "path": "org/jetbrains/trove4j/trove4j/20160824",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "trove4j-20160824.pom": {
+        "sha1": "5be49445de412640606e639322600e584162f8ff",
+        "sha256": "1sasg00fjvzz8vlmkk1q3qhqi24h8w9a0iflph4wfw0cg5rhnjy9"
+      },
+      "trove4j-20160824.jar": {
+        "sha1": "33c3e174a9c8368d93761d3d12712db18e903959",
+        "sha256": "1ryvjrjzixf0gwwnv35rn2lgawj5lj3hqs44ll3q6ipbilf8f5qr"
+      }
     }
   },
 
   {
-    "path": "org/junit/junit-bom/5.9.2/junit-bom-5.9.2",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "645a08cbe455cad14d8bfb25a35d7f594c53cafd",
-      "sha256": "01gp6mpz7c4vcyrmm0drb05rvdan82d6qiw6d8rzacaihijpvl1f"
+    "path": "org/junit/junit-bom/5.9.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "junit-bom-5.9.2.pom": {
+        "sha1": "645a08cbe455cad14d8bfb25a35d7f594c53cafd",
+        "sha256": "01gp6mpz7c4vcyrmm0drb05rvdan82d6qiw6d8rzacaihijpvl1f"
+      }
     }
   },
 
   {
-    "path": "org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "797e24598297af973b622e9a41662d0bbc497658",
-      "sha256": "1b9yhymk6zp9sva68v0829xsrvsdz03rjlb2hfyh0yindh5lbjr7"
-    },
-    "jar": {
-      "sha1": "18bed5a0da27a6b43efe01282f2dc911b1cb3a72",
-      "sha256": "1d1zh4ymilfc2shm51fcwb7c4i5f6nnmkvkzksqdxh33f7bzf7x3"
+    "path": "org/jvnet/staxex/stax-ex/1.7.7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "stax-ex-1.7.7.pom": {
+        "sha1": "797e24598297af973b622e9a41662d0bbc497658",
+        "sha256": "1b9yhymk6zp9sva68v0829xsrvsdz03rjlb2hfyh0yindh5lbjr7"
+      },
+      "stax-ex-1.7.7.jar": {
+        "sha1": "18bed5a0da27a6b43efe01282f2dc911b1cb3a72",
+        "sha256": "1d1zh4ymilfc2shm51fcwb7c4i5f6nnmkvkzksqdxh33f7bzf7x3"
+      }
     }
   },
 
   {
-    "path": "org/jvnet/staxex/stax-ex/2.1.0/stax-ex-2.1.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "4a982ee38f283642f4ad5b884472f140c66b1fa0",
-      "sha256": "0903lif2ck91xayz8jwy3i7a6pdlg94yiq1cgzv0ddcikcrm6jsi"
-    },
-    "jar": {
-      "sha1": "33160568d70c01da407f8ba982bacf283d00ad4a",
-      "sha256": "0dfg8y38lj8dny3h7qw0n9dwja4hppcdvl8v959nl44j4fsnly4z"
+    "path": "org/jvnet/staxex/stax-ex/2.1.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "stax-ex-2.1.0.pom": {
+        "sha1": "4a982ee38f283642f4ad5b884472f140c66b1fa0",
+        "sha256": "0903lif2ck91xayz8jwy3i7a6pdlg94yiq1cgzv0ddcikcrm6jsi"
+      },
+      "stax-ex-2.1.0.jar": {
+        "sha1": "33160568d70c01da407f8ba982bacf283d00ad4a",
+        "sha256": "0dfg8y38lj8dny3h7qw0n9dwja4hppcdvl8v959nl44j4fsnly4z"
+      }
     }
   },
 
   {
-    "path": "org/objenesis/objenesis-parent/3.3/objenesis-parent-3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "60b46fea1dc4cb9c3123f8c366f8b33d0c774fa3",
-      "sha256": "1zz41g0qr0bryyl293a2gnwl6ln37qfa8vd9agzcgqgil953hp1h"
+    "path": "org/objenesis/objenesis-parent/3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "objenesis-parent-3.3.pom": {
+        "sha1": "60b46fea1dc4cb9c3123f8c366f8b33d0c774fa3",
+        "sha256": "1zz41g0qr0bryyl293a2gnwl6ln37qfa8vd9agzcgqgil953hp1h"
+      }
     }
   },
 
   {
-    "path": "org/objenesis/objenesis/3.3/objenesis-3.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8da1208285232e541d0bbb869bbe66af6ec6abb4",
-      "sha256": "1lsac7xdv93chlz6m7jhrjzvq3qz8xm0dxsfwav4i8394vd4035s"
-    },
-    "jar": {
-      "sha1": "1049c09f1de4331e8193e579448d0916d75b7631",
-      "sha256": "1sxzd7py9f2rx4vldxxbaf7r9c2f8zsx53khbgir2mcs8fqd1pq2"
+    "path": "org/objenesis/objenesis/3.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "objenesis-3.3.pom": {
+        "sha1": "8da1208285232e541d0bbb869bbe66af6ec6abb4",
+        "sha256": "1lsac7xdv93chlz6m7jhrjzvq3qz8xm0dxsfwav4i8394vd4035s"
+      },
+      "objenesis-3.3.jar": {
+        "sha1": "1049c09f1de4331e8193e579448d0916d75b7631",
+        "sha256": "1sxzd7py9f2rx4vldxxbaf7r9c2f8zsx53khbgir2mcs8fqd1pq2"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-analysis/5.0.3/asm-analysis-5.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2270e3099f178e9562a92c6eb27a7ad12e3fa850",
-      "sha256": "1l570la07zr6ay1c9i5caglj029dyjwrv24zmn9n511xpjhh5z4z"
-    },
-    "jar": {
-      "sha1": "c7126aded0e8e13fed5f913559a0dd7b770a10f3",
-      "sha256": "17c4j2r94xgbjh5wylgqdwv7fjr6w4jmbhinrmymb5ic8rijmyp8"
+    "path": "org/ow2/asm/asm-analysis/5.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-analysis-5.0.3.pom": {
+        "sha1": "2270e3099f178e9562a92c6eb27a7ad12e3fa850",
+        "sha256": "1l570la07zr6ay1c9i5caglj029dyjwrv24zmn9n511xpjhh5z4z"
+      },
+      "asm-analysis-5.0.3.jar": {
+        "sha1": "c7126aded0e8e13fed5f913559a0dd7b770a10f3",
+        "sha256": "17c4j2r94xgbjh5wylgqdwv7fjr6w4jmbhinrmymb5ic8rijmyp8"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-analysis/5.1/asm-analysis-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "529d264690bf03a432e29ae546fdc960a176839c",
-      "sha256": "16yma32h7zzniq7xi2v1yb7iy8xc5f6igqc9jw74y329sns0s4l1"
-    },
-    "jar": {
-      "sha1": "6d1bf8989fc7901f868bee3863c44f21aa63d110",
-      "sha256": "1a8zpdmfbhlfn89g6i3r81k7npy25k1iq4r1xwz5fjyyqpsmhim3"
+    "path": "org/ow2/asm/asm-analysis/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-analysis-5.1.pom": {
+        "sha1": "529d264690bf03a432e29ae546fdc960a176839c",
+        "sha256": "16yma32h7zzniq7xi2v1yb7iy8xc5f6igqc9jw74y329sns0s4l1"
+      },
+      "asm-analysis-5.1.jar": {
+        "sha1": "6d1bf8989fc7901f868bee3863c44f21aa63d110",
+        "sha256": "1a8zpdmfbhlfn89g6i3r81k7npy25k1iq4r1xwz5fjyyqpsmhim3"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-analysis/6.0/asm-analysis-6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f6128ea377c7d740fdc8db304689a37cd5374019",
-      "sha256": "0m0h4mzcg9nw29rz76sl0s7bfz71wm6xxdakvamlmqp380pg9ank"
-    },
-    "jar": {
-      "sha1": "dd1cc1381a970800268160203aae2d3784da779b",
-      "sha256": "1x6113vddxcsy1m42v9ji90g5n9vn0hz50b4hp26qflw463n66ig"
+    "path": "org/ow2/asm/asm-analysis/6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-analysis-6.0.pom": {
+        "sha1": "f6128ea377c7d740fdc8db304689a37cd5374019",
+        "sha256": "0m0h4mzcg9nw29rz76sl0s7bfz71wm6xxdakvamlmqp380pg9ank"
+      },
+      "asm-analysis-6.0.jar": {
+        "sha1": "dd1cc1381a970800268160203aae2d3784da779b",
+        "sha256": "1x6113vddxcsy1m42v9ji90g5n9vn0hz50b4hp26qflw463n66ig"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-commons/5.1/asm-commons-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "99b522fe5920cdfddee2ce51053ba9b4ba2748ac",
-      "sha256": "0l2psg8h5i04b8i4ji87z3hlbndxg9h01p9nm5azxx4m2hgv6dnd"
-    },
-    "jar": {
-      "sha1": "25d8a575034dd9cfcb375a39b5334f0ba9c8474e",
-      "sha256": "1gl1976jbfxvy0v7pzdpyv0wpfrk1vsjn45dz3flprsm3xp7icwp"
+    "path": "org/ow2/asm/asm-commons/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-commons-5.1.pom": {
+        "sha1": "99b522fe5920cdfddee2ce51053ba9b4ba2748ac",
+        "sha256": "0l2psg8h5i04b8i4ji87z3hlbndxg9h01p9nm5azxx4m2hgv6dnd"
+      },
+      "asm-commons-5.1.jar": {
+        "sha1": "25d8a575034dd9cfcb375a39b5334f0ba9c8474e",
+        "sha256": "1gl1976jbfxvy0v7pzdpyv0wpfrk1vsjn45dz3flprsm3xp7icwp"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-commons/6.0/asm-commons-6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f434c622e92b7ad7048706b78c5ce014e74a7e8e",
-      "sha256": "1pawmm9ydlf0h4wrn15wcwdwqxj9jm0mgsqnj0i5gfdgffag5x4h"
-    },
-    "jar": {
-      "sha1": "f256fd215d8dd5a4fa2ab3201bf653de266ed4ec",
-      "sha256": "1gwsf7cvnvss04fbhybvznbm517rkbaya7yhvixh2sm9933fbg7i"
+    "path": "org/ow2/asm/asm-commons/6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-commons-6.0.pom": {
+        "sha1": "f434c622e92b7ad7048706b78c5ce014e74a7e8e",
+        "sha256": "1pawmm9ydlf0h4wrn15wcwdwqxj9jm0mgsqnj0i5gfdgffag5x4h"
+      },
+      "asm-commons-6.0.jar": {
+        "sha1": "f256fd215d8dd5a4fa2ab3201bf653de266ed4ec",
+        "sha256": "1gwsf7cvnvss04fbhybvznbm517rkbaya7yhvixh2sm9933fbg7i"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-commons/9.4/asm-commons-9.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "a73e9b6e9061dd1477e0009420785215c476095e",
-      "sha256": "0yaildilrkjwrpf0v2y7h8zk2zvd23r900nwbmm7f4c8ryms4b5l"
-    },
-    "jar": {
-      "sha1": "8fc2810ddbcbbec0a8bbccb3f8eda58321839912",
-      "sha256": "0r336bb5caxxrm5mflc9yl4bais2y5nd3xkjjaarhg7kqfg8l4hc"
+    "path": "org/ow2/asm/asm-commons/9.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-commons-9.4.pom": {
+        "sha1": "a73e9b6e9061dd1477e0009420785215c476095e",
+        "sha256": "0yaildilrkjwrpf0v2y7h8zk2zvd23r900nwbmm7f4c8ryms4b5l"
+      },
+      "asm-commons-9.4.jar": {
+        "sha1": "8fc2810ddbcbbec0a8bbccb3f8eda58321839912",
+        "sha256": "0r336bb5caxxrm5mflc9yl4bais2y5nd3xkjjaarhg7kqfg8l4hc"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-debug-all/5.0.1/asm-debug-all-5.0.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "e536746490b031d435e1bfaa17a8d85f77973412",
-      "sha256": "0zsmb8dfmk23b2zcw3sxfxa82h4g9ib9zll6p16vk0fa6xb5x7qz"
-    },
-    "jar": {
-      "sha1": "f69b5f7d96cec0d448acf1c1a266584170c9643b",
-      "sha256": "0mzdg3cybprgpnry5ghby7k70pwf0vxp2sfvjq04niasa5dxwd27"
+    "path": "org/ow2/asm/asm-debug-all/5.0.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-debug-all-5.0.1.pom": {
+        "sha1": "e536746490b031d435e1bfaa17a8d85f77973412",
+        "sha256": "0zsmb8dfmk23b2zcw3sxfxa82h4g9ib9zll6p16vk0fa6xb5x7qz"
+      },
+      "asm-debug-all-5.0.1.jar": {
+        "sha1": "f69b5f7d96cec0d448acf1c1a266584170c9643b",
+        "sha256": "0mzdg3cybprgpnry5ghby7k70pwf0vxp2sfvjq04niasa5dxwd27"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-debug-all/6.0_BETA/asm-debug-all-6.0_BETA",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "355a030ac2f0b90c7d6d047ac4743f2c24a91166",
-      "sha256": "017nnrw5ryz8mha5y4jfnfbx7m27hrpc8vmvcl0dx2wsz1sfkdcf"
-    },
-    "jar": {
-      "sha1": "5d1f7d145b0094c3955dff56d3119d7bd9807aff",
-      "sha256": "1z9f0f5q533jlg4jrmgr36wd21f38rjr4a1dp7j7m8jfgjf8ssjk"
+    "path": "org/ow2/asm/asm-debug-all/6.0_BETA",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-debug-all-6.0_BETA.pom": {
+        "sha1": "355a030ac2f0b90c7d6d047ac4743f2c24a91166",
+        "sha256": "017nnrw5ryz8mha5y4jfnfbx7m27hrpc8vmvcl0dx2wsz1sfkdcf"
+      },
+      "asm-debug-all-6.0_BETA.jar": {
+        "sha1": "5d1f7d145b0094c3955dff56d3119d7bd9807aff",
+        "sha256": "1z9f0f5q533jlg4jrmgr36wd21f38rjr4a1dp7j7m8jfgjf8ssjk"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-parent/5.0.1/asm-parent-5.0.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "fbd79905ab811db2c82640f58ddbd22807cfb29d",
-      "sha256": "0brabhbilxzxaxzwf6hlsg9a41mjydg5nrr7zghn8hr48wnw114q"
+    "path": "org/ow2/asm/asm-parent/5.0.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-parent-5.0.1.pom": {
+        "sha1": "fbd79905ab811db2c82640f58ddbd22807cfb29d",
+        "sha256": "0brabhbilxzxaxzwf6hlsg9a41mjydg5nrr7zghn8hr48wnw114q"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-parent/5.0.3/asm-parent-5.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "f2b915adcf47fab0e17bccf47390aa206eba7937",
-      "sha256": "0clf3252nhw52k34vhjsm4mj8kz9casvkc5lp3s4slwa2bsapvf2"
+    "path": "org/ow2/asm/asm-parent/5.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-parent-5.0.3.pom": {
+        "sha1": "f2b915adcf47fab0e17bccf47390aa206eba7937",
+        "sha256": "0clf3252nhw52k34vhjsm4mj8kz9casvkc5lp3s4slwa2bsapvf2"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-parent/5.1/asm-parent-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "2768685ec9f3a387a328e4851c36716de2b34720",
-      "sha256": "01qh2la7mkwyfx8gbz5n3p0j22490js12skycihkya7wz9c85v45"
+    "path": "org/ow2/asm/asm-parent/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-parent-5.1.pom": {
+        "sha1": "2768685ec9f3a387a328e4851c36716de2b34720",
+        "sha256": "01qh2la7mkwyfx8gbz5n3p0j22490js12skycihkya7wz9c85v45"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-parent/6.0/asm-parent-6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "6a030ede2a62bdde4a6b23ef342994703a11ea24",
-      "sha256": "053xrln1w9nj0aw23wsiqkgn8569fk6zx7mw8dns9jgcp55hc7br"
+    "path": "org/ow2/asm/asm-parent/6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-parent-6.0.pom": {
+        "sha1": "6a030ede2a62bdde4a6b23ef342994703a11ea24",
+        "sha256": "053xrln1w9nj0aw23wsiqkgn8569fk6zx7mw8dns9jgcp55hc7br"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-parent/6.0_BETA/asm-parent-6.0_BETA",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "17f1e886ce6311f3116d0acd2f1854fd79bad267",
-      "sha256": "02bfgn3vwf8gc2j7dm02xhdpdaf2p4xd5r4q5cr0hdql2vzasxv8"
+    "path": "org/ow2/asm/asm-parent/6.0_BETA",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-parent-6.0_BETA.pom": {
+        "sha1": "17f1e886ce6311f3116d0acd2f1854fd79bad267",
+        "sha256": "02bfgn3vwf8gc2j7dm02xhdpdaf2p4xd5r4q5cr0hdql2vzasxv8"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "67e01f0d7339cdeaf709be24a7c333f396005e8e",
-      "sha256": "0djjrxa10ny1mv0sq5yh6zqq371174xjzrzbz14zy652qnkrr0b5"
-    },
-    "jar": {
-      "sha1": "287749b48ba7162fb67c93a026d690b29f410bed",
-      "sha256": "0755acl6d70q49znzcy39c18vp7bivj80f8xr63lx5pr02a7lyil"
+    "path": "org/ow2/asm/asm-tree/5.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-tree-5.0.3.pom": {
+        "sha1": "67e01f0d7339cdeaf709be24a7c333f396005e8e",
+        "sha256": "0djjrxa10ny1mv0sq5yh6zqq371174xjzrzbz14zy652qnkrr0b5"
+      },
+      "asm-tree-5.0.3.jar": {
+        "sha1": "287749b48ba7162fb67c93a026d690b29f410bed",
+        "sha256": "0755acl6d70q49znzcy39c18vp7bivj80f8xr63lx5pr02a7lyil"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-tree/5.1/asm-tree-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "09e0a8798bb85ba11a36f21f2a0888bdd87d4ba4",
-      "sha256": "088sg1xdmlfvv2f1g2w1px0i7y4p3lzj883gip7y7cm4gvy6jlzv"
-    },
-    "jar": {
-      "sha1": "87b38c12a0ea645791ead9d3e74ae5268d1d6c34",
-      "sha256": "042cx29y8hsiri25a7swvp8pw1qxxpafq4wqclcp8adq9jy2ppn0"
+    "path": "org/ow2/asm/asm-tree/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-tree-5.1.pom": {
+        "sha1": "09e0a8798bb85ba11a36f21f2a0888bdd87d4ba4",
+        "sha256": "088sg1xdmlfvv2f1g2w1px0i7y4p3lzj883gip7y7cm4gvy6jlzv"
+      },
+      "asm-tree-5.1.jar": {
+        "sha1": "87b38c12a0ea645791ead9d3e74ae5268d1d6c34",
+        "sha256": "042cx29y8hsiri25a7swvp8pw1qxxpafq4wqclcp8adq9jy2ppn0"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-tree/6.0/asm-tree-6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "b318fdac4c1b914798862a4ab478eae81cc308d2",
-      "sha256": "1d01wx74alk2xd8d1ic5yc87zacnwm2ylf4a6y95l66vgw6px21n"
-    },
-    "jar": {
-      "sha1": "a624f1a6e4e428dcd680a01bab2d4c56b35b18f0",
-      "sha256": "05b2229fwn5cndkabjnlkwzy6098h9bghlyjwicqfz3jd7xrhyc8"
+    "path": "org/ow2/asm/asm-tree/6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-tree-6.0.pom": {
+        "sha1": "b318fdac4c1b914798862a4ab478eae81cc308d2",
+        "sha256": "1d01wx74alk2xd8d1ic5yc87zacnwm2ylf4a6y95l66vgw6px21n"
+      },
+      "asm-tree-6.0.jar": {
+        "sha1": "a624f1a6e4e428dcd680a01bab2d4c56b35b18f0",
+        "sha256": "05b2229fwn5cndkabjnlkwzy6098h9bghlyjwicqfz3jd7xrhyc8"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-tree/9.4/asm-tree-9.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "cb6463c845158931c700e51b4922a4a5159299fa",
-      "sha256": "05iw3bjrilkc4crm45wwb1n2s02dqvy84lyf68q3dayqpn9yzsf7"
-    },
-    "jar": {
-      "sha1": "a99175a17d7fdc18cbcbd0e8ea6a5d276844190a",
-      "sha256": "1krabgknafs85zvnqc46m2sbv1jfxypfxxqan8ga4rj5yaf4fbf4"
+    "path": "org/ow2/asm/asm-tree/9.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-tree-9.4.pom": {
+        "sha1": "cb6463c845158931c700e51b4922a4a5159299fa",
+        "sha256": "05iw3bjrilkc4crm45wwb1n2s02dqvy84lyf68q3dayqpn9yzsf7"
+      },
+      "asm-tree-9.4.jar": {
+        "sha1": "a99175a17d7fdc18cbcbd0e8ea6a5d276844190a",
+        "sha256": "1krabgknafs85zvnqc46m2sbv1jfxypfxxqan8ga4rj5yaf4fbf4"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-util/5.1/asm-util-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "f5b08655a7056cdf8573524347706bae44f6707f",
-      "sha256": "03i4sxdsws79pc9hva8rfigfbbr9rjwffssw3gbx2l62awc9s3hc"
-    },
-    "jar": {
-      "sha1": "b60e33a6bd0d71831e0c249816d01e6c1dd90a47",
-      "sha256": "0h206v70i27sw0zf14ybwl9xd7jg2aiakfwg2jcx0g2ymqwjq0zf"
+    "path": "org/ow2/asm/asm-util/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-util-5.1.pom": {
+        "sha1": "f5b08655a7056cdf8573524347706bae44f6707f",
+        "sha256": "03i4sxdsws79pc9hva8rfigfbbr9rjwffssw3gbx2l62awc9s3hc"
+      },
+      "asm-util-5.1.jar": {
+        "sha1": "b60e33a6bd0d71831e0c249816d01e6c1dd90a47",
+        "sha256": "0h206v70i27sw0zf14ybwl9xd7jg2aiakfwg2jcx0g2ymqwjq0zf"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm-util/6.0/asm-util-6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "00a631614520a8655772955f43dcc80db071230e",
-      "sha256": "04hz479zzrz6jk1ldsss43s212w0ln1dl69la2bpn5ldk0gwdprw"
-    },
-    "jar": {
-      "sha1": "430b2fc839b5de1f3643b528853d5cf26096c1de",
-      "sha256": "1xm5pi4v9m041csb1956lni7mcd3163qy675c991fw7qn2yzwsim"
+    "path": "org/ow2/asm/asm-util/6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-util-6.0.pom": {
+        "sha1": "00a631614520a8655772955f43dcc80db071230e",
+        "sha256": "04hz479zzrz6jk1ldsss43s212w0ln1dl69la2bpn5ldk0gwdprw"
+      },
+      "asm-util-6.0.jar": {
+        "sha1": "430b2fc839b5de1f3643b528853d5cf26096c1de",
+        "sha256": "1xm5pi4v9m041csb1956lni7mcd3163qy675c991fw7qn2yzwsim"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm/5.0.3/asm-5.0.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "7d9570aceff0131a35a87d37b53452be33cf3cd9",
-      "sha256": "18565g4264fv0d7hq9fq34dyrybxl5h9d5pis8a7ggk2zqznad3x"
-    },
-    "jar": {
-      "sha1": "dcc2193db20e19e1feca8b1240dbbc4e190824fa",
-      "sha256": "1k265g2nq810yg7sb9h5f1kyp2f0m2z2mz8drkcxr3vv8f7ggi3i"
+    "path": "org/ow2/asm/asm/5.0.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-5.0.3.pom": {
+        "sha1": "7d9570aceff0131a35a87d37b53452be33cf3cd9",
+        "sha256": "18565g4264fv0d7hq9fq34dyrybxl5h9d5pis8a7ggk2zqznad3x"
+      },
+      "asm-5.0.3.jar": {
+        "sha1": "dcc2193db20e19e1feca8b1240dbbc4e190824fa",
+        "sha256": "1k265g2nq810yg7sb9h5f1kyp2f0m2z2mz8drkcxr3vv8f7ggi3i"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm/5.1/asm-5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "87afb3c6d9329d889ef8dc7bded4a5482cb15e99",
-      "sha256": "01dj1vq56rz9k9sdsczkfjajxkzmxqxlcs6cmjx27wrrpxd9n1vd"
-    },
-    "jar": {
-      "sha1": "5ef31c4fe953b1fd00b8a88fa1d6820e8785bb45",
-      "sha256": "0m2bfr224dqpvk5cm0ih48n2516jg7x5d4kk4459zik7k6d3knnj"
+    "path": "org/ow2/asm/asm/5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-5.1.pom": {
+        "sha1": "87afb3c6d9329d889ef8dc7bded4a5482cb15e99",
+        "sha256": "01dj1vq56rz9k9sdsczkfjajxkzmxqxlcs6cmjx27wrrpxd9n1vd"
+      },
+      "asm-5.1.jar": {
+        "sha1": "5ef31c4fe953b1fd00b8a88fa1d6820e8785bb45",
+        "sha256": "0m2bfr224dqpvk5cm0ih48n2516jg7x5d4kk4459zik7k6d3knnj"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm/6.0/asm-6.0",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "8e8ac765fb0b5099bde117857df7f7cc7aa08165",
-      "sha256": "0bn3281hli8z7dx2cs6s0a0bxc0sbfsbn9jl12cyc4ki35z4kg62"
-    },
-    "jar": {
-      "sha1": "bc6fa6b19424bb9592fe43bbc20178f92d403105",
-      "sha256": "0q8489h5grwm2xxvkikd91nflq47xbjalp79m2cphsaf9b3p32fx"
+    "path": "org/ow2/asm/asm/6.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-6.0.pom": {
+        "sha1": "8e8ac765fb0b5099bde117857df7f7cc7aa08165",
+        "sha256": "0bn3281hli8z7dx2cs6s0a0bxc0sbfsbn9jl12cyc4ki35z4kg62"
+      },
+      "asm-6.0.jar": {
+        "sha1": "bc6fa6b19424bb9592fe43bbc20178f92d403105",
+        "sha256": "0q8489h5grwm2xxvkikd91nflq47xbjalp79m2cphsaf9b3p32fx"
+      }
     }
   },
 
   {
-    "path": "org/ow2/asm/asm/9.4/asm-9.4",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "91bffd75aa63f199ab1a97746ae563d6099890b9",
-      "sha256": "1513k0r5vs96bbdjzz6q6c1xqvj6z87v0fmdc4yg9ldjizj52ds8"
-    },
-    "jar": {
-      "sha1": "b4e0e2d2e023aa317b7cfcfc916377ea348e07d1",
-      "sha256": "10gk2l71sfj4d0sgj971abh2d8cl19slay89kfh6bbs5vjry5l1r"
+    "path": "org/ow2/asm/asm/9.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "asm-9.4.pom": {
+        "sha1": "91bffd75aa63f199ab1a97746ae563d6099890b9",
+        "sha256": "1513k0r5vs96bbdjzz6q6c1xqvj6z87v0fmdc4yg9ldjizj52ds8"
+      },
+      "asm-9.4.jar": {
+        "sha1": "b4e0e2d2e023aa317b7cfcfc916377ea348e07d1",
+        "sha256": "10gk2l71sfj4d0sgj971abh2d8cl19slay89kfh6bbs5vjry5l1r"
+      }
     }
   },
 
   {
-    "path": "org/ow2/ow2/1.3/ow2-1.3",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "f679d6639bfb209b0836a5e7cf09bfbcc1a41f06",
-      "sha256": "1yr8hfx8gffpppa4ii6cvrsq029a6x8hzy7nsavxhs60s9kmq8ai"
+    "path": "org/ow2/ow2/1.3",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ow2-1.3.pom": {
+        "sha1": "f679d6639bfb209b0836a5e7cf09bfbcc1a41f06",
+        "sha256": "1yr8hfx8gffpppa4ii6cvrsq029a6x8hzy7nsavxhs60s9kmq8ai"
+      }
     }
   },
 
   {
-    "path": "org/ow2/ow2/1.5.1/ow2-1.5.1",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "bda66fa5f1b68fa7d2de3d569bdc8508b2af82d4",
-      "sha256": "01fgb949y6rn7dv1y71r8bx6nk8mfkdxck3bx8yzbr3gxsvxn79j"
+    "path": "org/ow2/ow2/1.5.1",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "ow2-1.5.1.pom": {
+        "sha1": "bda66fa5f1b68fa7d2de3d569bdc8508b2af82d4",
+        "sha256": "01fgb949y6rn7dv1y71r8bx6nk8mfkdxck3bx8yzbr3gxsvxn79j"
+      }
     }
   },
 
   {
-    "path": "org/slf4j/jcl-over-slf4j/2.0.6/jcl-over-slf4j-2.0.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "c9d9caedcca2a1564e47b55614960958c5f78773",
-      "sha256": "1swgy5hwv54b1i1117shn3wmwba3v78qvy6cnv8v243j7ac6vzqq"
-    },
-    "jar": {
-      "sha1": "839ff57e112f2e28ef372e96d135696a6896b9ad",
-      "sha256": "0s9scdwkxwj3al87ihanj10rscrjh44kligr5asb7qpl28d1xvks"
+    "path": "org/slf4j/jcl-over-slf4j/2.0.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "jcl-over-slf4j-2.0.6.pom": {
+        "sha1": "c9d9caedcca2a1564e47b55614960958c5f78773",
+        "sha256": "1swgy5hwv54b1i1117shn3wmwba3v78qvy6cnv8v243j7ac6vzqq"
+      },
+      "jcl-over-slf4j-2.0.6.jar": {
+        "sha1": "839ff57e112f2e28ef372e96d135696a6896b9ad",
+        "sha256": "0s9scdwkxwj3al87ihanj10rscrjh44kligr5asb7qpl28d1xvks"
+      }
     }
   },
 
   {
-    "path": "org/slf4j/slf4j-api/2.0.6/slf4j-api-2.0.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "2b93d5f66ad2ba259bf4b2c94da39f0d6c544400",
-      "sha256": "0dipzawn8rxikciij2z06c25rb2vdj83s8ga3a7n10r77p2qcklb"
-    },
-    "jar": {
-      "sha1": "88c40d8b4f33326f19a7d3c0aaf2c7e8721d4953",
-      "sha256": "1nkv0z4dpkvp6pr9ph8087z5r691bv95xdv3gnfi6s5j23a94aig"
+    "path": "org/slf4j/slf4j-api/2.0.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "slf4j-api-2.0.6.pom": {
+        "sha1": "2b93d5f66ad2ba259bf4b2c94da39f0d6c544400",
+        "sha256": "0dipzawn8rxikciij2z06c25rb2vdj83s8ga3a7n10r77p2qcklb"
+      },
+      "slf4j-api-2.0.6.jar": {
+        "sha1": "88c40d8b4f33326f19a7d3c0aaf2c7e8721d4953",
+        "sha256": "1nkv0z4dpkvp6pr9ph8087z5r691bv95xdv3gnfi6s5j23a94aig"
+      }
     }
   },
 
   {
-    "path": "org/slf4j/slf4j-jdk14/2.0.6/slf4j-jdk14-2.0.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "jar",
-    "pom": {
-      "sha1": "96ac9d6ab608e787d54892b35205bc6a560aa007",
-      "sha256": "0gnsyy1n5v8xqdy6a6p1752m5c4afihpw0n36n6aqw01y9l86q1h"
-    },
-    "jar": {
-      "sha1": "13056cb341f2d8795120f8027766a058da874f85",
-      "sha256": "0jncm8a2ppliqpzkbqm26sn98mwif8c1nligc1zh4jbzr8mxyzhy"
+    "path": "org/slf4j/slf4j-jdk14/2.0.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "slf4j-jdk14-2.0.6.pom": {
+        "sha1": "96ac9d6ab608e787d54892b35205bc6a560aa007",
+        "sha256": "0gnsyy1n5v8xqdy6a6p1752m5c4afihpw0n36n6aqw01y9l86q1h"
+      },
+      "slf4j-jdk14-2.0.6.jar": {
+        "sha1": "13056cb341f2d8795120f8027766a058da874f85",
+        "sha256": "0jncm8a2ppliqpzkbqm26sn98mwif8c1nligc1zh4jbzr8mxyzhy"
+      }
     }
   },
 
   {
-    "path": "org/slf4j/slf4j-parent/2.0.6/slf4j-parent-2.0.6",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "0f99f8426c64fc5e0c4b6749245e50484a16c372",
-      "sha256": "091il49sidk0lcmzdy0vl3a4l16kw6x1q0l9vk0hir1ipq66b0hl"
+    "path": "org/slf4j/slf4j-parent/2.0.6",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "slf4j-parent-2.0.6.pom": {
+        "sha1": "0f99f8426c64fc5e0c4b6749245e50484a16c372",
+        "sha256": "091il49sidk0lcmzdy0vl3a4l16kw6x1q0l9vk0hir1ipq66b0hl"
+      }
     }
   },
 
   {
-    "path": "org/sonatype/oss/oss-parent/7/oss-parent-7",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "46b8a785b60a2767095b8611613b58577e96d4c9",
-      "sha256": "0m4lallnlhyfj3z24ispxzwvsxzaznhw6zsmk4j74sibr5kqh7xm"
+    "path": "org/sonatype/oss/oss-parent/7",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "oss-parent-7.pom": {
+        "sha1": "46b8a785b60a2767095b8611613b58577e96d4c9",
+        "sha256": "0m4lallnlhyfj3z24ispxzwvsxzaznhw6zsmk4j74sibr5kqh7xm"
+      }
     }
   },
 
   {
-    "path": "org/sonatype/oss/oss-parent/9/oss-parent-9",
-    "host": "https://repo.maven.apache.org/maven2",
-    "type": "pom",
-    "pom": {
-      "sha1": "e5cdc4d23b86d79c436f16fed20853284e868f65",
-      "sha256": "0yl2hbwz2kn1hll1i00ddzn8f89bfdcjwdifz0pj2j15k1gjch7v"
+    "path": "org/sonatype/oss/oss-parent/9",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "oss-parent-9.pom": {
+        "sha1": "e5cdc4d23b86d79c436f16fed20853284e868f65",
+        "sha256": "0yl2hbwz2kn1hll1i00ddzn8f89bfdcjwdifz0pj2j15k1gjch7v"
+      }
     }
   }
 ]

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -636,7 +636,7 @@ https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk15on/1.56/bcprov
 https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk15on/1.60/bcprov-jdk15on-1.60.pom
 https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.pom
-https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.31.0/checker-qual-3.31.0.pom
+https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.32.0/checker-qual-3.32.0.pom
 https://repo.maven.apache.org/maven2/org/codehaus/codehaus-parent/4/codehaus-parent-4.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-all/2.4.15/groovy-all-2.4.15.pom
 https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.pom

--- a/nix/deps/gradle/generate.sh
+++ b/nix/deps/gradle/generate.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 
-# Stop on any failures, including in pipes
-set -e
-set -o pipefail
+# This script takes care of generating/updating the maven-sources.nix file
+# representing the offline Maven repo containing the dependencies
+# required to build the project
+
+set -Eeo pipefail
 
 if [[ -z "${IN_NIX_SHELL}" ]]; then
     echo "Remember to call 'make shell'!"
     exit 1
 fi
-
-# This script takes care of generating/updating the maven-sources.nix file
-# representing the offline Maven repo containing the dependencies
-# required to build the project
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/scripts/colors.sh"
@@ -27,41 +25,43 @@ ulimit -n 16384
 
 # Generate list of Gradle sub-projects.
 function gen_proj_list() {
-    ${CUR_DIR}/get_projects.sh | sort -u -o ${PROJ_LIST}
-    echo -e "Found ${GRN}$(wc -l < ${PROJ_LIST})${RST} sub-projects..."
+    "${CUR_DIR}/get_projects.sh" | sort -u -o "${PROJ_LIST}"
+    echo -e "Found ${GRN}$(wc -l < "${PROJ_LIST}")${RST} sub-projects..."
 }
 
 # Check each sub-project in parallel, the ":" is for local deps.
 function gen_deps_list() {
-    PROJECTS=$(cat ${PROJ_LIST})
-    ${CUR_DIR}/get_deps.sh ":" ${PROJECTS[@]} | sort -uV -o ${DEPS_LIST}
-    echo -e "${CLR}Found ${GRN}$(wc -l < ${DEPS_LIST})${RST} direct dependencies..."
+    PROJECTS=$(cat "${PROJ_LIST}")
+    # WARNING: The ${PROJECTS[@]} needs to remain unquoted to expand correctly.
+    # shellcheck disable=SC2068
+    "${CUR_DIR}/get_deps.sh" ":" ${PROJECTS[@]} | sort -uV -o "${DEPS_LIST}"
+    echo -e "${CLR}Found ${GRN}$(wc -l < "${DEPS_LIST}")${RST} direct dependencies..."
 }
 
 # Find download URLs for each dependency.
 function gen_deps_urls() {
-    cat ${DEPS_LIST} | go-maven-resolver | sort -uV -o ${DEPS_URLS}
-    echo -e "${CLR}Found ${GRN}$(wc -l < ${DEPS_URLS})${RST} dependency URLs..."
+    go-maven-resolver < "${DEPS_LIST}" | sort -uV -o "${DEPS_URLS}"
+    echo -e "${CLR}Found ${GRN}$(wc -l < "${DEPS_URLS}")${RST} dependency URLs..."
 }
 
 # Generate the JSON that Nix will consume.
 function gen_deps_json() {
     # Open the Nix attribute set.
-    echo -n "[" > ${DEPS_JSON}
+    echo -n "[" > "${DEPS_JSON}"
 
     # Format URLs into a Nix consumable file.
-    URLS=$(cat ${DEPS_URLS})
+    URLS=$(cat "${DEPS_URLS}")
     # Avoid rate limiting by using 4 of the available threads.
     parallel --will-cite --keep-order --jobs 4 \
         "${CUR_DIR}/url2json.sh" \
-        ::: ${URLS} \
-        >> ${DEPS_JSON}
+        ::: "${URLS}" \
+        >> "${DEPS_JSON}"
 
     # Drop tailing comma on last object, stupid JSON
-    sed -i '$ s/},/}/' ${DEPS_JSON}
+    sed -i '$ s/},/}/' "${DEPS_JSON}"
 
     # Close the Nix attribute set
-    echo "]" >> ${DEPS_JSON}
+    echo "]" >> "${DEPS_JSON}"
 }
 
 # ------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ cd "${GIT_ROOT}/android"
 ./gradlew --stop >/dev/null
 
 # A way to run a specific stage of generation
-if [[ -n "${1}" ]] && type ${1} > /dev/null; then
+if [[ -n "${1}" ]] && type "${1}" > /dev/null; then
     ${1}; exit 0
 elif [[ -n "${1}" ]]; then
     echo "No such function: ${1}"; exit 1
@@ -86,6 +86,6 @@ gen_deps_list
 gen_deps_urls
 gen_deps_json
 
-REL_DEPS_JSON=$(realpath --relative-to=${PWD} ${DEPS_JSON})
+REL_DEPS_JSON=$(realpath --relative-to="${PWD}" "${DEPS_JSON}")
 echo -e "${CLR}Generated Nix deps file: ${REL_DEPS_JSON#../}"
 echo -e "${GRN}Done${RST}"

--- a/nix/deps/gradle/get_deps.sh
+++ b/nix/deps/gradle/get_deps.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-set -Eeu
+# This script generates a list of dependencies for the main project and its
+# sub-projects defined using Gradle config files. It parses Gradle output of
+# 'dependencies' and 'buildEnvironment` tasks using AWK.
+
+set -Eeuo pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
-# Gradle needs to be run in 'android' subfolder
+# Gradle needs to be run in 'android' subfolder.
 cd "${GIT_ROOT}/android"
 
-AWK_SCRIPT="${GIT_ROOT}/nix/deps/gradle/gradle_parser.awk"
+# Show Gradle log in case of failure.
+GRADLE_LOG_FILE='/tmp/gradle.log'
+function show_gradle_log() { cat "${GRADLE_LOG_FILE}" >&2; }
+trap show_gradle_log ERR
 
 # Run the gradle command for a project:
 # - ':buildEnvironment' to get build tools
@@ -20,16 +27,11 @@ for i in "${!DEPS[@]}"; do
     NORMAL_DEPS[${i}]="${DEPS[${i}]}:dependencies"
 done
 
-# And clean up the output by:
-# - keep only lines that start with \--- or +---
-# - drop lines that end with (*) or (n) but don't start with (+)
-# - drop lines that refer to a project
-# - drop entries starting with `status-im:` like `status-go`
-# - drop entries that aren't just the name of the dependency
-# - extract the package name and version, ignoring version range indications,
-#   such as in `com.google.android.gms:play-services-ads:[15.0.1,16.0.0) -> 15.0.1`
+# And clean up the output using AWK script.
+AWK_SCRIPT="${GIT_ROOT}/nix/deps/gradle/gradle_parser.awk"
 
 ./gradlew --no-daemon --console plain \
     "${BUILD_DEPS[@]}" \
     "${NORMAL_DEPS[@]}" \
-    | awk -f ${AWK_SCRIPT}
+    | tee "${GRADLE_LOG_FILE}" \
+    | awk -f "${AWK_SCRIPT}"

--- a/nix/deps/gradle/get_projects.sh
+++ b/nix/deps/gradle/get_projects.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 
-set -Eeu
+# This script generates a list of Gradle sub-projects by parsing the output
+# of Gradle 'projects' task using grep and sed. It is necessary in order to
+# collect list of dependencies for main project and its sub-projects.
+
+set -Eeuo pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
-# Gradle needs to be run in 'android' subfolder
+# Gradle needs to be run in 'android' subfolder.
 cd "${GIT_ROOT}/android"
+
+# Show Gradle log in case of failure.
+GRADLE_LOG_FILE='/tmp/gradle.log'
+function show_gradle_log() { cat "${GRADLE_LOG_FILE}" >&2; }
+trap show_gradle_log ERR
 
 # Print all our sub-projects
 ./gradlew projects --no-daemon --console plain 2>&1 \
+    | tee "${GRADLE_LOG_FILE}" \
     | grep "Project ':" \
     | sed -E "s;^.--- Project '\:([@_a-zA-Z0-9\-]+)';\1;"

--- a/nix/deps/gradle/proj.list
+++ b/nix/deps/gradle/proj.list
@@ -26,6 +26,7 @@ react-native-lottie-splash-screen
 react-native-mail
 react-native-navigation
 react-native-nfc-manager
+react-native-orientation-locker
 react-native-permissions
 react-native-randombytes
 react-native-reanimated

--- a/nix/deps/gradle/url2json.sh
+++ b/nix/deps/gradle/url2json.sh
@@ -6,8 +6,6 @@
 # a local Maven repository.
 #
 
-CUR_DIR=$(cd "${BASH_SOURCE%/*}" && pwd)
-
 # This defines URLs of Maven repos we know about and use.
 declare -a REPOS=(
   "https://repo.maven.apache.org/maven2"
@@ -37,105 +35,87 @@ function match_repo_url() {
 }
 
 function pom_has_nodeps_jar() {
-    grep '<shadedClassifierName>nodeps</shadedClassifierName>' $1 \
-        2>&1 >/dev/null
+    grep '<shadedClassifierName>nodeps</shadedClassifierName>' "${1}" \
+        >/dev/null 2>&1 
+}
+
+function fetch_and_template_file() {
+    local FILENAME="${1}"
+    local OBJ_URL OBJ_NIX_FETCH_OUT OBJ_NAME OBJ_PATH
+
+    OBJ_URL="${REPO_URL}/${PKG_PATH}/${FILENAME}"
+    if ! OBJ_NIX_FETCH_OUT=$(nix_fetch "${OBJ_URL}"); then
+        echo " ! Failed to fetch: ${OBJ_URL}" >&2
+        exit 1
+    fi
+
+    OBJ_NAME="${FILENAME}"
+    OBJ_PATH=$(get_nix_path "${OBJ_NIX_FETCH_OUT}")
+    echo -n ",
+      \"${OBJ_NAME}\": {
+        \"sha1\": \"$(get_sha1 "${OBJ_PATH}")\",
+        \"sha256\": \"$(get_nix_sha "${OBJ_NIX_FETCH_OUT}")\"
+      }"
 }
 
 if [[ -z "${1}" ]]; then
-    echo "Required argument not given!" >&2
+    echo "Required POM URL argument not given!" >&2
     exit 1
 fi
-
 POM_URL=${1}
-# Drop the POM extension
-OBJ_REL_URL=${POM_URL%.pom}
+# Drop the POM extension.
+PKG_URL_NO_EXT="${POM_URL%.pom}"
+# Name of package without extension.
+PKG_NAME="$(basename "${PKG_URL_NO_EXT}")"
 
 echo -en "${CLR} - Nix entry for: ${1##*/}\r" >&2
 
-REPO_URL=$(match_repo_url "${OBJ_REL_URL}")
+REPO_URL=$(match_repo_url "${PKG_URL_NO_EXT}")
 
 if [[ -z "${REPO_URL}" ]]; then
-    echo "\r\n ? REPO_URL: ${REPO_URL}" >&2
+    echo " ! Repo URL not found: %s" "${REPO_URL}" >&2
+    exit 1
 fi
 # Get the relative path without full URL
-OBJ_REL_NAME="${OBJ_REL_URL#${REPO_URL}/}"
+PKG_PATH="${PKG_URL_NO_EXT#"${REPO_URL}/"}"
+PKG_PATH="$(dirname "${PKG_PATH}")"
 
 # Both JARs and AARs have a POM
-POM_NIX_FETCH_OUT=$(nix_fetch "${OBJ_REL_URL}.pom")
+POM_NIX_FETCH_OUT=$(nix_fetch "${PKG_URL_NO_EXT}.pom")
 POM_PATH=$(get_nix_path "${POM_NIX_FETCH_OUT}")
+POM_NAME=$(basename "${PKG_URL_NO_EXT}.pom")
 if [[ -z "${POM_PATH}" ]]; then
-    echo " ! Failed to fetch: ${OBJ_REL_URL}.pom" >&2
+    echo " ! Failed to fetch: ${PKG_URL_NO_EXT}.pom" >&2
     exit 1
 fi
 POM_SHA256=$(get_nix_sha "${POM_NIX_FETCH_OUT}")
 POM_SHA1=$(get_sha1 "${POM_PATH}")
 
-# Identify packaging type, JAR, AAR, or just POM.
-OBJ_TYPE_RAW=$(grep -oP '<packaging>\K[^<]+' "${POM_PATH}")
-# Bundle is a JAR made using maven-bundle-plugin.
-case "${OBJ_TYPE_RAW}" in
-    ''|'bundle') OBJ_TYPE=jar;;
-    'aar.asc')   OBJ_TYPE=aar;;
-    *)           OBJ_TYPE="${OBJ_TYPE_RAW}"
-esac
+# Identify packaging type, JAR, AAR, bundle, or just POM.
+OBJ_TYPE=$(grep -oP '<packaging>\K[^<]+' "${POM_PATH}")
 
 # Some deps are Eclipse plugins, and we don't need those.
 if [[ "${OBJ_TYPE}" == "eclipse-plugin" ]]; then
     exit 0
 fi
 
-# Some deps are just POMs, in which case there is no JAR to fetch.
-if [[ "${OBJ_TYPE}" != "pom" ]]; then
-    OBJ_NIX_FETCH_OUT=$(nix_fetch "${OBJ_REL_URL}.${OBJ_TYPE}")
-    # If type was a JAR or other, not getting one is an error.
-    if [[ ${?} -ne 0 ]]; then
-        # POMs without packaging type defined can still include JARs.
-        if [[ "${OBJ_TYPE_RAW}" != "" ]]; then
-            echo " ! Failed to fetch: ${OBJ_REL_URL}.${OBJ_TYPE}" >&2
-            exit 1
-        fi
-    else
-        OBJ_PATH=$(get_nix_path "${OBJ_NIX_FETCH_OUT}")
-        OBJ_SHA256=$(get_nix_sha "${OBJ_NIX_FETCH_OUT}")
-        OBJ_SHA1=$(get_sha1 "${OBJ_PATH}")
-    fi
-fi
-
-# Some deps include nodeps JARs which include.
-if pom_has_nodeps_jar "${POM_PATH}"; then
-    NODEPS_NIX_FETCH_OUT=$(nix_fetch "${OBJ_REL_URL}-nodeps.jar")
-    if [[ ${?} -eq 0 ]]; then
-        NODEPS_PATH=$(get_nix_path "${NODEPS_NIX_FETCH_OUT}")
-        NODEPS_SHA256=$(get_nix_sha "${NODEPS_NIX_FETCH_OUT}")
-        NODEPS_SHA1=$(get_sha1 "${NODEPS_PATH}")
-    fi
-fi
-
 # Format into a Nix attrset entry
 echo -ne "
   {
-    \"path\": \"${OBJ_REL_NAME}\",
-    \"host\": \"${REPO_URL}\",
-    \"type\": \"${OBJ_TYPE}\","
-if [[ -n "${POM_SHA256}" ]]; then
-    echo -n "
-    \"pom\": {
-      \"sha1\": \"${POM_SHA1}\",
-      \"sha256\": \"${POM_SHA256}\"
-    }";[[ -n "${OBJ_SHA256}" ]] && echo -n ","
-fi
-if [[ -n "${OBJ_SHA256}" ]]; then
-    echo -n "
-    \"jar\": {
-      \"sha1\": \"${OBJ_SHA1}\",
-      \"sha256\": \"${OBJ_SHA256}\"
-    }";[[ -n "${NODEPS_SHA256}" ]] && echo -n ","
-fi
-if [[ -n "${NODEPS_SHA256}" ]]; then
-    echo -n "
-    \"nodeps\": {
-      \"sha1\": \"${NODEPS_SHA1}\",
-      \"sha256\": \"${NODEPS_SHA256}\"
-    }"
-fi
-echo -e "\n  },"
+    \"path\": \"${PKG_PATH}\",
+    \"repo\": \"${REPO_URL}\",
+    \"files\": {
+      \"${POM_NAME}\": {
+        \"sha1\": \"${POM_SHA1}\",
+        \"sha256\": \"${POM_SHA256}\"
+      }"
+
+# Some deps are just POMs, in which case there is no JAR to fetch.
+[[ "${OBJ_TYPE}" == "" ]]        && fetch_and_template_file "${PKG_NAME}.jar"
+[[ "${OBJ_TYPE}" == "jar" ]]     && fetch_and_template_file "${PKG_NAME}.jar"
+[[ "${OBJ_TYPE}" == "bundle" ]]  && fetch_and_template_file "${PKG_NAME}.jar"
+[[ "${OBJ_TYPE}" =~ aar* ]]      && fetch_and_template_file "${PKG_NAME}.aar"
+[[ "${OBJ_TYPE}" == "aar.asc" ]] && fetch_and_template_file "${PKG_NAME}.${OBJ_TYPE}"
+pom_has_nodeps_jar "${POM_PATH}" && fetch_and_template_file "${PKG_NAME}-nodeps.jar"
+
+echo -e '\n    }\n  },'


### PR DESCRIPTION
Refactoring the derivation that fetches all the POMs, JARs, and AARs in order to make it more generic and easier to extend.
The main change is adding `files` key in `deps.json` which contains a dict of all the files reletad to given package.

This way we can more easily include other files that might be available for download, like AARs with ASC suffix, or `nodeps` JARs.

This is also necessary for the React Native upgrade:
* https://github.com/status-im/status-mobile/pull/15203