### PR TITLE
nix: upgrade interpreter from 2.11.1 to 2.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ nix-gc-protected:
 	@echo -e "$(YELLOW)The following paths are protected:$(RESET)" && \
 	ls -1 $(_NIX_GCROOTS) | sed 's/^/ - /'
 
+nix-upgrade: SHELL := /bin/sh
+nix-upgrade: ##@nix Upgrade Nix interpreter to current version.
+	nix/scripts/upgrade.sh
+
 nix-gc: export TARGET := nix
 nix-gc: nix-gc-protected ##@nix Garbage collect all packages older than 20 days from /nix/store
 	nix-store --gc

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.7.9'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.11' }
+  agent { label 'linux && x86_64 && nix-2.14' }
 
   options {
     timestamps()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.7.9'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'macos && arm64 && nix-2.11 && xcode-14.3' }
+  agent { label 'macos && arm64 && nix-2.14 && xcode-14.3' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.7.9'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.11' }
+  agent { label 'linux && x86_64 && nix-2.14' }
 
   options {
     timestamps()

--- a/nix/scripts/lib.sh
+++ b/nix/scripts/lib.sh
@@ -48,3 +48,7 @@ nix_root() {
     fi
     echo "${NIX_ROOT}"
 }
+
+nix_current_version() {
+    nix-env --version | awk '{print $3}'
+}

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -6,9 +6,9 @@ GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
 
-NIX_VERSION="2.11.1"
+NIX_VERSION="2.14.1"
 NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-NIX_INSTALL_SHA256="4569a01dc5f62056f29f3195673bc3242fc70bf2474927fb5d8549c4d997402d"
+NIX_INSTALL_SHA256="565974057264f0536f600c68d59395927cd73e9fc5a60f33c1906e8f7bc33fcf"
 NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"
 
 install_nix() {

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -3,15 +3,11 @@
 set -eo pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
-source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
+source "${GIT_ROOT}/nix/scripts/lib.sh"
+source "${GIT_ROOT}/nix/scripts/version.sh"
 
-NIX_VERSION="2.14.1"
-NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-NIX_INSTALL_SHA256="565974057264f0536f600c68d59395927cd73e9fc5a60f33c1906e8f7bc33fcf"
-NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"
-
-install_nix() {
+nix_install() {
     # Download installer and verify SHA256>
     curl -sSf "${NIX_INSTALL_URL}" -o "${NIX_INSTALL_PATH}"
     echo "${NIX_INSTALL_SHA256}  ${NIX_INSTALL_PATH}" | sha256sum -c
@@ -72,5 +68,5 @@ fi
 
 # If none of the checks before succeeded we need to install Nix
 echo -e "${GRN}Setting up Nix package manager...${RST}"
-install_nix
+nix_install
 echo -e "${YLW}See STARTING_GUIDE.md if you're new here.${RST}"

--- a/nix/scripts/source.sh
+++ b/nix/scripts/source.sh
@@ -12,7 +12,7 @@ source_nix_profile() {
         source "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
     elif [[ "${NIX_INSTALL_TYPE}" == "single" ]]; then
         source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
-    elif [[ "${NIX_INSTALL_TYPE}" == "nixops" ]]; then
+    elif [[ "${NIX_INSTALL_TYPE}" == "nixos" ]]; then
         echo "Sourcing profile not necessary on NixOS!" >&2
     fi
 }

--- a/nix/scripts/upgrade.sh
+++ b/nix/scripts/upgrade.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# This script upgrades Nix to specific version.
+# https://nixos.org/manual/nix/stable/installation/upgrading.html
+set -eo pipefail
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+source "${GIT_ROOT}/scripts/colors.sh"
+source "${GIT_ROOT}/nix/scripts/source.sh"
+source "${GIT_ROOT}/nix/scripts/version.sh"
+
+nix_upgrade() {
+    echo -e "Upgrading Nix interpreter to: ${GRN}${NIX_VERSION}${RST}" >&2
+    nix-channel --update
+    nix-env --install --attr "nixpkgs.${NIX_PACKAGE}" "nixpkgs.cacert"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "Restarting Nix daemon Launchd service" >&2
+        launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+        launchctl load   /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    elif [[ "$(uname -s)" == "Linux" ]] && [[ "$(nix_install_type)" == "multi" ]]; then
+        echo "Restarting Nix daemon Systemd service" >&2
+        systemctl daemon-reload
+        systemctl restart nix-daemon
+    fi
+}
+
+# Allow for sourcing the script
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return
+fi
+
+if [[ "$(nix_current_version)" == "${NIX_VERSION}" ]]; then
+    echo -e "Nix interpreter already on version: ${GRN}${NIX_VERSION}${RST}"
+    exit 0
+fi
+
+NIX_INSTALL_TYPE=$(nix_install_type)
+if [[ "${NIX_INSTALL_TYPE}" == "nixos" ]]; then
+    echo -e "${YLW}WARNING:${RST} Upgrade Nix in your NixOS configuration!" >&2
+    exit 0
+elif [[ "${NIX_INSTALL_TYPE}" == "single" ]]; then
+    nix_upgrade
+elif [[ "${NIX_INSTALL_TYPE}" == "multi" ]]; then
+    sudo -i bash -c "source ${PWD}/${0}; nix_upgrade"
+fi

--- a/nix/scripts/version.sh
+++ b/nix/scripts/version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+export NIX_VERSION="2.14.1"
+export NIX_PACKAGE="nixVersions.nix_2_14"
+export NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
+export NIX_INSTALL_SHA256="565974057264f0536f600c68d59395927cd73e9fc5a60f33c1906e8f7bc33fcf"
+export NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"


### PR DESCRIPTION
This is a mild upgrade that should not cause any controversy.

You can read about changes here:
- https://nixos.org/manual/nix/stable/release-notes/rl-2.12.html
- https://nixos.org/manual/nix/stable/release-notes/rl-2.13.html
- https://nixos.org/manual/nix/stable/release-notes/rl-2.14.html

Relevant `infra-ci` change:
- https://github.com/status-im/infra-ci/commit/0cc419c5

The simplest way to upgrade to `2.14` your version locally is using:
```sh
make nix-upgrade
```
For manual instructions see:
https://nixos.org/manual/nix/stable/installation/upgrading.html