### PR TITLE
ios: direct logs to ios/logs, archive on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,9 +100,8 @@ Statusgo.xcframework
 
 #ios
 /ios/Pods/
+/ios/logs/
 /ios/StatusIm.xcworkspace
-/ios/react-native-xcode.log
-/ios/set_xcode_version.log
 .ruby-version
 status-e2e/
 

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -63,6 +63,9 @@ pipeline {
       steps {
         script { api = ios.bundle() }
       }
+      post {
+        failure { archiveArtifacts 'ios/logs/*' }
+      }
     }
     stage('Parallel Upload') {
       parallel {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -123,6 +123,7 @@ def build_ios_adhoc(readonly: false, pr_build: false)
     export_method: 'ad-hoc',
     output_name: 'StatusIm',
     output_directory: 'status-ios',
+    buildlog_path: 'ios/logs',
     export_options: {
       signingStyle: 'manual',
       provisioningProfiles: {
@@ -162,6 +163,7 @@ def build_ios_e2e
     # 3. directory where to up StatusIm.app
     derived_data_path: 'status-ios',
     output_name: 'StatusIm.app',
+    buildlog_path: 'ios/logs',
     # -------------------------------------
     # Normal stuff
     scheme: 'StatusIm',
@@ -239,6 +241,7 @@ platform :ios do
       clean: true,
       export_method: 'app-store',
       output_directory: 'status-ios',
+      buildlog_path: 'ios/logs',
       include_symbols: false,
       export_options: {
         "combileBitcode": true,

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -526,7 +526,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\" --openssl-legacy-provider --max-old-space-size=16384 \"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./react-native-xcode.log 2>&1";
+			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\" --openssl-legacy-provider --max-old-space-size=16384 \"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./logs/react-native-xcode.log 2>&1";
 		};
 		0F876BD5356F61BF142A01A0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -584,7 +584,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\" --openssl-legacy-provider --max-old-space-size=16384 \"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./react-native-xcode.log 2>&1";
+			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\" --openssl-legacy-provider --max-old-space-size=16384 \"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./logs/react-native-xcode.log 2>&1";
 		};
 		3AAD2AD724A3A60E0075D594 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -598,7 +598,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./set_xcode_version.log 2>&1";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./logs/set_xcode_version.log 2>&1";
 		};
 		3C1038075AE5E6FB86AC2319 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -678,7 +678,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./set_xcode_version.log 2>&1";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./logs/set_xcode_version.log 2>&1";
 		};
 		E732E3E1B024946173BF6D3D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
This way people don't have to ask me for access to logs from CI hosts to be acquired using SSH access, but instead they will be simply included in Jenkins build artifacts.

![image](https://user-images.githubusercontent.com/2212681/224001842-3462293e-c3b9-41c4-a9f6-f08aa2382751.png)

I should have done this a long time ago.