### PR TITLE
Harden browser bridge messaging

### DIFF
--- a/resources/js/provider.js
+++ b/resources/js/provider.js
@@ -2,9 +2,12 @@
   if (typeof EthereumProvider === 'undefined') {
     var callbackId = 0;
     var callbacks = {};
+    var bridgeToken = '__STATUS_APP_BRIDGE_TOKEN__';
+    var bridgePostMessage = ReactNativeWebView.postMessage.bind(ReactNativeWebView);
 
     var bridgeSend = function (data) {
-      ReactNativeWebView.postMessage(JSON.stringify(data));
+      data.bridgeToken = bridgeToken;
+      bridgePostMessage(JSON.stringify(data));
     };
 
     var history = window.history;

--- a/src/legacy/status_im/browser/core.cljs
+++ b/src/legacy/status_im/browser/core.cljs
@@ -296,6 +296,7 @@
   [{:keys [db] :as cofx} url]
   (let [normalized-url (url/normalize-and-decode-url url)
         browser        {:browser-id    (random/id)
+                        :bridge-token  (random/guid)
                         :history-index 0
                         :history       [normalized-url]}]
     (if (links/universal-link? normalized-url)
@@ -317,7 +318,9 @@
   "Opens an existing browser with it's history"
   {:events [:browser.ui/browser-item-selected]}
   [{:keys [db] :as cofx} browser-id]
-  (let [browser (get-in db [:browser/browsers browser-id])]
+  (let [stored-browser (get-in db [:browser/browsers browser-id])
+        browser        (cond-> stored-browser
+                         (nil? (:bridge-token stored-browser)) (assoc :bridge-token (random/guid)))]
     (rf/merge cofx
               {:db         (assoc db
                                   :browser/options
@@ -413,22 +416,31 @@
                                                                                     browser)
         data                                                                       (types/json->clj
                                                                                     message)
-        {{:keys [url]} :navState :keys [type permission payload messageId params]} data
+        {{:keys [url]} :navState :keys [type permission payload messageId params bridgeToken]} data
         {:keys [dapp? name]}                                                       browser
         dapp-name                                                                  (if dapp?
                                                                                      name
                                                                                      (url/url-host
                                                                                       url-original))]
-    (cond
-      (and (= type constants/history-state-changed)
-           (not= "about:blank" url))
-      (update-browser-on-nav-change cofx url nil)
+    (when (and browser bridgeToken (= bridgeToken (:bridge-token browser)))
+      (cond
+        (and (= type constants/history-state-changed)
+             (not= "about:blank" url))
+        (update-browser-on-nav-change cofx url nil)
 
-      (= type constants/web3-send-async-read-only)
-      (web3-send-async-read-only cofx dapp-name payload messageId)
+        (= type constants/web3-send-async-read-only)
+        (web3-send-async-read-only cofx dapp-name payload messageId)
 
       (= type constants/api-request)
-      (browser.permissions/process-permission cofx dapp-name permission messageId params))))
+      (browser.permissions/process-permission cofx dapp-name permission messageId params)))))
+
+(defn bridge-callback-script
+  [message]
+  (let [encoded-message (types/clj->json (types/clj->json message))]
+    (str
+     "(function() { var __send = function() { if (ReactNativeWebView.onMessage) { ReactNativeWebView.onMessage("
+     encoded-message
+     ");} else {setTimeout(__send, 0)}}; __send();})();")))
 
 (re-frame/reg-fx
  :browser/resolve-ens-contenthash
@@ -438,13 +450,8 @@
 (re-frame/reg-fx
  :browser/send-to-bridge
  (fn [message]
-   (let
-     [^js webview @webview-ref/webview-ref
-      msg
-      (str
-       "(function() { var __send = function() { if (ReactNativeWebView.onMessage) { ReactNativeWebView.onMessage('"
-       (types/clj->json message)
-       "');} else {setTimeout(__send, 0)}}; __send();})();")]
+   (let [^js webview @webview-ref/webview-ref
+         msg             (bridge-callback-script message)]
      (when (and message webview)
        (.injectJavaScript webview msg)))))
 

--- a/src/legacy/status_im/browser/core_test.cljs
+++ b/src/legacy/status_im/browser/core_test.cljs
@@ -1,0 +1,36 @@
+(ns legacy.status-im.browser.core-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as string]
+            [legacy.status-im.browser.core :as sut]
+            [legacy.status-im.utils.deprecated-types :as types]
+            [status-im.constants :as constants]))
+
+(defn- browser-cofx
+  []
+  {:db {:browser/options  {:browser-id "browser-1"
+                           :url        "https://good.example"}
+        :browser/browsers {"browser-1" {:browser-id    "browser-1"
+                                        :bridge-token  "bridge-token"
+                                        :history       ["https://good.example"]
+                                        :history-index 0}}}})
+
+(deftest process-bridge-message-test
+  (testing "ignores bridge messages that do not carry the current browser token"
+    (let [message (types/clj->json {:type     constants/history-state-changed
+                                    :navState {:url "https://evil.example"}})]
+      (is (nil? (sut/process-bridge-message (browser-cofx) message)))))
+
+  (testing "accepts provider messages with the current browser token"
+    (let [message (types/clj->json {:type        constants/history-state-changed
+                                    :bridgeToken "bridge-token"
+                                    :navState    {:url "https://next.example"}})
+          result  (sut/process-bridge-message (browser-cofx) message)]
+      (is (some? result)))))
+
+(deftest bridge-callback-script-test
+  (testing "passes native replies as a JavaScript string literal"
+    (let [script (sut/bridge-callback-script
+                  {:type constants/api-response
+                   :data "');globalThis.__injected = true;//"})]
+      (is (string/includes? script "ReactNativeWebView.onMessage("))
+      (is (not (string/includes? script "ReactNativeWebView.onMessage('"))))))

--- a/src/legacy/status_im/ui/screens/browser/views.cljs
+++ b/src/legacy/status_im/ui/screens/browser/views.cljs
@@ -180,7 +180,8 @@
 (views/defview browser-component
   [{:keys [error? url browser-id unsafe? can-go-back? ignore-unsafe
            can-go-forward? resolving? network-id url-original dapp? dapp
-           show-permission show-tooltip name dapps-account resources-permission?]}]
+           show-permission show-tooltip name dapps-account resources-permission?
+           bridge-token]}]
   {:should-component-update (fn [_ _ args]
                               (let [[_ props] args]
                                 (not (nil? (:url props)))))}
@@ -221,7 +222,8 @@
                                                                          (.. ^js % -nativeEvent -data)])
         :on-load                                    #(re-frame/dispatch [:browser/loading-started])
         :on-error                                   #(re-frame/dispatch [:browser/error-occured])
-        :injected-java-script-before-content-loaded (js-res/ethereum-provider (str network-id))
+        :injected-java-script-before-content-loaded (js-res/ethereum-provider (str network-id)
+                                                                              bridge-token)
         ;; https://github.com/status-im/status-mobile/issues/17854
         :allows-inline-media-playback               true}])]
    [navigation
@@ -275,4 +277,5 @@
          :show-tooltip          show-tooltip
          :name                  name
          :dapps-account         dapps-account
+         :bridge-token          (:bridge-token current-browser)
          :resources-permission? webview-allow-permission-requests?}]])))

--- a/src/legacy/status_im/utils/js_resources.cljs
+++ b/src/legacy/status_im/utils/js_resources.cljs
@@ -1,13 +1,16 @@
 (ns legacy.status-im.utils.js-resources
   (:require-macros [legacy.status-im.utils.slurp :refer [slurp]])
   (:require
+    [clojure.string :as string]
     [status-im.config :as config]))
 
 (def provider-file (slurp "resources/js/provider.js"))
 (defn ethereum-provider
-  [network-id]
+  [network-id bridge-token]
   (str "window.statusAppNetworkId = \""
        network-id
        "\";"
        (when config/debug-webview? "window.statusAppDebug = true;")
-       provider-file))
+       (string/replace provider-file
+                       "'__STATUS_APP_BRIDGE_TOKEN__'"
+                       (.stringify js/JSON bridge-token))))


### PR DESCRIPTION
## Summary
- add a per-browser bridge token to provider-originated WebView messages and ignore messages without the current token
- preserve the original bridge postMessage function inside the injected provider closure
- serialize native bridge replies as a JavaScript string literal instead of concatenating raw JSON into a quoted callback
- add focused coverage for token-gated bridge messages and safe callback script generation

## Testing
- git diff --check
- node --check resources/js/provider.js
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home SHADOW_NS_REGEXP='^legacy\.status-im\.browser\.core-test$' SHADOW_OUTPUT_TO=target/browser_core_test/test.js TARGET=clojure corepack yarn shadow-cljs compile mocks && corepack yarn shadow-cljs compile test
- node --require ./test-resources/override.js target/browser_core_test/test.js (blocked locally: missing lib/binding/status_nodejs_addon.node; requires status-go-library/native binding)
- make test-unit (blocked locally: status-go-library Nix setup failed at sha256sum on macOS)
