### PR TITLE
nix: use jsbundle derivation for iOS as well

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.6'
+library 'status-jenkins-lib@v1.7.7'
 
 pipeline {
   agent {

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 import "node-libs-react-native/globals";
-import "./app/index.js";
+import "./result/index.js";

--- a/nix/DETAILS.md
+++ b/nix/DETAILS.md
@@ -55,12 +55,12 @@ The [`nix/scripts/shell.sh`](./scripts/shell.sh) script is essentially a wrapper
 
 # Building
 
-We will use the `make jsbundle-android` target as an example of a derivation you can build using Nix:
+We will use the `make jsbundle` target as an example of a derivation you can build using Nix:
 
-1. `make jsbundle-android` is called by developer
-2. `make` calls `nix/scripts/build.sh targets.mobile.android.jsbundle`
-3. [`build.sh`](/nix/scripts/build.sh) calls `nix-build --attr targets.mobile.android.jsbundle` with extra arguments
-4. `nix-build` builds the derivation from [`nix/mobile/android/jsbundle/default.nix`](/nix/mobile/android/jsbundle/default.nix)
+1. `make jsbundle` is called by developer
+2. `make` calls `nix/scripts/build.sh targets.mobile.jsbundle`
+3. [`build.sh`](/nix/scripts/build.sh) calls `nix-build --attr targets.mobile.jsbundle` with extra arguments
+4. `nix-build` builds the derivation from [`nix/mobile/jsbundle/default.nix`](/nix/mobile/jsbundle/default.nix)
 
 The same can be done for other targets like `targets.mobile.android.release`.
 Except in that case extra arguments are required which is why the [`scripts/release-android.sh`](/scripts/release-android.sh) is used in the `make release-android` target.

--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -1,14 +1,10 @@
 { pkgs, deps, callPackage, mkShell
-, status-go, androidPkgs, androidShell }:
+, jsbundle, status-go, androidPkgs, androidShell }:
 
-let
-  # Import a jsbundle compiled out of clojure codebase
-  jsbundle = callPackage ./jsbundle { };
-
-  release = callPackage ./release.nix { inherit jsbundle status-go; };
-in {
-  # TARGETS
-  inherit release jsbundle;
+rec {
+  release = callPackage ./release.nix {
+    inherit jsbundle status-go;
+  };
 
   shell = mkShell {
     buildInputs = with pkgs; [

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
       root = path;
       include = [
         "package.json" "yarn.lock" "metro.config.js" "babel.config.js"
-        "resources/.*" "translations/.*" "src/js/.*"
+        "resources/.*" "translations/.*" "src/js/.*" "index.js"
         "modules/react-native-status/android.*" "android/.*"
         envFileName "VERSION" "status-go-version.json" "react-native.config.js"
       ];
@@ -94,8 +94,10 @@ in stdenv.mkDerivation rec {
     # Export all vars from .env file
     export $(cut -d= -f1 .env)
 
-    # Copy index.js and app/ input files
-    cp -ra --no-preserve=ownership ${builtJsBundle}/* ./
+    # Symlink React Native entrypoint.
+    cp -Lr ${builtJsBundle} ./result
+    pwd
+    find -L result
 
     # Copy android/ directory
     mkdir -p ./android/build

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -3,7 +3,10 @@
 let
   fastlane = callPackage ./fastlane { };
 
+  jsbundle = callPackage ./jsbundle { };
+
   android = callPackage ./android {
+    inherit jsbundle;
     status-go = status-go.mobile.android;
   };
 
@@ -26,5 +29,5 @@ in {
   };
 
   # TARGETS
-  inherit android ios fastlane;
+  inherit android ios fastlane jsbundle;
 }

--- a/nix/mobile/jsbundle/default.nix
+++ b/nix/mobile/jsbundle/default.nix
@@ -8,9 +8,9 @@
 { secretsFile ? "" }:
 
 stdenv.mkDerivation {
-  name = "status-mobile-build-jsbundle-android";
+  name = "status-mobile-jsbundle";
   src =
-    let path = ./../../../..;
+    let path = ./../../..;
     # We use builtins.path so that we can name the resulting derivation,
     # otherwise the name would be taken from the checkout directory,
     # which is outside of our control inherit path;
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
           ignoreVCS = false;
           include = [ 
             "VERSION" "BUILD_NUMBER" "scripts/version/.*"
-            "src/.*" "shadow-cljs.edn" "index.js"
+            "src/.*" "shadow-cljs.edn"
             # I want to avoid including the whole .git directory
             ".git/HEAD" ".git/objects" ".git/refs/heads/.*"
             # shadow-cljs expects these for deps resolution
@@ -77,6 +77,6 @@ stdenv.mkDerivation {
   '';
   installPhase = ''
     mkdir -p $out
-    cp -r index.js app $out/
+    cp -r result/* $out/
   '';
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -37,7 +37,8 @@
  :builds
  {:mobile
   {:target :react-native
-   :output-dir "app"
+   ;; To match the folder created by Nix build of JSBundle.
+   :output-dir "result"
    :init-fn status-im2.core/init
    ;; When false, the Shadow-CLJS watcher won't automatically refresh
    ;; the target files (a.k.a hot reload). When false, you can manually


### PR DESCRIPTION
For some unknown to me reason we are using a different Yarn call to Shadow-cljs to generate the JSBundle for iOS builds, while the one created by the Android derivation shoudl be exactly the same. I'm changing the target to just be `make jsbundle` while keeping aliases referencing old naming, and moving things around in `nix` folder to reflect the fact that the derivation is no longer Android-specific.

Also, crucially, __I've changed the `import` in `index.js` to use the `./result/index.js` path__, since that's what Nix creates. I'm not sure if this clashes with any developer workflow that takes place locally, so I'd appreciate some testing from developers.

Depends on:
* https://github.com/status-im/status-jenkins-lib/pull/67