### PR TITLE
nix: patch all Gradle configs of nodejs deps

### DIFF
--- a/nix/deps/nodejs-patched/default.nix
+++ b/nix/deps/nodejs-patched/default.nix
@@ -29,7 +29,14 @@ stdenv.mkDerivation {
   # maven and google central repositories with our own local directories.
   # This prevents the builder from downloading Maven artifacts
   patchGradlePhase = ''
-    for modBuildGradle in $(find -L ./node_modules -name build.gradle); do
+    gradleConfigs=$(
+      find -L ./node_modules \
+        -name build.gradle -or \
+        -name build.gradle.kts -or \
+        -name settings.gradle -or \
+        -name settings.gradle.kts
+    )
+    for modBuildGradle in $gradleConfigs; do
       relativeToNode=''${modBuildGradle#*node_modules/}
       moduleName=''${relativeToNode%%/*}
       if [[ -L ./node_modules/$moduleName ]]; then

--- a/nix/pkgs/patch-maven-srcs/default.nix
+++ b/nix/pkgs/patch-maven-srcs/default.nix
@@ -16,7 +16,8 @@ writeScript "patch-maven-srcs" (''
   gradleFile="$1"
 
   # Some of those find something, some don't, that's fine.
-  patchMavenSource "$gradleFile" 'mavenCentral()' 'mavenLocal()'
-  patchMavenSource "$gradleFile" 'google()'       'mavenLocal()'
-  patchMavenSource "$gradleFile" 'jcenter()'      'mavenLocal()'
+  patchMavenSource "$gradleFile" 'mavenCentral()'       'mavenLocal()'
+  patchMavenSource "$gradleFile" 'google()'             'mavenLocal()'
+  patchMavenSource "$gradleFile" 'jcenter()'            'mavenLocal()'
+  patchMavenSource "$gradleFile" 'gradlePluginPortal()' 'mavenLocal()'
 '')


### PR DESCRIPTION
Before we were patching only `build.gradle`, which is not the only type of Gradle config file. If we do not cover them all we can encounter errors about missing package because they will continue using remote repositories instead of `mavenLocal()`, to which pass Nix store path.

We also need to cover `gradlePluginPortal()` to provide plugins.

This is also necessary for the React Native upgrade:
* https://github.com/status-im/status-mobile/pull/15203