### PR TITLE
ci: drop useless call to doGitRebasePR

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -49,7 +49,6 @@ pipeline {
     stage('Prep') {
       steps {
         script {
-          utils.doGitRebasePR()
           utils.symlinkEnv()
           println("Build Number: ${utils.genBuildNumber()}")
         }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -48,7 +48,6 @@ pipeline {
     stage('Prep') {
       steps {
         script {
-          utils.doGitRebasePR()
           utils.symlinkEnv()
           println("Build Number: ${utils.genBuildNumber()}")
         }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -41,13 +41,6 @@ pipeline {
   }
 
   stages {
-    stage('Prep') {
-      steps {
-        script {
-          utils.doGitRebasePR()
-        }
-      }
-    }
     stage('Checks') {
       parallel {
         stage('Lint') {

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.7'
+library 'status-jenkins-lib@v1.7.8'
 
 pipeline {
   agent {


### PR DESCRIPTION
It only blocks CI builds for no good reason when branch has not been rebased recently, which has no real benefit as GitHub already enforces not merging outdated PRs. It's just annoying and wastes time.

Depends on:
* https://github.com/status-im/status-jenkins-lib/pull/68