### PR TITLE
nix: disable sandboxing for xcodewrapper

### DIFF
--- a/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
+++ b/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
@@ -8,6 +8,9 @@ assert stdenv.isDarwin;
 
 stdenv.mkDerivation {
   name = "xcode-wrapper-${version}${if allowHigher then "-plus" else ""}";
+  # Fix 'xcodebuild: Operation not permitted' when 'sandbox=relaxed' is used.
+  # https://github.com/NixOS/nixpkgs/pull/228696
+  __noChroot = stdenv.isDarwin;
   buildCommand = ''
     mkdir -p $out/bin
     cd $out/bin


### PR DESCRIPTION
Otherwise we see weird errors like this:
```
/nix/store/g0jijpgcb4q54zbvz5p8yvxcnb6lshnk-stdenv-darwin/setup: line 1391: /nix/store/sja8sqq4y5s9ijkb97i3pi2jrhsy40cz-xcode-wrapper-14.3/bin/xcodebuild: Operation not permitted
We require xcodebuild version: 14.3
error: builder for '/nix/store/d1dji0ywl851wgj9vv58ibpm32gq3wsm-xcode-wrapper-14.3.drv' failed with exit code 1;
       last 2 log lines:
       > /nix/store/g0jijpgcb4q54zbvz5p8yvxcnb6lshnk-stdenv-darwin/setup: line 1391: /nix/store/sja8sqq4y5s9ijkb97i3pi2jrhsy40cz-xcode-wrapper-14.3/bin/xcodebuild: Operation not permitted
       > We require xcodebuild version: 14.3
```
Related: https://github.com/NixOS/nixpkgs/pull/228696