### PR TITLE
ios: provide explicit NODE_ARGS in Nix shell

### DIFF
--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\" --openssl-legacy-provider --max-old-space-size=16384 \"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./logs/react-native-xcode.log 2>&1";
+			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\"${NODE_ARGS:- --max-old-space-size=16384 }\"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./logs/react-native-xcode.log 2>&1";
 		};
 		3AAD2AD524A3A60E0075D594 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -558,7 +558,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\" --openssl-legacy-provider --max-old-space-size=16384 \"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./logs/react-native-xcode.log 2>&1";
+			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\"${NODE_ARGS:- --max-old-space-size=16384 }\"\n\nbash -x ../node_modules/react-native/scripts/react-native-xcode.sh > ./logs/react-native-xcode.log 2>&1";
 		};
 		3AAD2AD724A3A60E0075D594 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/nix/mobile/ios/shells/nodejs.nix
+++ b/nix/mobile/ios/shells/nodejs.nix
@@ -5,6 +5,8 @@ mkShell {
   shellHook = ''
     # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
     export NODE_OPTIONS="--openssl-legacy-provider";
+    # Same fix but for Xcode React Native script.
+    export NODE_ARGS="--openssl-legacy-provider --max-old-space-size=16384";
 
     # Fix Xcode using system Node.js version.
     export NODE_BINARY="${nodejs}/bin/node";


### PR DESCRIPTION
Some users have reported local `make run-ios` failures with errors like:
```
Command PhaseScriptExecution failed with a nonzero exit code
```
Where the actual error that can be found in `ios/logs/react-native-xcode.log` is:
```
node: bad option: --openssl-legacy-provider
```
Caused by a flag we apply to our pinned Node.js `18.9.1` to fix:
```
opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
library: 'digital envelope routines',
reason: 'unsupported',
code: 'ERR_OSSL_EVP_UNSUPPORTED'
```
From:
* https://github.com/status-im/status-mobile/pull/15167

And the need for that should go away once we upgrade Node.js further. But for now a decent fix is to not apply that flag directly in Xcode config so as to avoid the `bad option` error when Xcode us called outside of Nix context.

Fixes: https://github.com/status-im/status-mobile/issues/15631