### PR TITLE
nix: downgrade from 2.14.1 to 2.13.4

### DIFF
--- a/nix/scripts/version.sh
+++ b/nix/scripts/version.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-export NIX_VERSION="2.14.1"
-export NIX_PACKAGE="nixVersions.nix_2_14"
+# WARNING: Versions 2.14, 2.15, 2.16 have an issue creating gcroots:
+# https://github.com/NixOS/nix/issues/8564
+export NIX_VERSION="2.13.4"
+export NIX_PACKAGE="nixVersions.nix_2_13"
 export NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-export NIX_INSTALL_SHA256="565974057264f0536f600c68d59395927cd73e9fc5a60f33c1906e8f7bc33fcf"
+export NIX_INSTALL_SHA256="a9908cc48f5886b4f22172bdd2f9657873276fd295e78c6ed97fb308c6d284d0"
 export NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"


### PR DESCRIPTION
This Downgrades Nix interpreter from `2.14.1` to `2.13.4` to fix these errors:
* `error: creating directory '/nix/var/nix/gcroots/per-user/jakubgs': Permission denied`
* `error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)`

Resolves:
* https://github.com/status-im/status-mobile/issues/16344