### PR TITLE
Clear biometric auth cache when removing profiles

### DIFF
--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -210,7 +210,7 @@
   [{:keys [db]} key-uid]
   (let [multiaccounts (dissoc (:profile/profiles-overview db) key-uid)]
     {:db (assoc db :profile/profiles-overview multiaccounts)
-     :fx (cond-> []
+     :fx (cond-> [[:keychain/clear-user-password key-uid]]
            (ff/enabled? ::ff/settings.news-notifications)
            (conj [:dispatch
                   [:profile/remove-local-profile-storage

--- a/src/status_im/contexts/onboarding/events_test.cljs
+++ b/src/status_im/contexts/onboarding/events_test.cljs
@@ -1,0 +1,14 @@
+(ns status-im.contexts.onboarding.events-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [status-im.contexts.onboarding.events :as sut]))
+
+(deftest on-delete-profile-success-test
+  (testing "clears cached auth credentials when removing a profile"
+    (let [key-uid       "profile-key"
+          remaining-uid "remaining-profile"
+          cofx          {:db {:profile/profiles-overview {key-uid       {:name "deleted"}
+                                                          remaining-uid {:name "remaining"}}}}
+          result        (sut/on-delete-profile-success cofx key-uid)]
+      (is (= {remaining-uid {:name "remaining"}}
+             (get-in result [:db :profile/profiles-overview])))
+      (is (some #{[:keychain/clear-user-password key-uid]} (:fx result))))))


### PR DESCRIPTION
## Summary
- clear saved keychain auth credentials after a profile is removed
- prevents restoring the same key-uid from reusing a stale biometric auth method
- add unit coverage for the profile-removal success path

Fixes #21842

## Testing
- git diff --check
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home SHADOW_NS_REGEXP='^status-im\.contexts\.onboarding\.events-test$' SHADOW_OUTPUT_TO=target/onboarding_events_test/test.js TARGET=clojure corepack yarn shadow-cljs compile mocks && corepack yarn shadow-cljs compile test
- node --require ./test-resources/override.js target/onboarding_events_test/test.js (blocked locally: missing lib/binding/status_nodejs_addon.node; requires status-go-library/native binding)
- make test-unit (blocked locally: status-go-library Nix setup failed at sha256sum on macOS)
